### PR TITLE
Use protocol-relative src for connect.facebook.net

### DIFF
--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -743,7 +743,7 @@
   <% end -%>
   
   <div id="fblike" class="stacked">
-    <script src="http://connect.facebook.net/en_US/all.js#xfbml=1"></script>
+    <script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>
     <fb:like send="true" show_faces="true" width="270" layout="button_count"></fb:like>
   </div>
   

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -268,7 +268,7 @@
   <% end -%>
   
   <div id="fblike" class="stacked">
-    <script src="http://connect.facebook.net/en_US/all.js#xfbml=1"></script>
+    <script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>
     <fb:like send="true" show_faces="true" width="270" layout="button_count"></fb:like>
   </div>
   

--- a/app/views/taxa/show.html.erb
+++ b/app/views/taxa/show.html.erb
@@ -606,7 +606,7 @@
     </div>
     
     <div id="fblike" class="stacked">
-      <script src="http://connect.facebook.net/en_US/all.js#xfbml=1"></script>
+      <script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>
       <fb:like send="true" show_faces="true" width="270" layout="button_count"></fb:like>
     </div>
   <div><a href="http://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="inaturalist">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script></div>


### PR DESCRIPTION
I'm not sure how I ended up on the HTTPS version of iNat, but when I did I noticed this error in the JavaScript console:

[blocked] The page at https://www.inaturalist.org/projects/biodiversity-of-martha-s-vineyard ran insecure content from http://connect.facebook.net/en_US/all.js.

Switching the protocol-relative URLs for the src should do the trick.

_Note_: I'm not yet set up to run the app, but this change is pretty cut and dry.
