### PR TITLE
Enabled garbage collection profiling; saving more COUNT() queries; faste...

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -874,6 +874,9 @@ class Observation < ActiveRecord::Base
   end
   
   def serializable_hash(options = {})
+    # making a deep copy of the options so they don't get modified
+    # This was more effective than options.deep_dup
+    options[:include] = options[:include].marshal_copy if options[:include]
     # don't use delete here, it will just remove the option for all 
     # subsequent records in an array
     options[:include] = if options[:include].is_a?(Hash)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -37,7 +37,7 @@
       <ul class="subnav taxon_links" style="display: none">
         <% for taxon in Taxon::ICONIC_TAXA %>
           <li>
-            <%= link_to t("all_taxa.#{Taxon::ICONIC_TAXON_NAMES[taxon.name].gsub(' ','_').gsub('-','_').downcase}", :default=>Taxon::ICONIC_TAXON_NAMES[taxon.name]), taxon, :class => "taxon #{taxon.name}" %>
+            <%= link_to t("all_taxa.#{Taxon::ICONIC_TAXON_NAMES[taxon.name].gsub(' ','_').gsub('-','_').downcase}", :default=>Taxon::ICONIC_TAXON_NAMES[taxon.name]), taxon_path(taxon), :class => "taxon #{taxon.name}" %>
           </li>
         <% end %>
         <li class="formwrapper">

--- a/config/initializers/gc_profiler.rb
+++ b/config/initializers/gc_profiler.rb
@@ -1,0 +1,2 @@
+GC::Profiler.enable
+

--- a/config/initializers/marshal_copy.rb
+++ b/config/initializers/marshal_copy.rb
@@ -1,0 +1,13 @@
+# Make a truely new copy of an Array or Hash using Marshal
+
+class Hash
+  def marshal_copy
+    Marshal.load(Marshal.dump(self))
+  end
+end
+
+class Array
+  def marshal_copy
+    Marshal.load(Marshal.dump(self))
+  end
+end

--- a/config/initializers/will_paginate_with_count.rb
+++ b/config/initializers/will_paginate_with_count.rb
@@ -3,7 +3,7 @@ module WillPaginate
 
     module RelationMethods
 
-      # this method is an overried to the built in .to_a method
+      # this method is an override to the built in .to_a method
       # See https://github.com/mislav/will_paginate/blob/master/lib/will_paginate/active_record.rb
       def to_a
         if current_page.nil? then super # workaround for Active Record 3.0
@@ -15,7 +15,7 @@ module WillPaginate
             # called as that will initiate a new COUNT() query. Just grab the
             # count from the first result (all results have a total_count attribute).
             # Be sure to also set the ActiveRecord::Relation @total_entries
-            if build_arel.to_sql.match(/COUNT\(.*?\) OVER\(\) as total_count/)
+            if using_count_over?
               @total_entries = col.first ? col.first['total_count'].to_i : 0
               col.total_entries = @total_entries
             else
@@ -23,6 +23,10 @@ module WillPaginate
             end
           end
         end
+      end
+
+      def using_count_over?
+        @using_count_over ||= build_arel.to_sql.match(/COUNT\(.*?\) OVER\(\) as total_count/)
       end
 
     end
@@ -34,7 +38,12 @@ module WillPaginate
       # for fetching the page of results while simultaneously counting the
       # total entries
       def paginate_with_count_over(options)
-        paginate(options.merge(select: "#{table_name}.*, COUNT(#{table_name}.id) OVER() as total_count"))
+        pager = paginate(options.merge(select: "#{table_name}.*, COUNT(#{table_name}.id) OVER() as total_count"))
+        # this is unfortunately necessary to properly set total_entries.
+        # Without this, if you call .total_entries before iterating the results,
+        # a separate count query will be used, thus negating the intent of this method
+        pager.to_a
+        pager
       end
 
     end

--- a/spec/initializers/marshal_copy.rb
+++ b/spec/initializers/marshal_copy.rb
@@ -1,0 +1,39 @@
+require File.expand_path("../../spec_helper", __FILE__)
+
+describe 'Array' do
+
+  before do
+    @array = [ 1, 2, 3, 4 ]
+  end
+
+  it "should create an identical marshal_copy" do
+    @array.marshal_copy.should == @array
+  end
+
+  it "should points to a different instance in memory" do
+    copy = @array.marshal_copy
+    copy << 5
+    copy.length.should_not == @array.length
+    copy.should_not == @array
+  end
+
+end
+
+describe 'Hash' do
+
+  before do
+    @hash = { one: [ ], two: [ ] }
+  end
+
+  it "should create an identical marshal_copy" do
+    @hash.marshal_copy.should == @hash
+  end
+
+  it "should points to a different instance in memory" do
+    copy = @hash.marshal_copy
+    copy[:one] << :something
+    copy[:one].length.should_not == @hash.length
+    copy.should_not == @hash
+  end
+
+end


### PR DESCRIPTION
This enables GC::Profiling which can report data to be graphed in NewRelic. This commit fixes an issue where an :include parameter was growing iteratively, causing very large arrays to render slowly with .to_json. It also prevents some more unnecessary COUNT() queries
