### PR TITLE
Add missing French translations for Project join page

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1511,7 +1511,7 @@ fr:
     des taxons répertoriés associés, etc. # Not really a litteral workaround but works better given the context / word reordering in taxa/edit
   its_important_that_you: Il est important que vous cliquiez
   iucn_red_list_status: Situation selon la liste rouge de l’UICN
-  join: Joignez-vous
+  join: Joignez-vous à
   join_and: Joignez-vous et
   join_inat: Joignez %{site_name} !
   join_project: Joignez-vous à ce projet
@@ -2578,6 +2578,7 @@ fr:
   receive_email_notifications_when_people_leave_you: Recevoir des avis par
     courriel sur
   received: reçu
+  receive_updates_from_this_project: Recevoir des avis pour ce projet
   recent_additions: Ajouts récents
   recent_comments_on_your_stuff: Commentaires récents sur vos trucs
   recent_observations: Observations récentes
@@ -4529,6 +4530,22 @@ fr:
           Il s’agit de la liste de contrôle organisée et du nombre de taxons des observations explicitement ajoutées à ce
           projet, et non de toutes les observations enregistrées dans ce lieu et au moment de
           l’activité.
+      updates_desc: Recevoir des notifications pour ce projet sur votre tableau de bord et dans le courriel quotidien
+      curator_coordinate_access_label: Permettre au responsable du projet de voir les coordonnées privées
+        de vos observations lorsqu'elles sont ajoutées par
+      project_user_curator_coordinate_access_labels:
+        observer: Vous
+        any: Responsables du projet
+        none: Personne
+      project_user_curator_coordinate_access_descriptions:
+        observer: Permettre aux responsables du projet de voir uniquement les coordonnées
+          privées des observations que vous ajoutez au projet
+        any: Permettre aux responsables du projet de voir les coordonnées privées de vos observations
+          si vous ou un responsable du projet les avez ajoutées
+        none: Ne pas partager les coordonnées privées de vos observations avec les responsables du projet
+      curator_coordinate_access_note: |-
+        Vous pouvez configurer individuellement les avis de chaque observations.
+        Cette option sera appliquée automatiquement sur toutes les autres.
     shared:
       spam:
         message_for_owner_and_curators_html: |-


### PR DESCRIPTION
Some more translation work as requested by James.

I figured I could open a PR for `master` since this only affects the french yml file — let me know if you'd rather have it opened against `i18n`.

Thanks!