### PR TITLE
fix for iconic_taxon filter bug on lifelists

### DIFF
--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -211,7 +211,7 @@
             <% end -%>
             <%- grouper_name = t(:other_animals) if grouper_name == 'Animals' -%>
             <%- grouper_class = grouper.name rescue 'Unknown' -%>
-            <% fill_in_params = {taxon:"", observed: 't', rank: 'species', taxonomic_status: 'active'} %>
+            <% fill_in_params = params[:observed] ? {} : {taxon:"", observed: 't', rank: 'species', taxonomic_status: 'active'} %>
             <a class="clear stat <%= grouper_class %><%= ' current' if @filter_taxon && @filter_taxon.id == grouper.id %>" href="<%= url_for_params({:iconic_taxon => grouper.id, :without => [:page, :q]}.merge(fill_in_params)) %>">
               <div class="readable title">
                 &nbsp;


### PR DESCRIPTION
fix for bug described here: https://groups.google.com/forum/#!topic/inaturalist/XO_kkdgPJSA
that was introduced with the dynamic list filters and fixed for checklists here:
https://github.com/inaturalist/inaturalist/commit/39023094c4dfb242df2a0d8a33b37d5481b22852
this is an analogous fix for non-checklists
