### PR TITLE
Fix choosers under HTTPS

### DIFF
--- a/app/views/facebook/photo_invite.html.erb
+++ b/app/views/facebook/photo_invite.html.erb
@@ -37,13 +37,13 @@
 <script type="text/javascript" charset="utf-8">
   $('#taxonchooser').chooser({
     queryParam: 'q',
-    collectionUrl: 'http://'+window.location.host + '/taxa/search.json',
-    resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json'
+    collectionUrl: '/taxa/search.json',
+    resourceUrl: '/taxa/{{id}}.json'
   })
   $('#projectchooser').chooser({
     queryParam: 'q',
-    collectionUrl: 'http://'+window.location.host + '/projects/search.json',
-    resourceUrl: 'http://'+window.location.host + '/projects/{{id}}.json',
+    collectionUrl: '/projects/search.json',
+    resourceUrl: '/projects/{{id}}.json',
     defaultSources: <%= @projects.to_json %>
   })
     var DEFAULT_PHOTO_IDENTITY_URL = "/facebook/photo_fields", //?context=user",

--- a/app/views/flickr/create_invite.html.erb
+++ b/app/views/flickr/create_invite.html.erb
@@ -27,13 +27,13 @@
 <script type="text/javascript" charset="utf-8">
   $('#taxonchooser').chooser({
     queryParam: 'q',
-    collectionUrl: 'http://'+window.location.host + '/taxa/search.json',
-    resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json'
+    collectionUrl: '/taxa/search.json',
+    resourceUrl: '/taxa/{{id}}.json'
   })
   $('#projectchooser').chooser({
     queryParam: 'q',
-    collectionUrl: 'http://'+window.location.host + '/projects/search.json',
-    resourceUrl: 'http://'+window.location.host + '/projects/{{id}}.json',
+    collectionUrl: '/projects/search.json',
+    resourceUrl: '/projects/{{id}}.json',
     defaultSources: <%= @projects.to_json.html_safe %>
   })
     var DEFAULT_PHOTO_IDENTITY_URL = "/facebook/photo_fields", //?context=user",

--- a/app/views/guide_taxa/_form.html.haml
+++ b/app/views/guide_taxa/_form.html.haml
@@ -22,8 +22,8 @@
   :javascript
     var GUIDE_TAXON = #{raw @guide_taxon.to_json}
     $('#guide_taxon_taxon_id:visible').chooser({
-      collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-      resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+      collectionUrl: '/taxa/autocomplete.json',
+      resourceUrl: '/taxa/{{id}}.json?partial=chooser',
     })
     $('#edit_photos_dialog').dialog({
       modal: true, 

--- a/app/views/messages/new.html.haml
+++ b/app/views/messages/new.html.haml
@@ -35,8 +35,8 @@
     $('#message_to_user_id').chooser({
       queryParam: 'q',
       defaultSources: CONTACTS,
-      collectionUrl: 'http://'+window.location.host + '/people/search.json',
-      resourceUrl: 'http://'+window.location.host + '/people/{{id}}.json'
+      collectionUrl: '/people/search.json',
+      resourceUrl: '/people/{{id}}.json'
     })
   }
   

--- a/app/views/observations/_filter_fields.html.erb
+++ b/app/views/observations/_filter_fields.html.erb
@@ -123,8 +123,8 @@
   <% if @filters_open -%>
     <script type="text/javascript" charset="utf-8">
       $('#filters input[name=place_id]').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json?with_geom=t',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json?with_geom=t',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: eval('(' + $('#filters input[name=place_id]').attr('data-json') + ')')
       })
     </script>

--- a/app/views/observations/identotron.html.erb
+++ b/app/views/observations/identotron.html.erb
@@ -77,14 +77,14 @@
       })
       var currentState = $.deparam.fragment()
       $('#placechooser').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         defaultSources: places,
         chosen: currentState.place ? place : null
       })
       $('#taxonchooser').chooser({
-        collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+        collectionUrl: '/taxa/autocomplete.json',
+        resourceUrl: '/taxa/{{id}}.json?partial=chooser',
         defaultSources: defaultTaxa,
         chosen: currentState.taxon ? taxon : null
       })

