### PR TITLE
Made former 'Still needs ID?' conditionally display and deduped Appropriate UI

### DIFF
--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -802,24 +802,6 @@
       </div>
     <% end -%>
   </div>
-  
-  <% if @observation.flagged? %>
-    <div id="flaggings_heads_up" class="description">
-      <%=t :heads_up_this_observation_has_been_flagged %>
-      <%= link_to t(:view_flags), observation_flags_path(@observation) %>
-      |
-      <%= link_to t(:add_another_flag), new_observation_flag_path(@observation),
-                  :id => "flag_this", :rel => "nofollow", :class => "flaglink" %>
-    </div>
-  <% else %>
-    <p class="description ui">
-      <%= t(:is_this_observation_offensive_html) %>
-      <%= link_to t(:flag_this_observation), new_observation_flag_path(@observation), :id => "flag_this", :rel => "nofollow", :class => "flaglink" %>
-    </p>
-    <p class="description ui">
-      <%=t :you_think_observation_inacurate %>
-    </p>
-  <% end %>
 
   <div id="sharing">
     <div id="fb-root"></div>

--- a/app/views/quality_metrics/_quality_metrics.html.erb
+++ b/app/views/quality_metrics/_quality_metrics.html.erb
@@ -34,7 +34,85 @@
           <% end -%>
         </td>
       </tr>
-
+      <% unless (o.community_supported_id? && o.community_taxon_at_species_or_lower?) || !o.research_grade_candidate? %>
+        <tr>
+          <td>
+            <%=t :still_needs_id? %>
+          </td>
+          <td width="100%">
+            <% if score = o.needs_id_vote_score %>
+              <table width="100%">
+                <tr>
+                  <td>
+                    <% if score >= 0.5 -%>
+                      <span class="good"><%=t :yes %></span>
+                    <% else %>
+                      <%=t :yes %>
+                    <% end -%>
+                  </td>
+                  <td width="100%">
+                    <% for v in o.get_upvotes(vote_scope: :needs_id) %>
+                      <%= link_to user_image(v.user, title: v.user.login, alt: v.user.login), person_by_login_path(v.user.login) %>
+                    <% end %>
+                  </td>
+                  <td class="small meta"><%= (score * 100).round %>%</td>
+                </tr>
+                <tr>
+                  <td>
+                    <% if score >= 0.5 -%>
+                      <%=t :no %>
+                    <% else %>
+                      <span class="bad"><%=t :no %></span>
+                    <% end -%>
+                  </td>
+                  <td>
+                    <% for v in o.get_downvotes(vote_scope: :needs_id) %>
+                      <%= link_to user_image(v.user, title: v.user.login, alt: v.user.login), person_by_login_path(v.user.login) %>
+                    <% end %>
+                  </td>
+                  <td class="small meta percent"><%= ((1 - score) * 100).round %>%</td>
+                </tr>
+              </table>
+            <% else %>
+              <%= o.needs_id? ? t(:yes) : t(:no) %>
+            <% end %>
+            <div class="small meta">
+              <%= t(:what_do_you_think) %>
+              <div class="right">
+                <% if user_vote = o.find_votes_for(vote_scope: :needs_id).detect{|v| v.voter_id == current_user.try(:id)} -%>
+                  <% if user_vote.vote_flag? -%>
+                    <strong>
+                      <%=t :yes %>
+                      <%= link_to "(x)", unvote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "delete", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
+                    </strong>
+                    /
+                    <%= link_to t(:no), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id, vote: :no), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
+                  <% else %>
+                    <%= link_to t(:yes), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
+                    /
+                    <strong>
+                      <%= t(:no) %>
+                      <%= link_to "(x)", unvote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "delete", "data-loading-click" => '&nbsp;', :class => "inlineblock status quality_metric_vote_link" %>
+                    </strong>
+                  <% end -%>
+                <% else %>
+                  <% if logged_in? -%>
+                    <% unless o.needs_id? %>
+                      <%= link_to t(:yes), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %> /
+                    <% end -%>
+                    <%= link_to t(:no), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id, vote: :no), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
+                  <% else %>
+                    <% unless o.needs_id? %>
+                      <%= link_to t(:yes), login_path, :class => "inlineblock status" %> /
+                    <% end -%>
+                    <%= link_to t(:no), login_path, :class => "inlineblock status" %>
+                  <% end -%>
+                <% end -%>
+              </div>
+            </div>
+          </td>
+        </tr>
+      <% end -%>
       <tr>
         <td><%= t(:observation_date?) %></td>
         <td>
@@ -70,92 +148,25 @@
         <td>
           <% if o.appropriate? -%>
             <span class="good"><%=t :yes %></span>
