### PR TITLE
Ignore .ruby-gemset and .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ public/taxa
 public/attachments
 public/guides
 .rvmrc
+.ruby-gemset
+.ruby-version
 .bundle
 *.rails2
 *.orig


### PR DESCRIPTION
Apologies for not doing this in the other pull request, but this should be more in line with expectations.
