### PR TITLE
Added the Updates ES index logic

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1960,8 +1960,11 @@ class ObservationsController < ApplicationController
 
   def user_viewed_updates
     return unless logged_in?
-    Update.where(["resource_type = 'Observation' AND resource_id = ? AND subscriber_id = ?", @observation.id, current_user.id]).
-      update_all(viewed_at: Time.now)
+    updates_scope = Update.where([
+      "resource_type = 'Observation' AND resource_id = ? AND subscriber_id = ?",
+      @observation.id, current_user.id])
+    updates_scope.update_all(viewed_at: Time.now)
+    Update.elastic_index!(scope: updates_scope)
   end
 
   def stats_adequately_scoped?

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -14,34 +14,24 @@ class Observation < ActiveRecord::Base
     mappings(dynamic: true) do
       indexes :taxon do
         indexes :names do
-          indexes :name, index_analyzer: "ascii_snowball_analyzer",
-            search_analyzer: "ascii_snowball_analyzer"
+          indexes :name, analyzer: "ascii_snowball_analyzer"
         end
       end
       indexes :photos do
-        indexes :license_code, index_analyzer: "keyword_analyzer",
-          search_analyzer: "keyword_analyzer"
+        indexes :license_code, analyzer: "keyword_analyzer"
       end
       indexes :sounds do
-        indexes :license_code, index_analyzer: "keyword_analyzer",
-          search_analyzer: "keyword_analyzer"
+        indexes :license_code, analyzer: "keyword_analyzer"
       end
       indexes :field_values do
-        indexes :name, index_analyzer: "keyword_analyzer",
-          search_analyzer: "keyword_analyzer"
-        indexes :value, index_analyzer: "keyword_analyzer",
-          search_analyzer: "keyword_analyzer"
+        indexes :name, analyzer: "keyword_analyzer"
+        indexes :value, analyzer: "keyword_analyzer"
       end
-      indexes :description, index_analyzer: "ascii_snowball_analyzer",
-        search_analyzer: "ascii_snowball_analyzer"
-      indexes :tags, index_analyzer: "ascii_snowball_analyzer",
-        search_analyzer: "ascii_snowball_analyzer"
-      indexes :place_guess, index_analyzer: "ascii_snowball_analyzer",
-        search_analyzer: "ascii_snowball_analyzer"
-      indexes :species_guess, index_analyzer: "keyword_analyzer",
-        search_analyzer: "keyword_analyzer"
-      indexes :license_code, index_analyzer: "keyword_analyzer",
-        search_analyzer: "keyword_analyzer"
+      indexes :description, analyzer: "ascii_snowball_analyzer"
+      indexes :tags, analyzer: "ascii_snowball_analyzer"
+      indexes :place_guess, analyzer: "ascii_snowball_analyzer"
+      indexes :species_guess, analyzer: "keyword_analyzer"
+      indexes :license_code, analyzer: "keyword_analyzer"
       indexes :observed_on_string, type: "string"
       indexes :location, type: "geo_point", lat_lon: true, geohash: true, geohash_precision: 10
       indexes :private_location, type: "geo_point", lat_lon: true

--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -18,8 +18,7 @@ class Place < ActiveRecord::Base
       indexes :location, type: "geo_point", lat_lon: true
       indexes :point_geojson, type: "geo_shape"
       indexes :bbox_area, type: "double"
-      indexes :display_name, index_analyzer: "ascii_snowball_analyzer",
-        search_analyzer: "ascii_snowball_analyzer"
+      indexes :display_name, analyzer: "ascii_snowball_analyzer"
       indexes :display_name_autocomplete, index_analyzer: "keyword_autocomplete_analyzer",
         search_analyzer: "keyword_analyzer"
     end

--- a/app/es_indices/project_index.rb
+++ b/app/es_indices/project_index.rb
@@ -5,12 +5,10 @@ class Project < ActiveRecord::Base
   scope :load_for_index, -> { includes(:place) }
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do
-      indexes :title, index_analyzer: "ascii_snowball_analyzer",
-        search_analyzer: "ascii_snowball_analyzer"
+      indexes :title, analyzer: "ascii_snowball_analyzer"
       indexes :title_autocomplete, index_analyzer: "keyword_autocomplete_analyzer",
         search_analyzer: "keyword_analyzer"
