### PR TITLE
Removed Brisbane "Daylight Savings"

### DIFF
--- a/config/initializers/time_zone_codes.rb
+++ b/config/initializers/time_zone_codes.rb
@@ -6,6 +6,7 @@ class ActiveSupport::TimeZone
     'AWST' => ActiveSupport::TimeZone["Perth"],
     'ACST' => ActiveSupport::TimeZone["Adelaide"],
     'AEST' => ActiveSupport::TimeZone["Brisbane"],
+    'AEDT' => ActiveSupport::Timezone["Sydney"],
     'AWDT' => ActiveSupport::TimeZone["Perth"],
     'ACDT' => ActiveSupport::TimeZone["Adelaide"],
     'ADT' => ActiveSupport::TimeZone['Atlantic Time (Canada)'],

--- a/config/initializers/time_zone_codes.rb
+++ b/config/initializers/time_zone_codes.rb
@@ -8,7 +8,6 @@ class ActiveSupport::TimeZone
     'AEST' => ActiveSupport::TimeZone["Brisbane"],
     'AWDT' => ActiveSupport::TimeZone["Perth"],
     'ACDT' => ActiveSupport::TimeZone["Adelaide"],
-    'AEDT' => ActiveSupport::TimeZone["Brisbane"],
     'ADT' => ActiveSupport::TimeZone['Atlantic Time (Canada)'],
     'AKDT' => ActiveSupport::TimeZone['Alaska'],
     'ALMT' => ActiveSupport::TimeZone['Almaty'],

--- a/config/initializers/time_zone_codes.rb
+++ b/config/initializers/time_zone_codes.rb
@@ -6,7 +6,7 @@ class ActiveSupport::TimeZone
     'AWST' => ActiveSupport::TimeZone["Perth"],
     'ACST' => ActiveSupport::TimeZone["Adelaide"],
     'AEST' => ActiveSupport::TimeZone["Brisbane"],
-    'AEDT' => ActiveSupport::Timezone["Sydney"],
+    'AEDT' => ActiveSupport::TimeZone["Sydney"],
     'AWDT' => ActiveSupport::TimeZone["Perth"],
     'ACDT' => ActiveSupport::TimeZone["Adelaide"],
     'ADT' => ActiveSupport::TimeZone['Atlantic Time (Canada)'],


### PR DESCRIPTION
This is because Brisbane doesn't have daylight savings. This might be better changed to somewhere that does (for example, Sydney or Melbourne).