### PR TITLE
Trying to add obs from the aggregator in a transaction (#996)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -762,8 +762,10 @@ class Project < ActiveRecord::Base
       Rails.logger.debug "[DEBUG] Processing page #{observations.current_page} of #{observations.total_pages} for #{slug}"
       observations.each do |o|
         # don't use first_or_create here
-        po = ProjectObservation.where(project: self, observation: o).first ||
-          ProjectObservation.create(project: self, observation: o)
+        po = transaction do
+          ProjectObservation.where(project: self, observation: o).first ||
+            ProjectObservation.create(project: self, observation: o)
+        end
         if po && !po.errors.any?
           added += 1
         else


### PR DESCRIPTION
@pleary, do you think this would kill performance for the aggregator? I'm trying to prevent it from creating the same project observation twice. Not entirely sure why it would be doing that, but maybe it's running on multiple machines at the same time?