### PR TITLE
title tooltips for observation view icon buttons

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -567,6 +567,7 @@ en:
   green: green
   grey: grey
   grid: Grid
+  grid_tooltip: Show grid view
   guess_description: Guess / Description
   guide_colors: Guide Colors
   hasnt_contributed_any_observations: hasn't contributed any observations to this project.
@@ -713,6 +714,7 @@ en:
   linked_flickr_password_html: "<strong>We will never ask you for your Flickr password</strong> (but Flickr might, check the url that the button sends you and make sure it's Flickr.com)."
   linked_flickr_photo_copy_html: "<strong>We will never store copies of your photos or change your Flickr data (unless you ask us to), ever.</strong> We care too much about birds, bugs and slugs to want to mess with your information!"
   list: List
+  list_tooltip: Show list view
   listed_taxon: Listed taxon
   listing_announcement: Listing announcement
   listing_announcements: Listing announcements
@@ -759,6 +761,7 @@ en:
   mammals: mammals
   manually_create_new_place: Manually Create a New Place
   map: Map
+  map_tooltip: Show map view
   map_for: Map for 
   maybe_your_signed_in_with: "Maybe you signed in with your %{omniauth} account?"
   members: Members

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -720,7 +720,7 @@ $.fn.observationControls = function(options) {
 
     var gridButton = $('.gridbutton', this)
     if (gridButton.length == 0) {
-      gridButton = $('<a href="#" class="gridbutton" title="'+I18n.t('grid')+'"><span class="inat-icon ui-icon ui-icon-grid inlineblock">&nbsp;</span><label>'+I18n.t('grid')+'</label></a>')
+      gridButton = $('<a href="#" class="gridbutton" title="'+I18n.t('grid_tooltip')+'"><span class="inat-icon ui-icon ui-icon-grid inlineblock">&nbsp;</span><label>'+I18n.t('grid')+'</label></a>')
       gridButton.data('gridSize', $(observations).hasClass('medium') ? 'medium' : null)
       gridButton.click(function() {
         $(observations).observationsGrid($(this).data('gridSize'))
@@ -732,7 +732,7 @@ $.fn.observationControls = function(options) {
 
     var listButton = $('.listbutton', this)
     if (listButton.length == 0) {
-      listButton = $('<a href="#" class="listbutton" title="'+I18n.t('list')+'"><span class="inat-icon ui-icon ui-icon-list inlineblock">&nbsp;</span><label>'+I18n.t('list')+'</label></a>')
+      listButton = $('<a href="#" class="listbutton" title="'+I18n.t('list_tooltip')+'"><span class="inat-icon ui-icon ui-icon-list inlineblock">&nbsp;</span><label>'+I18n.t('list')+'</label></a>')
       listButton.click(function() {
         $(observations).observationsList()
         $(this).siblings().addClass('disabled')
@@ -743,7 +743,7 @@ $.fn.observationControls = function(options) {
 
     var mapButton = $('.mapbutton', this)
     if (mapButton.length == 0) {
-      mapButton = $('<a href="#" class="mapbutton" title="'+I18n.t('map')+'"><span class="inat-icon ui-icon ui-icon-map inlineblock">&nbsp;</span><label>'+I18n.t('map')+'</label></a>')
+      mapButton = $('<a href="#" class="mapbutton" title="'+I18n.t('map_tooltip')+'"><span class="inat-icon ui-icon ui-icon-map inlineblock">&nbsp;</span><label>'+I18n.t('map')+'</label></a>')
       mapButton.click(function() {
         $(observations).observationsMap()
         $(this).siblings().addClass('disabled')


### PR DESCRIPTION
Just a small change to add some title tooltips. This is especially useful in the "Recent observations" view where the labels are not displayed.
