### PR TITLE
Fix Spanish showing up for "lowest_rank" under en locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1291,7 +1291,7 @@ en:
   lookup: Lookup
   lookup: Lookup
   lookup_user_rarr: "Lookup user &rarr;"
-  lowest_rank: Rango más bajo
+  lowest_rank: Lowest rank
   made_a: made a
   mail_disclaimer: "%{site_name} will not allow its users to send you additional invitations via our inviter. Please report invitation abuse to %{site}."
   main_content: Main content


### PR DESCRIPTION
When using the search form for observations, the "lowest rank" field is showing up in Spanish as "rango más bajo" instead of "lowest rank", despite the fact that my locale is English.
