### PR TITLE
Parallelize execution of spec/* directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: ruby
 rvm:
   - 1.9.3
 
+env:
+  - SPEC_DIR=spec/models
+  - SPEC_DIR=spec/helpers
+  - SPEC_DIR=spec/controllers
+
 before_install: ci/scripts/before_install.sh
 before_script:  ci/scripts/before_script.sh
 script:         ci/scripts/script.sh

--- a/ci/scripts/script.sh
+++ b/ci/scripts/script.sh
@@ -2,5 +2,13 @@
 
 source ./ci/scripts/guard.sh
 
-echo "Executing rspec"
-RAILS_ENV=test xvfb-run bundle exec rspec --format d spec
+if [ -z "$SPEC_DIR" ]; then
+    echo "SPEC_DIR environment variable missing" 1>&2
+    exit 1
+elif [ \! -d "$SPEC_DIR" ]; then
+    echo "Spec directory not found: $SPEC_DIR" 1>&2
+    exit 1
+fi
+
+echo "Executing rspec for $SPEC_DIR"
+RAILS_ENV=test xvfb-run bundle exec rspec --format d "$SPEC_DIR"


### PR DESCRIPTION
This PR parallelizes the execution of the spec/\* directories into different Travis builds. The build is currently failing for this branch, but the failures are the same ones fixed by #207. This update cuts about 25% off the wall-clock CI build time with the current three jobs and assuming the jobs all execute promptly, although it does double the amount of CPU time used. The build time is still largely dominated by bundle install, though, so cutting down that time could significantly decrease the overall build time.