--- a/app/views/observations/widget.html.erb
+++ b/app/views/observations/widget.html.erb
@@ -31,8 +31,8 @@
   <script type="text/javascript" charset="utf-8">
     $(document).ready(function() {
       $('#placechooser input[type=text]').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json?with_geom=t',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json?with_geom=t',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         afterSelect: function(item) {
           $('#placechooser .default.button').attr('disabled', false).removeClass('disabled').focus()
         },
@@ -42,8 +42,8 @@
         chosen: eval('(' + $('#placechooser input[type=text]').attr('data-json') + ')')
       })
       $('.placefield input[type=text]').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: eval('(' + $('.placefield input[type=text]').attr('data-json') + ')')
       })
       <% if @place.blank? %>

--- a/app/views/photos/inviter.html.erb
+++ b/app/views/photos/inviter.html.erb
@@ -35,13 +35,13 @@
 <script type="text/javascript" charset="utf-8">
   $('#taxonchooser').chooser({
     queryParam: 'q',
-    collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-    resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+    collectionUrl: '/taxa/autocomplete.json',
+    resourceUrl: '/taxa/{{id}}.json?partial=chooser',
   })
   $('#projectchooser').chooser({
     queryParam: 'q',
-    collectionUrl: 'http://'+window.location.host + '/projects/search.json',
-    resourceUrl: 'http://'+window.location.host + '/projects/{{id}}.json',
+    collectionUrl: '/projects/search.json',
+    resourceUrl: '/projects/{{id}}.json',
     defaultSources: <%= @projects.to_json.html_safe %>
   })
   var PHOTO_SOURCES = {

--- a/app/views/places/edit.html.erb
+++ b/app/views/places/edit.html.erb
@@ -38,8 +38,8 @@
       <% end %>
       
       $('#place_parent_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: eval('(' + $('place_parent_id').attr('data-json') + ')')
       })
     })

--- a/app/views/places/merge.html.erb
+++ b/app/views/places/merge.html.erb
@@ -19,8 +19,8 @@
   <script type="text/javascript" charset="utf-8">
     $(document).ready(function() {
       $('#merge_target_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: eval('(' + $('place_parent_id').attr('data-json') + ')'),
         afterSelect: function(item) {
           $.each(item, function(i, val) {

--- a/app/views/places/new.html.erb
+++ b/app/views/places/new.html.erb
@@ -59,8 +59,8 @@
       var importMap = iNaturalist.Map.createMap({div: 'importMap'});
       window.importMap = importMap;
       $('#place_parent_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: eval('(' + $('place_parent_id').attr('data-json') + ')')
       })
     })

--- a/app/views/places/widget.html.erb
+++ b/app/views/places/widget.html.erb
@@ -16,8 +16,8 @@ end
   <script type="text/javascript" charset="utf-8">
     $(document).ready(function() {
       $('#taxonchooser').chooser({
-        collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+        collectionUrl: '/taxa/autocomplete.json',
+        resourceUrl: '/taxa/{{id}}.json?partial=chooser',
         defaultSources: <%= @default_taxa.to_json(:methods => [:html]).html_safe %>
       })
       

--- a/app/views/subscriptions/_form.html.haml
+++ b/app/views/subscriptions/_form.html.haml
@@ -11,21 +11,21 @@
 
   if ($('#subscription_resource_type').val() == 'Place') {
     $('#subscription_resource_id').chooser({
-      collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json?with_geom=t',
-      resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+      collectionUrl: '/places/autocomplete.json?with_geom=t',
+      resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
       afterSelect: function(item) {
         $('#subscription_resource_type').val('Place')
       }
     })
     $('#subscription_taxon_id').chooser({
-      collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-      resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+      collectionUrl: '/taxa/autocomplete.json',
+      resourceUrl: '/taxa/{{id}}.json?partial=chooser',
       defaultSources: defaultTaxa
     })
   } else if ($('#subscription_resource_type').val() == 'Taxon') {
     $('#subscription_resource_id').chooser({
-      collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-      resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+      collectionUrl: '/taxa/autocomplete.json',
+      resourceUrl: '/taxa/{{id}}.json?partial=chooser',
       defaultSources: defaultTaxa
     })
     $('.taxon_id_field').hide()

--- a/app/views/subscriptions/edit.html.erb
+++ b/app/views/subscriptions/edit.html.erb
@@ -14,8 +14,8 @@
   <script type="text/javascript" charset="utf-8">
     $(document).ready(function() {
       $('#subscription_taxon_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+        collectionUrl: '/taxa/autocomplete.json',
+        resourceUrl: '/taxa/{{id}}.json?partial=chooser',
         defaultSources: <%= @default_taxa.to_json(:methods => [:html]).html_safe %>,
         chosen: <%= @subscription.taxon.to_json.html_safe %>
       })

--- a/app/views/taxa/_form_head.html.erb
+++ b/app/views/taxa/_form_head.html.erb
@@ -68,8 +68,8 @@ var CONSERVATION_STATUS_AUTHORITIES = <%=raw @conservation_status_authorities.to
         chosen: $('.authority_field input', this).val()
       })
       $('.place_id_field input', this).chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item'
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item'
       })
     })
   }

