### PR TITLE
Content type detection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
 
   def set_site
     @site ||= CONFIG.site unless Rails.env.test?
-    if !@site && CONFIG.site_id
+    if ( !@site || !@site.is_a?( Site ) ) && CONFIG.site_id
       @site = Site.find_by_id(CONFIG.site_id)
       CONFIG.site = @site unless Rails.env.test?
     end

--- a/app/models/local_photo.rb
+++ b/app/models/local_photo.rb
@@ -37,9 +37,9 @@ class LocalPhoto < Photo
       bucket: CONFIG.s3_bucket,
       #
       #  NOTE: the path used to be "photos/:id/:style.:extension" as of
-      #  [DATE], but that wasn't setting the extension based on the detected
+      #  2016-07-15, but that wasn't setting the extension based on the detected
       #  content type, just echoing what was in the file name. So if you're
-      #  trying to use file.url or file.path for photos older than [DATE],
+      #  trying to use file.url or file.path for photos older than 2016-07-15,
       #  you'll probably want to fetch the original from original_url first
       #  before you do any work on the photo.
       #

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -22,7 +22,7 @@
     <% if logged_in? && current_user.is_curator? -%>
       <h4 class="upstacked"><%=t :curators %></h4>
       <p class="ui">
-        <%=t 'views.photos.show.view_original_html', :url => @photo.is_a?(LocalPhoto) ? @photo.file.url(:original) : @photo.native_page_url %>
+        <%=t 'views.photos.show.view_original_html', :url => @photo.is_a?(LocalPhoto) ? @photo.original_url : @photo.native_page_url %>
       </p>
     <% end -%>
   </div>

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -18,3 +18,5 @@ Paperclip.interpolates('icon_type_extension') do |attachment, style|
   end
   ext
 end
+
+Paperclip::UploadedFileAdapter.content_type_detector = Paperclip::FileCommandContentTypeDetector


### PR DESCRIPTION
Force paperclip to check the content type of the file instead of relying on the file name. This should prevent us from storing photo files without extensions and deal with some issues with Twitter previews. Older photos can still be repaired and rotated, but any future code dealing with the `path` or `url` of past photos attachments will need to re-download the image referenced in `original_url` before doing any work.