### PR TITLE
Mushroom Observer Import

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1809,6 +1809,7 @@ class ObservationsController < ApplicationController
     if @api_key = params[:api_key]
       mot = MushroomObserverImportFlowTask.new
       @mo_user_id = mot.mo_user_id( @api_key )
+      @mo_user_name = mot.mo_user_name( @api_key )
       @results = mot.get_results_xml( api_key: @api_key ).map{ |r| [r, mot.observation_from_result( r, skip_images: true )] }
     end
     respond_to do |format|

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1805,6 +1805,17 @@ class ObservationsController < ApplicationController
     end
   end
 
+  def moimport
+    if @api_key = params[:api_key]
+      mot = MushroomObserverImportFlowTask.new
+      @mo_user_id = mot.mo_user_id( @api_key )
+      @results = mot.get_results_xml( api_key: @api_key ).map{ |r| [r, mot.observation_from_result( r, skip_images: true )] }
+    end
+    respond_to do |format|
+      format.html { render layout: "bootstrap" }
+    end
+  end
+
   private
 
   def observation_params(options = {})

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -164,6 +164,18 @@ class Emailer < ActionMailer::Base
     reset_locale
   end
 
+  def moimport_finished( mot, errors = {} )
+    @user = mot.user
+    set_locale
+    @subject = "#{subject_prefix} Mushroom Observer Import Finished"
+    @errors = errors
+    @exception = mot.exception
+    mail(set_site_specific_opts.merge(
+      :to => "#{@user.name} <#{@user.email}>", :subject => @subject
+    ))
+    reset_locale
+  end
+
   private
   def default_url_options
     opts = Rails.application.config.action_mailer.default_url_options.dup

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -164,11 +164,12 @@ class Emailer < ActionMailer::Base
     reset_locale
   end
 
-  def moimport_finished( mot, errors = {} )
+  def moimport_finished( mot, errors = {}, warnings = {} )
     @user = mot.user
     set_locale
     @subject = "#{subject_prefix} Mushroom Observer Import Finished"
     @errors = errors
