### PR TITLE
Caching some Flickr API requests

### DIFF
--- a/app/models/flickr_photo.rb
+++ b/app/models/flickr_photo.rb
@@ -86,7 +86,7 @@ class FlickrPhoto < Photo
     elsif options[:square_url].blank?
       unless sizes = options.delete(:sizes)
         f = FlickrPhoto.flickraw_for_user(options[:user])
-        sizes = f.photos.getSizes(:photo_id => fp.id)
+        sizes = FlickrCache.fetch(f, "photos", "getSizes", photo_id: fp.id)
       end
       sizes = sizes.blank? ? {} : sizes.index_by{|s| s.label} rescue {}
       options[:square_url]   ||= sizes['Square'].source rescue nil

--- a/config/environments/prod_dev.rb
+++ b/config/environments/prod_dev.rb
@@ -61,7 +61,7 @@ Inaturalist::Application.configure do
 
   Rails.logger = Logger.new(STDOUT)
   Rails.logger.formatter = proc do |severity, datetime, progname, msg|
-    "[#{ datetime.to_formatted_s(:db) }] (PID: #{$$}) #{ msg }\n"
+    "[#{ datetime.to_formatted_s(:db) }] #{ msg }\n"
   end
 
   config.middleware.use Rack::GoogleAnalytics, :trackers => lambda { |env|

--- a/lib/flickr_cache.rb
+++ b/lib/flickr_cache.rb
@@ -1,0 +1,34 @@
+class FlickrCache
+  def self.fetch(flickraw, type, method, params={})
+    # find or create the endpoint
+    @api_endpoint = ApiEndpoint.find_or_create_by(title: "Flickr",
+      documentation_url: "http://www.flickr.com/services/api/",
+      base_url: "https://api.flickr.com/services/rest?", cache_hours: 720)
+    # find or create the cache entry for this call
+    api_endpoint_cache = ApiEndpointCache.find_or_create_by(api_endpoint: @api_endpoint,
+      request_url: "flickr.#{ type }.#{ method }(#{ params.to_json })")
+    # return the cached entry if it is valid
+    api_response = if api_endpoint_cache.cached?
+      JSON.parse(api_endpoint_cache.response).map do |r|
+        # map each hash to an object, as we would get from Flickraw
+        OpenStruct.new(r)
+      end
+    else
+      begin
+        # mark the start time of the fetch
+        api_endpoint_cache.update_attributes(request_began_at: Time.now,
+          request_completed_at: nil, success: nil, response: nil)
+        # call the API via Flickraw
+        response = flickraw.send(type).send(method, params)
+        # mark the end time and update the cache with the results
+        api_endpoint_cache.update_attributes(
+          request_completed_at: Time.now, success: true, response: response.to_json)
+      rescue FlickRaw::FailedResponse, EOFError, OpenSSL::SSL::SSLError => e
+        Rails.logger.error "Failed Flickr API request: #{e}"
+        Rails.logger.error e.backtrace.join("\n\t")
+        api_endpoint_cache.update_attributes(request_completed_at: Time.now, success: false)
+      end
+      response
+    end
+  end
+end

--- a/spec/lib/flickr_cache_spec.rb
+++ b/spec/lib/flickr_cache_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe FlickrCache do
+
+  before(:all) do
+    @flickr_response = OpenStruct.new(url: "some image URL")
+    @flickraw = flickr
+  end
+
+  it "creates the endpoint" do
+    expect(ApiEndpoint.count).to eq 0
+    expect(@flickraw.photos).to receive(:search).and_return(@flickr_response)
+    FlickrCache.fetch(@flickraw, "photos", "search", tags: "animals")
+    expect(ApiEndpoint.count).to eq 1
+    endpoint = ApiEndpoint.first
+    expect(endpoint.title).to eq "Flickr"
+    expect(endpoint.description).to eq nil
+    expect(endpoint.documentation_url).to eq "http://www.flickr.com/services/api/"
+    expect(endpoint.base_url).to eq "https://api.flickr.com/services/rest?"
+    expect(endpoint.cache_hours).to eq 720
+  end
+
+  it "caches the result" do
+    expect(ApiEndpointCache.count).to eq 0
+    expect(@flickraw.photos).to receive(:search).and_return(@flickr_response)
+    fetched = FlickrCache.fetch(@flickraw, "photos", "search", tags: "animals")
+    expect(ApiEndpointCache.count).to eq 1
+    cache = ApiEndpointCache.first
+    expect(cache.request_url).to eq "flickr.photos.search({\"tags\":\"animals\"})"
+    expect(cache.response).to eq "{\"table\":{\"url\":\"some image URL\"}}"
+    expect(cache.cached?).to be true
+    expect(fetched).to be @flickr_response
+  end
+
+  it "cached calls to any method" do
+    expect(ApiEndpointCache.count).to eq 0
+    expect(@flickraw.photos).to receive(:getSizes).and_return(@flickr_response)
+    fetched = FlickrCache.fetch(@flickraw, "photos", "getSizes", tags: "animals")
+    expect(ApiEndpointCache.count).to eq 1
+    cache = ApiEndpointCache.first
+    expect(cache.request_url).to eq "flickr.photos.getSizes({\"tags\":\"animals\"})"
+    expect(cache.response).to eq "{\"table\":{\"url\":\"some image URL\"}}"
+    expect(cache.cached?).to be true
+    expect(fetched).to be @flickr_response
+  end
+
+end


### PR DESCRIPTION
Caching the photo search, and subsequent getSizes on all resulting images, as generated by taxa#photos. Should work with any Flickraw call (e.g. replace `flickr.photos.getSizes(photo_id: 1234)` with `FlickrCache.fetch(flickr, "photos", "getSizes", photo_id: 1234)`)