### PR TITLE
Added help and info emails to settings.yml.

### DIFF
--- a/app/controllers/emailer_controller.rb
+++ b/app/controllers/emailer_controller.rb
@@ -3,7 +3,7 @@ class EmailerController < ApplicationController
   before_filter :login_required
 
   def invite
-    from = "The iNaturalist Community <no-reply@inaturalist.org>"
+    from = "#{APP_CONFIG[:site_name]} <#{APP_CONFIG[:noreply_email]}>"
     subject = "#REAL NAME wants you to join them on iNaturalist"
     @sending_user = current_user
     @sending_user_real_name = "YOUR REAL NAME"

--- a/app/controllers/flickr_controller.rb
+++ b/app/controllers/flickr_controller.rb
@@ -61,7 +61,7 @@ class FlickrController < ApplicationController
       HoptoadNotifier.notify(e, :request => request, :session => session) # testing
       flash[:error] = <<-EOF
         Ack! Something went wrong linking your iNaturalist account to Flickr.
-        Try it again, or contact us at help@inaturalist.org.
+        Try it again, or contact us at #{APP_CONFIG[:help_email]}.
         
         Error: #{e.message}
       EOF
@@ -102,8 +102,8 @@ class FlickrController < ApplicationController
       logger.error "[Error #{Time.now}] Flickr connection failed (#{e}): #{e.message}"
       HoptoadNotifier.notify(e, :request => request, :session => session) # testing
       flash[:notice] = "Ack! Something went horribly wrong, like a giant " + 
-                       "squid ate your Flickr info.  You can contact us at " + 
-                       "help@inaturalist.org if you still can't get this " + 
+                       "squid ate your Flickr info.  You can contact us at " +
+                       "#{APP_CONFIG[:help_email]} if you still can't get this " +
                        "working.  Error: #{e.message}"
       redirect_to :action => 'options'
     end
@@ -226,7 +226,7 @@ class FlickrController < ApplicationController
       HoptoadNotifier.notify(e, :request => request, :session => session) # testing
       flash[:notice] = "Ack! Something went horribly wrong, like a giant " + 
                        "squid ate your Flickr info.  You can contact us at " +
-                       "help@inaturalist.org if you still can't get this " + 
+                       "#{APP_CONFIG[:help_email]} if you still can't get this " +
                        "working.  Error: #{e.message}"
     end
   end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -729,7 +729,7 @@ class ObservationsController < ApplicationController
       flash[:error] = <<-EOT
         Your CSV had a formatting problem. Try removing any strange
         characters and unclosed quotes, and if the problem persists, please
-        <a href="mailto:help@inaturalist.org">email us</a> the file and we'll
+        <a href="mailto:#{APP_CONFIG[:help_email]}">email us</a> the file and we'll
         figure out the problem.
       EOT
       redirect_to :action => 'import'

--- a/app/views/emailer/invite_send.text.plain.erb
+++ b/app/views/emailer/invite_send.text.plain.erb
@@ -15,4 +15,4 @@ If you want, you can check out my observations at <%= observations_by_login_url(
 - <%= @sending_user %>
 
 ============
-iNaturalist will not allow its users to send you additional invitations via our inviter. Please report invitation abuse to info@inaturalist.org.
+iNaturalist will not allow its users to send you additional invitations via our inviter. Please report invitation abuse to <%= APP_CONFIG[:info_email] %>.

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -118,7 +118,7 @@
     <li>
       <h5><a name="general5">How do I contact iNaturalist?</a></h5>
       <p>
-        You can contact us at <a href="mailto:inaturalist@gmail.com">inaturalist@gmail.com</a>
+        You can contact us at <a href="mailto:<%= APP_CONFIG[:help_email] %>"><%= APP_CONFIG[:help_email] %></a>
       </p>
     </li>
     
@@ -133,7 +133,7 @@
       <p>
         Curators are iNat users who volunteer to help keep our taxonomic data
         up to date. If you're interested in becoming a curator, please 
-        <a href="mailto:inaturalist@gmail.com">contact us</a>. Curators can
+        <a href="mailto:<%= APP_CONFIG[:help_email] %>">contact us</a>. Curators can
         also promote other users to curator status. Please only promote people
         you trust and that you know to have some taxonomic knowledge.
       </p>

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -3,7 +3,9 @@ development: &non_production_settings
   site_name: iNaturalist.org
   admin_email: admin@inaturalist.org
   noreply_email: no-reply@inaturalist.org
-  
+  help_email: help@inaturalist.org
+  info_email: info@inaturalist.org
+
 test:
   <<: *non_production_settings
 
@@ -12,9 +14,13 @@ staging:
   site_name: iNaturalist.org
   admin_email: admin@inaturalist.org
   noreply_email: no-reply@inaturalist.org
-  
+  help_email: help@inaturalist.org
+  info_email: info@inaturalist.org
+
 production:
   site_url: http://www.inaturalist.org
   site_name: iNaturalist.org
   admin_email: admin@inaturalist.org
   noreply_email: no-reply@inaturalist.org
+  help_email: help@inaturalist.org
+  info_email: info@inaturalist.org


### PR DESCRIPTION
I've added help and info emails to settings.yml and replaced the hard-coded strings with APP_CONFIG tokens. I've also changed the email address on the help page from "inaturalist@gmail.com" to the help email token.
