### PR TITLE
Fixes map infowindows; also tweaks their style to get rid of scrollbars

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -928,7 +928,7 @@ google.maps.Map.prototype.addTileInteractivity = function( tilejson ) {
               beforeSend: function() {
                 var iw = map.getInfoWindow()
                 iw.position = latLng
-                iw.content = $('<div class="loading status">'+I18n.t('loading')+'</div>').get(0)
+                iw.setContent($('<div class="loading status">'+I18n.t('loading')+'</div>').get(0));
                 iw.open(map)
                 // remove any text highlighting, which happens when the user clicks around
                 deselectText();
@@ -936,7 +936,7 @@ google.maps.Map.prototype.addTileInteractivity = function( tilejson ) {
               success: function(data) {
                 var iw = map.getInfoWindow()
                 iw.position = latLng
-                iw.content = $('<div class="compact mini infowindow observations"></div>').append(data).get(0)
+                iw.setContent($('<div class="compact mini infowindow observations"></div>').append(data).get(0));
                 iw.open(map)
                 // make sure the InfoWindow has focus
                 $(iw).focus();

--- a/app/assets/stylesheets/observations.css.scss
+++ b/app/assets/stylesheets/observations.css.scss
@@ -193,13 +193,6 @@
   padding: 5px 0;
 }
 
-.observations.mini .observation:after {
-  content: '.';
-  clear: both;
-  height: 0;
-  visibility: hidden;
-  display: block;
-}
 
 .observations.mini .observed_on,
 .observations.mini .created_at,
@@ -470,7 +463,7 @@
 .observations.infowindow .observation {
   border: 0 none;
   margin: 0;
-  padding: 0;
+  padding-bottom: 10px;
   width: 400px;
   max-height: 300px;
 }

--- a/app/views/observations/_observation_component.html.erb
+++ b/app/views/observations/_observation_component.html.erb
@@ -64,7 +64,7 @@ Some notes:
   </div>
   <div class="photos attribute">
     <h4 class="label"><%= t :'sounds.photos_sounds' %></h4>
-    <div class="photolist clear">
+    <div class="photolist">
       <% photo_count, sound_count, link_text = observation.observation_photos.size, observation.observation_sounds_count, [] %>
       <% if photo_count == 0 && sound_count == 0 -%>
         <div class="photo nophoto description">


### PR DESCRIPTION
Scott noticed that the map infowindows were not loading. Not sure why this started happening now, but the `iw.content = ` expression is no longer working so I updated them to `iw.setContent()`. I also noticed recently the info windows almost always had scrollbars, so there are some CSS tweaks to fix that.