-      indexes :description, index_analyzer: "ascii_snowball_analyzer",
-        search_analyzer: "ascii_snowball_analyzer"
+      indexes :description, analyzer: "ascii_snowball_analyzer"
       indexes :location, type: "geo_point", lat_lon: true
       indexes :geojson, type: "geo_shape"
     end

--- a/app/es_indices/taxon_index.rb
+++ b/app/es_indices/taxon_index.rb
@@ -9,8 +9,7 @@ class Taxon < ActiveRecord::Base
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do
       indexes :names do
-        indexes :name, index_analyzer: "ascii_snowball_analyzer",
-          search_analyzer: "ascii_snowball_analyzer"
+        indexes :name, analyzer: "ascii_snowball_analyzer"
         indexes :name_autocomplete, index_analyzer: "autocomplete_analyzer",
           search_analyzer: "standard_analyzer"
       end

--- a/app/es_indices/update_index.rb
+++ b/app/es_indices/update_index.rb
@@ -1,0 +1,29 @@
+class Update < ActiveRecord::Base
+
+  include ActsAsElasticModel
+
+  settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
+    mappings(dynamic: true) do
+      indexes :resource_type, analyzer: "keyword_analyzer"
+      indexes :notifier, analyzer: "keyword_analyzer"
+      indexes :notification, analyzer: "keyword_analyzer"
+    end
+  end
+
+  def as_indexed_json(options={})
+    {
+      id: id,
+      subscriber_id: subscriber_id,
+      resource_id: resource_id,
+      resource_type: resource_type,
+      notifier_type: notifier_type,
+      notifier_id: notifier_id,
+      notification: notification,
+      created_at: created_at,
+      updated_at: updated_at,
+      resource_owner_id: resource_owner_id,
+      viewed_at: viewed_at
+    }
+  end
+
+end

--- a/app/models/update.rb
+++ b/app/models/update.rb
@@ -1,4 +1,7 @@
 class Update < ActiveRecord::Base
+
+  include ActsAsElasticModel
+
   belongs_to :subscriber, :class_name => "User"
   belongs_to :resource, :polymorphic => true
   belongs_to :notifier, :polymorphic => true
@@ -211,10 +214,12 @@ class Update < ActiveRecord::Base
     updates = updates.to_a.compact
     return if updates.blank?
     subscriber_id = updates.first.subscriber_id
-    
+
     # mark all as viewed
-    Update.where(id: updates).update_all(viewed_at: Time.now)
-    
+    updates_scope = Update.where(id: updates)
+    updates_scope.update_all(viewed_at: Time.now)
+    Update.elastic_index!(scope: updates_scope)
+
     # delete PAST activity updates that were not in this batch
     clauses = []
     update_ids = []

--- a/db/migrate/20150421155510_create_updates_index.rb
+++ b/db/migrate/20150421155510_create_updates_index.rb
@@ -1,0 +1,13 @@
+class CreateUpdatesIndex < ActiveRecord::Migration
+  def up
+    # delete older updates
+    starting_id = Update.where("created_at >= '2014-11-01'").minimum("id")
+    Update.where("id < #{ starting_id }").delete_all
+    Update.__elasticsearch__.create_index! force: true
+  end
+
+  def down
+    # not deleting the indices on down. If you redo this migration
+    # the up method with destory and recreate your indices
+  end
+end

--- a/lib/tasks/es.rake
+++ b/lib/tasks/es.rake
@@ -66,7 +66,8 @@ def elastic_models
     Observation => { },
     Project => { },
     Place => { batch_size: 20 },
-    Taxon => { }
+    Taxon => { },
+    Update => { batch_size: 5000 }
   }
 end
 

--- a/spec/controllers/users_controller_api_spec.rb
+++ b/spec/controllers/users_controller_api_spec.rb
@@ -1,6 +1,8 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 shared_examples_for "a signed in UsersController" do
+  before(:each) { enable_elastic_indexing( Update ) }
+  after(:each) { disable_elastic_indexing( Update ) }
   let(:user) { User.make! }
   it "should show email for edit" do
     get :edit, :format => :json


### PR DESCRIPTION
This has a migration that will delete all updates older than 2014-11-01, which can take a few minutes. There may be some query locking that happens during the delete, so we should release this at a slow time, or put up the maintenance page for a few minutes while it runs. The Updates ES indexing will need to be kicked off manually after the deploy