### PR TITLE
added X-frame exception for facebook endpoint

### DIFF
--- a/app/controllers/facebook_controller.rb
+++ b/app/controllers/facebook_controller.rb
@@ -3,6 +3,7 @@ class FacebookController < ApplicationController
   before_filter :authenticate_user!, :except => [:index]
 
   def index
+    response.headers.delete "X-Frame-Options"
     @headless = @footless = true
     unless params[:by].blank?
       @selected_user = User.find_by_id(params[:by])


### PR DESCRIPTION
I got [this page](https://calm-ridge-9213.herokuapp.com/facebook/) loading as our [facebook canvas page](https://apps.facebook.com/inaturalist). I tried simulating several differences in our [broken endpoint ](http://www.inaturalist.org/facebook/)to see if I could break it (e.g. not having the FB js directly below the javascript)

The only difference I think might be breaking things on our end is the [default X-Frame-Options that Rails 4 added](http://stackoverflow.com/questions/16561066/ruby-on-rails-4-app-not-works-in-iframe).

Lets see if this works...