--- a/app/views/taxon_changes/index.html.erb
+++ b/app/views/taxon_changes/index.html.erb
@@ -36,14 +36,14 @@
     window.defaultTaxa = <%= @default_taxa.to_json(:methods => [:html]).html_safe %>
     $(document).ready(function() {
       $('#filters_taxon_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+        collectionUrl: '/taxa/autocomplete.json',
+        resourceUrl: '/taxa/{{id}}.json?partial=chooser',
         defaultSources: defaultTaxa,
         chosen: taxon
       })
       $('#filters_source_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/sources.json',
-        resourceUrl: 'http://'+window.location.host + '/sources/{{id}}.json'
+        collectionUrl: '/sources.json',
+        resourceUrl: '/sources/{{id}}.json'
       })
       
       if (taxon) {

--- a/app/views/taxon_links/_form.html.erb
+++ b/app/views/taxon_links/_form.html.erb
@@ -14,8 +14,8 @@
     $(document).ready(function() {
       $('#species_guess').simpleTaxonSelector()
       $('#taxon_link_place_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+        collectionUrl: '/places/autocomplete.json',
+        resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: PLACE
       })
       toggleSpeciesOnly()

--- a/app/views/taxon_schemes/show.html.erb
+++ b/app/views/taxon_schemes/show.html.erb
@@ -30,8 +30,8 @@
     window.defaultTaxa = <%= @genera.to_json(:only => [:id, :name]).html_safe %>
     $(document).ready(function() {
       $('#filters_taxon_id').chooser({
-        collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-        resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+        collectionUrl: '/taxa/autocomplete.json',
+        resourceUrl: '/taxa/{{id}}.json?partial=chooser',
         defaultSources: defaultTaxa,
         chosen: taxon
       })

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -210,8 +210,8 @@ $(document).ready(function() {
   $('[data-tip]').each(autoTip)
   
   $('.source_nested_form_fields input.existing').chooser({
-    collectionUrl: 'http://'+window.location.host + '/sources.json',
-    resourceUrl: 'http://'+window.location.host + '/sources/{{id}}.json'
+    collectionUrl: '/sources.json',
+    resourceUrl: '/sources/{{id}}.json'
   })
   
   $('.zoomable').zoomify()

--- a/public/javascripts/guides/edit.js
+++ b/public/javascripts/guides/edit.js
@@ -4,12 +4,12 @@ $('#addtaxa').modal({
 })
 $('#addtaxa').on('shown', function() { $('input:visible', this).focus() })
 $('#addtaxa-place .taxonchooser').chooser({
-  collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-  resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser'
+  collectionUrl: '/taxa/autocomplete.json',
+  resourceUrl: '/taxa/{{id}}.json?partial=chooser'
 })
 $('#addtaxa-place .placechooser').chooser({
-  collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-  resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item'
+  collectionUrl: '/places/autocomplete.json',
+  resourceUrl: '/places/{{id}}.json?partial=autocomplete_item'
 })
 $('#addtaxa-place .chooser').change(function() {
   $('#addtaxa-place .status').addClass('loading').html('Counting matches...')
@@ -35,8 +35,8 @@ window.addTaxonField = function() {
   var newInput = $('<input type="text" name="taxon_id" placeholder="'+I18n.t('start_typing_taxon_name')+'"/>')
   $('#addtaxa-single').append(newInput)
   newInput.chooser({
-    collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-    resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+    collectionUrl: '/taxa/autocomplete.json',
+    resourceUrl: '/taxa/{{id}}.json?partial=chooser',
     afterSelect: function(taxon) {
       window.addTaxonField()
     }
@@ -262,8 +262,8 @@ google.maps.event.addListener(map, 'zoom_changed', function() {
 })
 window.firstRun = true
 $('#guide_place_id').chooser({
-  collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json?with_geom=t',
-  resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+  collectionUrl: '/places/autocomplete.json?with_geom=t',
+  resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
   chosen: PLACE,
   afterSelect: function(item) {
     $('#guide_place_id').data('json', item)

--- a/public/javascripts/lists/show.js
+++ b/public/javascripts/lists/show.js
@@ -12,8 +12,8 @@ $(document).ready(function() {
   })
 
   $('#taxonchooser').chooser({
-    collectionUrl: 'http://'+window.location.host + '/taxa/autocomplete.json',
-    resourceUrl: 'http://'+window.location.host + '/taxa/{{id}}.json?partial=chooser',
+    collectionUrl: '/taxa/autocomplete.json',
+    resourceUrl: '/taxa/{{id}}.json?partial=chooser',
     afterSelect: function(taxon) {
       if (!FILTER_TAXON || FILTER_TAXON.id != taxon.id) {
         $('#taxonchooser').parents('form:first').submit()

--- a/public/javascripts/observations/filters.js
+++ b/public/javascripts/observations/filters.js
@@ -43,8 +43,8 @@ function showFilters(link, options) {
   }
   if ($('#place_filter .ui-widget').length == 0) {
     $('#filters input[name=place_id]').chooser({
-      collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json',
-      resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+      collectionUrl: '/places/autocomplete.json',
+      resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
       chosen: eval('(' + $('#filters input[name=place_id]').attr('data-json') + ')')
     })
   }

--- a/public/javascripts/observations/observation_fields.js
+++ b/public/javascripts/observations/observation_fields.js
@@ -2,8 +2,8 @@ $.fn.observationFieldsForm = function(options) {
   $(this).each(function() {
     var that = this
     $('.observation_field_chooser', this).chooser({
-      collectionUrl: 'http://'+window.location.host + '/observation_fields.json',
-      resourceUrl: 'http://'+window.location.host + '/observation_fields/{{id}}.json',
+      collectionUrl: '/observation_fields.json',
+      resourceUrl: '/observation_fields/{{id}}.json',
       afterSelect: function(item) {
         $('.observation_field_chooser', that).parents('.ui-chooser:first').next('.button').click()
         $('.observation_field_chooser', that).chooser('clear')

--- a/public/javascripts/projects/form.js
+++ b/public/javascripts/projects/form.js
@@ -1,7 +1,7 @@
 function rulify() {
   $('#new_operand_id').chooser({
-    collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json?with_geom=t',
-    resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+    collectionUrl: '/places/autocomplete.json?with_geom=t',
+    resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
     chosen: eval('(' + $('new_operand_id').attr('data-json') + ')'),
     afterSelect: function(item) {
       $('#new_operand_type').val("Place")
@@ -100,8 +100,8 @@ function updateProjectObservationFieldPositions() {
 
 $(document).ready(function() {
   $('.observation_field_chooser').chooser({
-    collectionUrl: 'http://'+window.location.host + '/observation_fields.json',
-    resourceUrl: 'http://'+window.location.host + '/observation_fields/{{id}}.json',
+    collectionUrl: '/observation_fields.json',
+    resourceUrl: '/observation_fields/{{id}}.json',
     afterSelect: function(item) {
       $('.observation_field_chooser').parents('.ui-chooser:first').next('.button').click()
       $('.observation_field_chooser').chooser('clear')
@@ -144,8 +144,8 @@ $(document).ready(function() {
 
   window.firstRun = true
   $('#project_place_id').chooser({
-    collectionUrl: 'http://'+window.location.host + '/places/autocomplete.json?with_geom=t',
-    resourceUrl: 'http://'+window.location.host + '/places/{{id}}.json?partial=autocomplete_item',
+    collectionUrl: '/places/autocomplete.json?with_geom=t',
+    resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
     chosen: PLACE,
     afterSelect: function(item) {
       $('#project_place_id').data('json', item)


### PR DESCRIPTION
This pull request changes the chooser URLs to use relative URLs. This makes them work under HTTPS.

The first place I noticed a broken chooser under HTTPS was the place selector on the Edit Project page, but I'm sure there are many others given that I had to change 24 files.
