### PR TITLE
Supress redundant IDs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -664,6 +664,7 @@ protected
       :prefers_community_taxa,
       :prefers_location_details,
       :prefers_receive_mentions,
+      :prefers_redundant_identification_notifications,
       :site_id,
       :time_zone
     )

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -47,7 +47,8 @@ class Identification < ActiveRecord::Base
       ident.taxon_change_id.blank?
     },
     :if => lambda {|notifier, subscribable, subscription|
-      return true if subscribable.user.prefers_redundant_identification_notifications
+      return true if subscribable && subscribable.user && subscribable.user.prefers_redundant_identification_notifications
+      return true unless subscribable.owners_identification && notifier
       subscribable.owners_identification.taxon_id != notifier.taxon_id
     }
   auto_subscribes :user, :to => :observation, :if => lambda {|ident, observation| 

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -43,7 +43,13 @@ class Identification < ActiveRecord::Base
   attr_accessor :captive_flag
   
   notifies_subscribers_of :observation, :notification => "activity", :include_owner => true, 
-    :queue_if => lambda {|ident| ident.taxon_change_id.blank?}
+    :queue_if => lambda {|ident| 
+      ident.taxon_change_id.blank?
+    },
+    :if => lambda {|notifier, subscribable, subscription|
+      return true if subscribable.user.prefers_redundant_identification_notifications
+      subscribable.owners_identification.taxon_id != notifier.taxon_id
+    }
   auto_subscribes :user, :to => :observation, :if => lambda {|ident, observation| 
     ident.user_id != observation.user_id
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ActiveRecord::Base
   PROJECT_ADDITION_BY_NONE = "none"
   preference :project_addition_by, :string, default: PROJECT_ADDITION_BY_ANY
   preference :location_details, :boolean, default: false
+  preference :redundant_identification_notifications, :boolean, default: true
 
   
   SHARING_PREFERENCES = %w(share_observations_on_facebook share_observations_on_twitter)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -100,6 +100,12 @@
           label: t(:notify_me_of_mentions),
           label_after: true %>
       </div>
+      <div class="stacked">
+        <%= f.check_box "prefers_redundant_identification_notifications",
+          label: t(:notify_me_about_redundant_identifications),
+          description: t(:notify_me_about_redundant_identifications_desc),
+          label_after: true %>
+      </div>
 
       <a name="projects"></a>
       <h3><%=t :project_settings %></h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1785,6 +1785,11 @@ en:
   note: Note
   note_you_can_modify_the_height_attribute: "Note: You can modify the 'height' attribute to fit the available space on your web page."
   notify_me_of_mentions: Notify me of mentions (e.g. @username)
+  notify_me_about_redundant_identifications: Notify me about redundant identifications
+  notify_me_about_redundant_identifications_desc: |
+    If you opt out of this you will only reveive notifications about
+    identifications of taxa that don't match the taxon in your own
+    identification exactly.
   number_of_observations: Number of observations
   numeric_: numeric
   noun_by_you: "%{noun} by you"

--- a/lib/has_subscribers.rb
+++ b/lib/has_subscribers.rb
@@ -198,6 +198,9 @@ module HasSubscribers
         if notify_owner
           owner_subscription = subscribable.update_subscriptions.where(user_id: subscribable.user_id).first
           unless owner_subscription
+            if options[:if]
+              next unless options[:if].call(notifier, subscribable, Subscription.new(resource: subscribable, user: subscribable.user))
+            end
             u = Update.create(:subscriber => subscribable.user, :resource => subscribable, :notifier => notifier, 
               :notification => notification)
             unless u.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -776,6 +776,12 @@ describe User do
         without_delay { Identification.make!(observation: o, taxon: genus) }
         expect( u.updates.count ).to eq 1
       end
+      it "should allow notification if observer has no identification" do
+        obs = Observation.make!(user: u)
+        expect( obs.owners_identification ).to be_blank
+        without_delay { Identification.make!(observation: obs) }
+        expect( u.updates.count ).to eq 1
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -730,6 +730,55 @@ describe User do
     end
   end
 
+  describe "prefers_redundant_identification_notifications" do
+    before(:each) { enable_elastic_indexing( Observation, Update ) }
+    after(:each) { disable_elastic_indexing( Observation, Update ) }
+
+    let(:u) { User.make! }
+    let(:genus) { Taxon.make!(rank: Taxon::GENUS) }
+    let(:species) { Taxon.make!(rank: Taxon::SPECIES, parent: genus) }
+    let(:subspecies) { Taxon.make!(rank: Taxon::SUBSPECIES, parent: species) }
+    let(:o) { Observation.make!(user: u, taxon: species) }
+
+    describe "true" do
+      before do
+        u.update_attributes(prefers_redundant_identification_notifications: true)
+        expect( o ).to be_persisted
+      end
+      it "should allow identifications that match with the observer" do
+        without_delay { Identification.make!(observation: o, taxon: species) }
+        expect( u.updates.count ).to eq 1
+      end
+      it "should allow identifications of taxa that are descendants of the observer's taxon" do
+        without_delay { Identification.make!(observation: o, taxon: subspecies) }
+        expect( u.updates.count ).to eq 1
+      end
+      it "should allow identifications of taxa that are ancestors of the observer's taxon" do
+        without_delay { Identification.make!(observation: o, taxon: genus) }
+        expect( u.updates.count ).to eq 1
+      end
+    end
+
+    describe "false" do
+      before do
+        u.update_attributes(prefers_redundant_identification_notifications: false)
+        expect( o ).to be_persisted
+      end
+      it "should supress identifications that match with the observer" do
+        without_delay { Identification.make!(observation: o, taxon: species) }
+        expect( u.updates.count ).to eq 0
+      end
+      it "should allow identifications of taxa that are descendants of the observer's taxon" do
+        without_delay { Identification.make!(observation: o, taxon: subspecies) }
+        expect( u.updates.count ).to eq 1
+      end
+      it "should allow identifications of taxa that are ancestors of the observer's taxon" do
+        without_delay { Identification.make!(observation: o, taxon: genus) }
+        expect( u.updates.count ).to eq 1
+      end
+    end
+  end
+
   protected
   def create_user(options = {})
     opts = {


### PR DESCRIPTION
Add preference to stop receiving notifications about redundant IDs.