+            <div class="small meta">
+              <%= link_to t(:inappropriate), "/help#inappropriate" %>
+              <div class="right">
+                <%= link_to t(:flag_this_observation), new_observation_flag_path(@observation), :id => "flag_this", :rel => "nofollow", :class => "flaglink" %>
+              </div>
+            </div>
           <% else %>
             <%= t(:no) %>
             <% if o.flagged? -%>
               <div class="small meta">
-                <%= link_to t(:view_observationflags), observation_flags_path(o) %>
+                <%= link_to t(:view_observation_flags), observation_flags_path(o) %>
               </div>
             <% end -%>
-            <% if @flagged_photos -%>
+            <% if @flagged_photos.length > 0 -%>
               <div class="small meta">
                 <%=t :view_flags_for_x_html, :x => commas_and(@flagged_photos.map{|p| link_to("#{t :photo} #{p.id}", p.becomes(Photo))}) %>
               </div>
             <% end -%>
           <% end -%>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <%=t :still_needs_id? %>
-        </td>
-        <td width="100%">
-          <% if score = o.needs_id_vote_score %>
-            <table width="100%">
-              <tr>
-                <td>
-                  <% if score >= 0.5 -%>
-                    <span class="good"><%=t :yes %></span>
-                  <% else %>
-                    <%=t :yes %>
-                  <% end -%>
-                </td>
-                <td width="100%">
-                  <% for v in o.get_upvotes(vote_scope: :needs_id) %>
-                    <%= link_to user_image(v.user, title: v.user.login, alt: v.user.login), person_by_login_path(v.user.login) %>
-                  <% end %>
-                </td>
-                <td class="small meta"><%= (score * 100).round %>%</td>
-              </tr>
-              <tr>
-                <td>
-                  <% if score >= 0.5 -%>
-                    <%=t :no %>
-                  <% else %>
-                    <span class="bad"><%=t :no %></span>
-                  <% end -%>
-                </td>
-                <td>
-                  <% for v in o.get_downvotes(vote_scope: :needs_id) %>
-                    <%= link_to user_image(v.user, title: v.user.login, alt: v.user.login), person_by_login_path(v.user.login) %>
-                  <% end %>
-                </td>
-                <td class="small meta percent"><%= ((1 - score) * 100).round %>%</td>
-              </tr>
-            </table>
-          <% else %>
-            <%= o.needs_id? ? t(:yes) : t(:no) %>
-          <% end %>
-          <div class="small meta">
-            <%= t(:what_do_you_think) %>
-            <div class="right">
-              <% if user_vote = o.find_votes_for(vote_scope: :needs_id).detect{|v| v.voter_id == current_user.try(:id)} -%>
-                <% if user_vote.vote_flag? -%>
-                  <strong>
-                    <%=t :yes %>
-                    <%= link_to "(x)", unvote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "delete", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
-                  </strong>
-                  /
-                  <%= link_to t(:no), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id, vote: :no), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
-                <% else %>
-                  <%= link_to t(:yes), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
-                  /
-                  <strong>
-                    <%= t(:no) %>
-                    <%= link_to "(x)", unvote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "delete", "data-loading-click" => '&nbsp;', :class => "inlineblock status quality_metric_vote_link" %>
-                  </strong>
-                <% end -%>
-              <% else %>
-                <% if logged_in? -%>
-                  <%= link_to t(:yes), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %> /
-                  <%= link_to t(:no), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id, vote: :no), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
-                <% else %>
-                  <%= link_to t(:yes), login_path, :class => "inlineblock status" %> /
-                  <%= link_to t(:no), login_path, :class => "inlineblock status" %>
-                <% end -%>
-              <% end -%>
-            </div>
-          </div>
         </td>
       </tr>
     </tbody>

--- a/app/views/quality_metrics/_quality_metrics.html.erb
+++ b/app/views/quality_metrics/_quality_metrics.html.erb
@@ -34,7 +34,7 @@
           <% end -%>
         </td>
       </tr>
-      <% unless (o.community_supported_id? && o.community_taxon_at_species_or_lower?) || !o.research_grade_candidate? %>
+      <% if o.research_grade_candidate? %>
         <tr>
           <td>
             <%=t :still_needs_id? %>
@@ -96,16 +96,22 @@
                     </strong>
                   <% end -%>
                 <% else %>