+    @warnings = warnings
     @exception = mot.exception
     mail(set_site_specific_opts.merge(
       :to => "#{@user.name} <#{@user.email}>", :subject => @subject

--- a/app/models/mushroom_observer_import_flow_task.rb
+++ b/app/models/mushroom_observer_import_flow_task.rb
@@ -44,7 +44,7 @@ class MushroomObserverImportFlowTask < FlowTask
   def get_results_xml( options = {} )
     user_id = mo_user_id( options[:api_key] )
     page = options[:page] || 1
-    Nokogiri::XML( open( "http://mushroomobserver.org/api/observations?user=#{user_id}&detail=high&page=#{page}" ) ).search( "result" )
+    Nokogiri::XML( open( "http://mushroomobserver.org/api/observations?user=#{user_id}&detail=high&page=#{page}&date=201601" ) ).search( "result" )
   end
 
   def mo_user_id( for_api_key = nil )
@@ -84,7 +84,7 @@ class MushroomObserverImportFlowTask < FlowTask
       begin
         taxon = Taxon.single_taxon_for_name( name, iconic_taxa: [ Taxon::ICONIC_TAXA_BY_NAME["Fungi"] ])
         taxon ||= Taxon.import( name, ancestor: Taxon::ICONIC_TAXA_BY_NAME["Fungi"] ) rescue nil
-        o.taxon = taxon if taxon
+        o.taxon = Taxon.find_by_id( taxon.id ) if taxon && taxon.persisted?
       rescue ActiveRecord::AssociationTypeMismatch
         log "Failed to import a new taxon for #{name}"
       end

--- a/app/models/mushroom_observer_import_flow_task.rb
+++ b/app/models/mushroom_observer_import_flow_task.rb
@@ -1,0 +1,139 @@
+class MushroomObserverImportFlowTask < FlowTask
+
+  def run
+    update_attributes(finished_at: nil, error: nil, exception: nil)
+    log "Importing observations from Mushroom Observer for #{user}"
+    page = 1
+    errors = {}
+    loop do
+      results = get_results_xml( page: page )
+      break if results.blank?
+      break if page > 5 # test
+      results.each do |result|
+        o = observation_from_result( result )
+        unless o.save
+          errors[result[:url]] = o.errors.full_messages.to_sentence
+        end
+      end
+      page += 1
+    end
+    log "Finished importing observations from Mushroom Observer for #{user}"
+    Emailer.moimport_finished( self, errors ).deliver_now
+  rescue Exception => e
+    exception_string = [ e.class, e.message ].join(" :: ")
+    logger.error "#{self.class.name} #{id}: Error: #{exception_string}" if @debug
+    update_attributes(
+      finished_at: Time.now,
+      error: "Error",
+      exception: [ exception_string, e.backtrace ].join("\n")
+    )
+    Emailer.moimport_finished( self, errors ).deliver_now
+    false
+  end
+
+  def log( msg )
+    if options[:logger] == "stdout"
+      puts
+      puts "[INFO] #{msg}"
+      puts
+    else
+      Rails.logger.info "[INFO] #{msg}"
+    end
+  end
+
+  def get_results_xml( options = {} )
+    user_id = mo_user_id( options[:api_key] )
+    page = options[:page] || 1
+    Nokogiri::XML( open( "http://mushroomobserver.org/api/observations?user=#{user_id}&detail=high&page=#{page}" ) ).search( "result" )
+  end
+
+  def mo_user_id( for_api_key = nil )
+    for_api_key ||= api_key
+    xml = Nokogiri::XML( open( "http://mushroomobserver.org/api/api_keys?api_key=#{for_api_key}" ) )
+    @mo_user_id ||= xml.at( "response/user" )[:id]
+  end
+
+  def api_key
+    return nil unless inputs && inputs.first && inputs.first.extra
+    @api_key ||= inputs.first.extra[:api_key]
+  end
+
+  def observation_from_result( result, options = {} )
+    log "working on result #{result[:url]}"
+    existing = Observation.by( user ).joins(:observation_field_values).
+      where(
+        "observation_field_values.observation_field_id = ? AND value = ?",
+        mo_url_observation_field,
+        result[:url]
+      ).first
+    return existing if existing
+    o = Observation.new( user: user )
+    o.observation_field_values.build( observation_field: mo_url_observation_field, value: result[:url] )
+    if location = result.at( "location" )
+      o.place_guess = location.at( "name" ).text
+      swlat = location.at( "latitude_south" ).text.to_f
+      swlng = location.at( "longitude_west" ).text.to_f
+      nelat = location.at( "latitude_north" ).text.to_f
+      nelng = location.at( "longitude_east" ).text.to_f
+      o.latitude = swlat + ( ( nelat - swlat ) / 2 )
+      o.longitude = swlng + ( ( nelng - swlng ) / 2 )
+      o.positional_accuracy = lat_lon_distance_in_meters(o.latitude, o.longitude, nelat, nelng)
+    end
+    if consensus_name = result.at( "consensus_name" )
+      name = consensus_name.at( "name" ).text
+      begin
+        taxon = Taxon.single_taxon_for_name( name, iconic_taxa: [ Taxon::ICONIC_TAXA_BY_NAME["Fungi"] ])
+        taxon ||= Taxon.import( name, ancestor: Taxon::ICONIC_TAXA_BY_NAME["Fungi"] ) rescue nil
+        o.taxon = taxon if taxon
+      rescue ActiveRecord::AssociationTypeMismatch
+        log "Failed to import a new taxon for #{name}"
+      end
+      o.species_guess = name
+    end
+    if date = result.at( "date" )
+      o.observed_on_string = date.text
+    end
+    if notes = result.at( "notes" )
+      o.description = notes.text
+    end
+    if !options[:skip_images] && ( primary_image = result.at( "primary_image" ) )
+      [primary_image, result.search( "image" )].flatten.each do |image|
+        lp = LocalPhoto.new( user: user )
+        image_url = "http://images.mushroomobserver.org/orig/#{image[:id]}.jpg"
+        begin
+          log "getting image from #{image_url}"
+          io = open( URI.parse( image_url ) )
+          Timeout::timeout(10) do
+            lp.file = (io.base_uri.path.split('/').last.blank? ? nil : io)
+          end
+        rescue => e
+          log "[ERROR #{Time.now}] Failed to download_remote_icon for #{id}: #{e}"
+        end
+        if image_license = image.at( "license")
+          lp.license = case image_license[:url]
+          when /by-nc-sa\// then Photo::CC_BY_NC_SA
+          when /by-nc-nd\// then Photo::CC_BY_NC_ND
+          when /by-sa\// then Photo::CC_BY_SA
+          when /by-nd\// then Photo::CC_BY_ND
+          when /by\// then Photo::CC_BY
+          when /publicdomain\// then Photo::PD
+          end
+        end 
+        o.observation_photos.build( photo: lp )
+      end
+    end
+    o
+  end
+
+  def mo_url_observation_field
+    unless @mo_url_observation_field
+      @mo_url_observation_field = ObservationField.find_by_name( "Mushroom Observer URL" )
+      @mo_url_observation_field ||= ObservationField.create!(
+        name: "Mushroom Observer URL",
+        datatype: ObservationField::TEXT,
+        description: "URL of this record on http://mushroomobserver.org"
+      )
+    end
+    @mo_url_observation_field
+  end
+end

--- a/app/views/emailer/moimport_finished.html.haml
+++ b/app/views/emailer/moimport_finished.html.haml
@@ -3,14 +3,29 @@
   = link_to observations_by_login_url( @user.login ), observations_by_login_url( @user.login )
 
 - unless @errors.blank?
+  %h2 Errors
   %p The following observations could not be imported:
   %ul
     - @errors.each do |url, errors|
-      = link_to url, url
-      %p= errors
+      %li
+        = link_to url, url
+        %p= errors
 - unless @exception.blank?
   %p There was also this one big error that caused the whole process to stop:
   = @exception
+
+- unless @warnings.blank?
+  %h2 Warnings
+  %ul
+    - @warnings.each do |url, warnings|
+      %li
+        = link_to url, url
+        %ul
+          - warnings.each do |wanring|
+            %li= warning
+          %li
+            = link_to "View on iNat", observations_url( "field:Mushroom+Observer+URL" => url )
+
 
 - unless @errors.blank? && @exception.blank?
   %p

--- a/app/views/emailer/moimport_finished.html.haml
+++ b/app/views/emailer/moimport_finished.html.haml
@@ -1,0 +1,18 @@
+%p
+  Your Mushroom Observer import is finished. You can see the results at
+  = link_to observations_by_login_url( @user.login ), observations_by_login_url( @user.login )
+
+- unless @errors.blank?
+  %p The following observations could not be imported:
+  %ul
+    - @errors.each do |url, errors|
+      = link_to url, url
+      %p= errors
+- unless @exception.blank?
+  %p There was also this one big error that caused the whole process to stop:
+  = @exception
+
+- unless @errors.blank? && @exception.blank?
+  %p
+    If you need some help resolving these errors, please forward this email to
+    = link_to "help@inaturalist.org", "mailto:help@inaturalist.org"

--- a/app/views/emailer/moimport_finished.html.haml
+++ b/app/views/emailer/moimport_finished.html.haml
@@ -21,10 +21,9 @@
       %li
         = link_to url, url
         %ul
-          - warnings.each do |wanring|
+          - warnings.each do |warning|
             %li= warning
-          %li
-            = link_to "View on iNat", observations_url( "field:Mushroom+Observer+URL" => url )
+        = link_to "View on iNat", observations_url( "field:Mushroom+Observer+URL" => url )
 
 
 - unless @errors.blank? && @exception.blank?

--- a/app/views/observations/moimport.html.haml
+++ b/app/views/observations/moimport.html.haml
@@ -1,0 +1,68 @@
+- content_for :extracss do
+  = stylesheet_link_tag "taxa"
+.container
+  .row
+    .col-xs-12
+      %h1 Mushroom Observer Import
+      %p
+        This tool will import your observations from Mushroom Observer to iNat. You'll need to get a Mushroom Observer API key from
+        = link_to "http://mushroomobserver.org/account/api_keys", "http://mushroomobserver.org/account/api_keys"
+  .row
+    .col-xs-6
+      %form.form-inline{ method: "get" }
+        .form-group
+          %input.form-control{ type: "text", name: "api_key", placeholder: "Enter your Mushroom Observer API key", style: "min-width: 300px", value: @api_key }
+        %input.btn.btn-default{ type: "submit", value: "Test" }
+    .col-xs6
+      = form_for MushroomObserverImportFlowTask.new, 
+          url: flow_tasks_url,
+          data: { confirm: "Are you sure? This is going to take a while, so expect the following screen to tell you there was an error because it was taking too long. Ignore it! You'll get an email when the import is done though, whether or not it succeeds." } do |f|
+        = f.hidden_field :redirect_url, value: observations_by_login_url( current_user.login )
+        = f.fields_for :inputs, f.object.inputs.first || f.object.inputs.build do |fti|
+          = fti.fields_for :extra do |ftie|
+            = ftie.text_field :api_key, class: "text", placeholder: "Enter your Mushroom Observer API key", style: "min-width: 300px", value: @api_key
+            = ftie.hidden_field :mo_user_id, value: @mo_user_id
+        = f.submit "Import", class: "btn btn-primary"
+  - if @results
+    .row
+      .col-xs-12
+        %h2
+          Test Import for MO user
+          = @mo_user_id
+        %table.table
+          %thead
+            %tr
+              %th Photo
+              %th Taxon
+              %th Date
+              %th Latitude
+              %th Longitude
+              %th Accuracy
+              %th Place desc
+              %th Description &amp; MO URL
+          %tbody
+            - @results.each do |result, observation|
+              %tr
+                %td
+                  - if img = result.at( "primary_image" )
+                    %img{ src: "http://images.mushroomobserver.org/thumb/#{img[:id]}.jpg" }
+                  - else
+                    = iconic_taxon_image( observation.taxon )
+                %td
+                  - if observation.taxon 
+                    = render "shared/taxon", taxon: observation.taxon, link_url: observation.taxon
+                  - else
+                    Placeholder:
+                    = observation.species_guess
+                %td.nobr
+                  = observation.munge_observed_on_with_chronic; observation.observed_on
+                %td= observation.latitude
+                %td= observation.longitude
+                %td= "#{observation.positional_accuracy} m"
+                %td= observation.place_guess
+                %td
+                  = formatted_user_text observation.description
+                  %p
+                    MO URL: 
+                    = link_to result[:url], result[:url]
+                

--- a/app/views/observations/moimport.html.haml
+++ b/app/views/observations/moimport.html.haml
@@ -12,7 +12,7 @@
       = form_for moimport_observations_path, html: { class: "form-inline" } do |f|
         .form-group
           %input.form-control{ type: "text", name: "api_key", placeholder: "Enter your Mushroom Observer API key", style: "min-width: 300px", value: @api_key }
-        %input.btn.btn-default{ type: "submit", value: "Test" }
+        %input.btn.btn-default{ type: "submit", value: "Test", data: { loading_click: "Loading..." } }
     .col-xs6
       = form_for MushroomObserverImportFlowTask.new, 
           url: flow_tasks_url,
@@ -22,7 +22,7 @@
           = fti.fields_for :extra do |ftie|
             = ftie.text_field :api_key, class: "text", placeholder: "Enter your Mushroom Observer API key", style: "min-width: 300px", value: @api_key
             = ftie.hidden_field :mo_user_id, value: @mo_user_id
-        = f.submit "Import", class: "btn btn-primary"
+        = f.submit "Import", class: "btn btn-primary", data: { loading_click: "Loading..." }
   - if @results
     .row
       .col-xs-12
@@ -72,7 +72,7 @@
       %p
         iNat will import all of your MO observations, doing its best to
         translate MO's data model to our own. The testing tool above will
-        give you a sense for what youre imported data will look like on
+        give you a sense for what your imported data will look like on
         iNat. It should not import the same record twice, so if you run this
         multiple times, don't expect a record that's already been imported
         to change. It will store the MO URL as an observation field so you

--- a/app/views/observations/moimport.html.haml
+++ b/app/views/observations/moimport.html.haml
@@ -9,7 +9,7 @@
         = link_to "http://mushroomobserver.org/account/api_keys", "http://mushroomobserver.org/account/api_keys"
   .row
     .col-xs-6
-      %form.form-inline{ method: "get" }
+      = form_for moimport_observations_path, html: { class: "form-inline" } do |f|
         .form-group
           %input.form-control{ type: "text", name: "api_key", placeholder: "Enter your Mushroom Observer API key", style: "min-width: 300px", value: @api_key }
         %input.btn.btn-default{ type: "submit", value: "Test" }
@@ -28,7 +28,8 @@
       .col-xs-12
         %h2
           Test Import for MO user
-          = @mo_user_id
+          = @mo_user_name
+          = "(#{@mo_user_id})"
         %table.table
           %thead
             %tr
@@ -65,4 +66,34 @@
                   %p
                     MO URL: 
                     = link_to result[:url], result[:url]
-                
+  .row
+    .col-xs-12
+      %h2 How This Works
+      %p
+        iNat will import all of your MO observations, doing its best to
+        translate MO's data model to our own. The testing tool above will
+        give you a sense for what youre imported data will look like on
+        iNat. It should not import the same record twice, so if you run this
+        multiple times, don't expect a record that's already been imported
+        to change. It will store the MO URL as an observation field so you
+        can always refer back to the original.
+      %h3 Some caveats
+      %ul
+        %li
+          %strong Names will not allways match up:
+          iNat will do its best to match MO names with iNat taxa, but it's not
+          always going to be perfect. If we can't find a matching taxon, we'll
+          just add a "placeholder" and you'll need to look for taxon-less
+          observations to correct them.
+        %li
+          %strong iNat will use the MO consensus name, not your name.
+          Getting your naming from the MO API seems to be impossible.
+        %li
+          %strong Observaitons not from collection location will be skipped:
+          iNat is for recording observations from where and when they were
+          observed in the wild.
+        %li
+          %strong You are the photo copyright holder:
+          iNat does not support uploading photos by other people. It will
+          assume and state publicly that you are the copyright holder for all
+          images.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,7 @@ Rails.application.routes.draw do
       get :map
       get :identify
       get :moimport
+      post :moimport
     end
     member do
       put :viewed_updates

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,7 @@ Rails.application.routes.draw do
       get :export
       get :map
       get :identify
+      get :moimport
     end
     member do
       put :viewed_updates


### PR DESCRIPTION
A quick and dirty tool for importing observations from Mushroom Observer. Not intended to be publicly linked or really even kept around for that long.