### PR TITLE
Capitalize provider names.

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -43,7 +43,7 @@
       <label>Or you can...</label>
     </div>
     <%- ProviderAuthorization::AUTH_URLS.each do |provider, url| -%>
-      <%= link_to "Sign in with #{provider}", url, :class => "button providerlink #{provider.downcase}" %>
+      <%= link_to "Sign in with #{provider.capitalize}", url, :class => "button providerlink #{provider.downcase}" %>
     <%- end -%>
   </div>
   

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -143,12 +143,12 @@
       <% ProviderAuthorization::PROVIDERS.each do |provider| %>
         <% if current_user.has_provider_auth(provider) %>
           <li class="clear">
-            <%= link_to "Disconnect #{provider}", omniauth_disconnect_path(provider.downcase), 
+            <%= link_to "Disconnect #{provider.capitalize}", omniauth_disconnect_path(provider.downcase),
               :class => "providerlink #{provider.downcase} disabled button", :method => "delete" %>
           </li>
         <% else %>
           <li class="clear">
-            <%= link_to "Connect to #{provider}", auth_url_for(provider.downcase), :class => "providerlink #{provider.downcase} button" %>
+            <%= link_to "Connect to #{provider.capitalize}", auth_url_for(provider.downcase), :class => "providerlink #{provider.downcase} button" %>
           </li>
         <% end %>
       <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,7 +22,7 @@
       <label>Or you can...</label>
     </div>
     <%- ProviderAuthorization::AUTH_URLS.each do |provider, url| -%>
-      <%= link_to "Sign in with #{provider}", url, :class => "button providerlink #{provider.downcase}" %>
+      <%= link_to "Sign in with #{provider.capitalize}", url, :class => "button providerlink #{provider.downcase}" %>
     <%- end -%>
   </div>
 </div>


### PR DESCRIPTION
Capitalize provider names (Twitter and Facebook, see http://www.inaturalist.org/signup).