-                  <% if logged_in? -%>
-                    <% unless o.needs_id? %>
-                      <%= link_to t(:yes), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %> /
+                  <% unless o.needs_id? && o.find_votes_for(vote_scope: :needs_id).length == 0 -%>
+                    <% if logged_in? -%>
+                      <%= link_to t(:yes), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
+                    <% else -%>
+                      <%= link_to t(:yes), login_path, :class => "inlineblock status" %>                      
                     <% end -%>
-                    <%= link_to t(:no), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id, vote: :no), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
-                  <% else %>
-                    <% unless o.needs_id? %>
-                      <%= link_to t(:yes), login_path, :class => "inlineblock status" %> /
+                  <% end -%>
+                  <% unless (o.needs_id? && o.find_votes_for(vote_scope: :needs_id).length == 0) || ((o.community_supported_id? && o.community_taxon_at_species_or_lower?) && o.find_votes_for(vote_scope: :needs_id).length == 0) -%>
+                    /
+                  <% end -%>
+                  <% unless (o.community_supported_id? && o.community_taxon_at_species_or_lower?) && o.find_votes_for(vote_scope: :needs_id).length == 0 -%>
+                    <% if logged_in? -%>
+                      <%= link_to t(:no), vote_path(resource_type: 'Observation', resource_id: o.id, scope: :needs_id, vote: :no), "data-method" => "post", "data-loading-click" => "&nbsp;", :class => "inlineblock status quality_metric_vote_link" %>
+                    <% else -%>
+                      <%= link_to t(:no), login_path, :class => "inlineblock status" %>                      
                     <% end -%>
-                    <%= link_to t(:no), login_path, :class => "inlineblock status" %>
                   <% end -%>
                 <% end -%>
               </div>

--- a/app/views/quality_metrics/_quality_metrics.html.erb
+++ b/app/views/quality_metrics/_quality_metrics.html.erb
@@ -155,7 +155,7 @@
           <% if o.appropriate? -%>
             <span class="good"><%=t :yes %></span>
             <div class="small meta">
-              <%= link_to t(:inappropriate), "/help#inappropriate" %>
+              <%= t(:inappropriate?) %>
               <div class="right">
                 <%= link_to t(:flag_this_observation), new_observation_flag_path(@observation), :id => "flag_this", :rel => "nofollow", :class => "flaglink" %>
               </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1304,7 +1304,7 @@ en:
   inactive_taxon_concepts_are:
     Inactive taxon concepts are either taxonomically outdated or being staged for a a taxon change.
     Outdated concepts are kept to maintain history and compatability with some partner sites.
-  inappropriate: inappropriate?
+  inappropriate?: Inappropriate?
   inat_account_action: "%{site_name} &#58; Account &#58; %{action_name}"
   inat_believes_this_is_a_complete_listing: "%{site_name} believes this is a complete listing of this taxon in this place."
   inat_user_profile: "%{site_name}: %{user}'s Profile"
@@ -1628,7 +1628,7 @@ en:
   message: Message
   messages: Messages
   mixed_licenses: mixed licenses
-  misleading_or_illegal_content: "Misleading or illegal content, racial or ethnic slurs, etc."
+  misleading_or_illegal_content: "Misleading or illegal content, racial or ethnic slurs, etc. For more on our definition of 'appropriate', see the <a href="/help#inappropriate">FAQ</a>."
   mobile_app_for: Mobile app for
   mobile_apps_for: Mobile apps for
   mobile_view_available: Mobile view available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1304,6 +1304,7 @@ en:
   inactive_taxon_concepts_are:
     Inactive taxon concepts are either taxonomically outdated or being staged for a a taxon change.
     Outdated concepts are kept to maintain history and compatability with some partner sites.
+  inappropriate: inappropriate?
   inat_account_action: "%{site_name} &#58; Account &#58; %{action_name}"
   inat_believes_this_is_a_complete_listing: "%{site_name} believes this is a complete listing of this taxon in this place."
   inat_user_profile: "%{site_name}: %{user}'s Profile"
@@ -3182,6 +3183,7 @@ en:
   view_post: View post
   view_observation: View observation
   view_observations: View observations
+  view_observation_flags: View observation flags
   view_observations_by_everyone: View observations by everyone
   view_observations_raquo: "View observations &raquo;"
   view_on: View on


### PR DESCRIPTION
In another attempt to reduce the confusion causing people to vote yes on 'Community can improve/confirm ID?' AKA 'Still needs ID', I moved it up with the rest of the community ID pieces and have it not display if the obs is not a research grade candidate or the obs already has a community ID of species or lower. If the obs is needs ID but there are no votes yet, 'Yes' is hidden (to prevent people proactively voting yes)

I also consolidated the 'appropriate?' logic which appeared below licensing and was mostly repeated again in the data quality assessment into the data quality assessment