### PR TITLE
Adding support for CC0 public domain dedication

### DIFF
--- a/app/models/wikimedia_commons_photo.rb
+++ b/app/models/wikimedia_commons_photo.rb
@@ -107,7 +107,7 @@ class WikimediaCommonsPhoto < Photo
     photo.native_photo_id = file_name
 
     license = api_response.search('.licensetpl_short').inner_text
-    photo.license = if (license.downcase.include? "public domain") || (license.downcase.include? "pd")
+    photo.license = if (license.downcase.include? "public domain") || (license.downcase.include? "pd") || (license.downcase.include? "cc0")
       Photo::PD
     elsif license.downcase.include? "cc-by-nc-sa"
       Photo::CC_BY_NC_SA


### PR DESCRIPTION
Wikimedia Commons typically uses CC0 for public domain dedication (as
opposed to regular copyright-expired public domain). If it seems strange
that this is listed under public domain, rather than as its own license like
CC-BY, remember that CC0 is not actually a license. It's just a fancy way
of putting something in the public domain so that it works the same in
different legal jurisdictions. (In some countries, it's actually rather difficult
to give up all of your copyrights.)
