### PR TITLE
change hash # to search ? to allow for crawling

### DIFF
--- a/tools/globi_observation_links.rb
+++ b/tools/globi_observation_links.rb
@@ -40,7 +40,7 @@ while true do
       puts "\tobservation #{observation_id} doesn't exist, skipping..."
       next
     end
-    href = "http://www.globalbioticinteractions.org/#interactionType=interactsWith&accordingTo=#{FakeView.observation_url(observation_id)}"
+    href = "http://www.globalbioticinteractions.org/?interactionType=interactsWith&accordingTo=#{FakeView.observation_url(observation_id)}"
     existing = ObservationLink.where(observation_id: observation_id, href: href).first
     if existing
       existing.touch unless opts[:debug]


### PR DESCRIPTION
I used https://developer.mozilla.org/en-US/docs/Web/API/History/pushState to allow for search ? in url instead of hash / anchor. Apparently, search engines crawl search ? but not hashes.

Thanks!