### PR TITLE
explicitly allow the archive.org indexer

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,3 +14,6 @@ Disallow: /taxa/*/description$
 Disallow: *.csv*
 Disallow: *page=*
 Disallow: /*?
+
+User-agent: ia_archiver
+Disallow: 


### PR DESCRIPTION
allow archive.org's wayback machine to create historical archives of the
inaturalist project.