### PR TITLE
Stop using listed_taxa.taxon_ancestor_ids

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1191,7 +1191,7 @@ class ObservationsController < ApplicationController
         @listed_taxa_alphabetical = @listed_taxa.to_a.sort! {|a,b| a.taxon.default_name.name <=> b.taxon.default_name.name}
         @listed_taxa = @listed_taxa_alphabetical if @order == ListedTaxon::ALPHABETICAL_ORDER
         @taxon_ids_by_name = {}
-        ancestor_ids = @listed_taxa.map {|lt| lt.taxon_ancestor_ids.to_s.split('/')}.flatten.uniq
+        ancestor_ids = @listed_taxa.map {|lt| lt.taxon.ancestry.to_s.split('/')}.flatten.uniq
         @orders = Taxon.where(rank: "order", id: ancestor_ids).order(:ancestry)
         @families = Taxon.where(rank: "family", id: ancestor_ids).order(:ancestry)
       end

--- a/app/controllers/shared/lists_module.rb
+++ b/app/controllers/shared/lists_module.rb
@@ -650,7 +650,7 @@ private
       "listed_taxa.observations_count #{order}"
     else
       # TODO: somehow make the following not cause a filesort...
-      "taxon_ancestor_ids || '/' || listed_taxa.taxon_id"
+      "taxa.ancestry || '/' || listed_taxa.taxon_id"
     end
     find_options
   end

--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -148,11 +148,11 @@ class CheckList < List
     return true unless comprehensive?
     ancestry = [taxon.ancestry, taxon.id].compact.join('/')
     conditions = [
-      "place_id = ? AND list_id != ? AND (taxon_ancestor_ids = ? OR taxon_ancestor_ids LIKE ?)", 
+      "place_id = ? AND list_id != ? AND (taxa.ancestry = ? OR taxa.ancestry LIKE ?)",
       place_id, id, ancestry, "#{ancestry}/%"
     ]
     that = self
-    ListedTaxon.where(conditions).find_each do |lt|
+    ListedTaxon.joins(:taxon).where(conditions).find_each do |lt|
       next if that.listed_taxa.exists?(:taxon_id => lt.taxon_id)
       ListedTaxon.where(id: lt.id).update_all(occurrence_status_level: ListedTaxon::ABSENT)
     end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -157,8 +157,8 @@ class List < ActiveRecord::Base
     FileUtils.mkdir_p File.dirname(tmp_path), :mode => 0755
     
     scope = if is_a?(CheckList) && is_default?
-      ListedTaxon.where(place_id: place_id).
-        select("DISTINCT ON (taxon_ancestor_ids || '/' || listed_taxa.taxon_id) listed_taxa.id")
+      ListedTaxon.joins(:taxon).where(place_id: place_id).
+        select("DISTINCT ON (taxa.ancestry || '/' || listed_taxa.taxon_id) listed_taxa.id")
     else
       ListedTaxon.where(list_id: id)
     end

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -25,7 +25,6 @@ class ListedTaxon < ActiveRecord::Base
   belongs_to :source # if added b/c of a published source
   
   before_validation :nilify_blanks
-  before_validation :set_ancestor_taxon_ids
   before_validation :update_cache_columns
   before_create :set_place_id
   before_create :set_updater_id
@@ -60,7 +59,10 @@ class ListedTaxon < ActiveRecord::Base
     end
   }
   
-  scope :filter_by_taxon, lambda {|filter_taxon_id, self_and_ancestor_ids| where("listed_taxa.taxon_id = ? OR listed_taxa.taxon_ancestor_ids = ? OR listed_taxa.taxon_ancestor_ids LIKE ?", filter_taxon_id, self_and_ancestor_ids, "#{self_and_ancestor_ids}/%")}
+  scope :filter_by_taxon, lambda { |filter_taxon_id, self_and_ancestor_ids|
+    joins(:taxon).where("listed_taxa.taxon_id = ? OR taxa.ancestry = ? OR taxa.ancestry LIKE ?",
+      filter_taxon_id, self_and_ancestor_ids, "#{self_and_ancestor_ids}/%")
+  }
   scope :filter_by_taxa, lambda {|search_taxon_ids| where("listed_taxa.taxon_id IN (?)", search_taxon_ids)}
   scope :find_listed_taxa_from_default_list, lambda{|place_id| where("listed_taxa.place_id = ? AND primary_listing = ?", place_id, true)}
   scope :filter_by_list, lambda {|list_id| where("list_id = ?", list_id)}
@@ -92,10 +94,11 @@ class ListedTaxon < ActiveRecord::Base
   scope :with_occurrence_status_levels_approximating_present, -> { where("occurrence_status_level NOT IN (10, 20) OR occurrence_status_level IS NULL") }
 
   scope :with_threatened_status, ->(place_id) {
+    joins(:taxon).
     joins("INNER JOIN conservation_statuses cs ON cs.taxon_id = listed_taxa.taxon_id").
     where("cs.iucn >= #{Taxon::IUCN_NEAR_THREATENED} AND (cs.place_id IS NULL OR cs.place_id::text IN (#{place_ancestor_ids_sql(place_id)}))").
-    select("DISTINCT ON (taxon_ancestor_ids || '/' || listed_taxa.taxon_id, listed_taxa.observations_count) listed_taxa.*").
-    order("taxon_ancestor_ids || '/' || listed_taxa.taxon_id, listed_taxa.observations_count")
+    select("DISTINCT ON (taxa.ancestry || '/' || listed_taxa.taxon_id, listed_taxa.observations_count) listed_taxa.*").
+    order("taxa.ancestry || '/' || listed_taxa.taxon_id, listed_taxa.observations_count")
   }
   scope :with_species, -> { joins(:taxon).where(taxa: { rank_level: 10 }) }
   
@@ -131,10 +134,9 @@ class ListedTaxon < ActiveRecord::Base
   # in a join table. Since those are *only* the ancestors, if you join the
   # original query on taxon_id and select those that do *not* have a matching
   # taxon in the ancestor join table, those are the leaves.
-  scope :with_leaves, lambda{|scope_to_sql| 
+  scope :with_leaves, lambda{|scope_to_sql|
     # generate the ancestor IDs subquery
-    ancestor_ids_sql = scope_to_sql.gsub(/^(S.*)\*/, "SELECT DISTINCT regexp_split_to_table(taxon_ancestor_ids, '/') AS ancestor_id")
-    ancestor_ids_sql + " AND taxon_ancestor_ids IS NOT NULL"
+    ancestor_ids_sql = scope_to_sql.gsub(/^(S.*)\*/, "SELECT DISTINCT regexp_split_to_table(t1.ancestry, '/') AS ancestor_id")
     # join ancestors on taxon_id
     join = <<-SQL
       LEFT JOIN (
@@ -217,7 +219,7 @@ class ListedTaxon < ActiveRecord::Base
                 :skip_index_taxon
   
   def ancestry
-    taxon_ancestor_ids
+    taxon.ancestry
   end
   
   def to_s
@@ -327,16 +329,6 @@ class ListedTaxon < ActiveRecord::Base
     end
   end
   
-  def set_ancestor_taxon_ids
-    return true unless taxon
-    unless taxon.ancestry.blank?
-      self.taxon_ancestor_ids = taxon.ancestry
-    else
-      self.taxon_ancestor_ids = '' # this should probably be in the db...
-    end
-    true
-  end
-
   def set_old_list
     @old_list = self.list
   end
@@ -700,21 +692,9 @@ class ListedTaxon < ActiveRecord::Base
   def taxon_common_name
     taxon.common_name.try(:name)
   end
-  
+
   def user_login
     user.try(:login)
-  end
-  
-  # Update the taxon_ancestors of ALL listed_taxa. Note this will be
-  # slow and memory intensive, so it should only be run from a script.
-  def self.update_all_taxon_attributes
-    start_time = Time.now
-    Rails.logger.info "[INFO] Starting ListedTaxon.update_all_taxon_attributes..."
-    Taxon.where("listed_taxa_count IS NOT NULL").find_each do |taxon|
-      taxon.update_listed_taxa
-    end
-    Rails.logger.info "[INFO] Finished ListedTaxon.update_all_taxon_attributes " +
-      "(#{Time.now - start_time}s)"
   end
 
   def expire_caches

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -60,7 +60,9 @@ class ListedTaxon < ActiveRecord::Base
   }
   
   scope :filter_by_taxon, lambda { |filter_taxon_id, self_and_ancestor_ids|
-    joins(:taxon).where("listed_taxa.taxon_id = ? OR taxa.ancestry = ? OR taxa.ancestry LIKE ?",
+    # explicit join so Arel doesn't alias the taxa table, breaking the where clause
+    joins("INNER JOIN taxa ON (listed_taxa.taxon_id=taxa.id)").
+      where("listed_taxa.taxon_id = ? OR taxa.ancestry = ? OR taxa.ancestry LIKE ?",
       filter_taxon_id, self_and_ancestor_ids, "#{self_and_ancestor_ids}/%")
   }
   scope :filter_by_taxa, lambda {|search_taxon_ids| where("listed_taxa.taxon_id IN (?)", search_taxon_ids)}

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -378,7 +378,6 @@ class Taxon < ActiveRecord::Base
     set_iconic_taxon
     return true if id_changed?
     return true if skip_after_move
-    update_listed_taxa
     update_life_lists
     update_obs_iconic_taxa
     conditions = ["taxa.id = ? OR taxa.ancestry = ? OR taxa.ancestry LIKE ?", id, "#{ancestry}/#{id}", "#{ancestry}/#{id}/%"]
@@ -782,41 +781,7 @@ class Taxon < ActiveRecord::Base
     return false if rank_level.blank?
     rank_level < SPECIES_LEVEL
   end
-  
-  # Updated the "cached" ancestor values in all listed taxa with this taxon
-  def update_listed_taxa
-    return true if ancestry.blank?
-    return true if ancestry_callbacks_disabled?
-    return true unless ancestry_changed?
-    Taxon.delay(:priority => INTEGRITY_PRIORITY, :queue => "slow").update_listed_taxa_for(id, ancestry_was)
-    true
-  end
-  
-  def self.update_listed_taxa_for(taxon, ancestry_was)
-    taxon = Taxon.find_by_id(taxon) unless taxon.is_a?(Taxon)
-    return true unless taxon
-    ListedTaxon.where(taxon_id: taxon.id).update_all(taxon_ancestor_ids: taxon.ancestry)
-    old_ancestry = ancestry_was
-    old_ancestry = old_ancestry.blank? ? taxon.id : "#{old_ancestry}/#{taxon.id}"
-    new_ancestry = taxon.ancestry
-    new_ancestry = new_ancestry.blank? ? taxon.id : "#{new_ancestry}/#{taxon.id}"
-    if !ListedTaxon.where("taxon_ancestor_ids = ?", old_ancestry.to_s).exists? &&
-       !ListedTaxon.where("taxon_ancestor_ids LIKE ?", "#{old_ancestry}/%").exists?
-      return
-    end
-    max = ListedTaxon.calculate(:maximum, :id)
-    offset = 0
-    batch_size = 10000
-    scope = ListedTaxon.where("taxon_ancestor_ids = ? OR taxon_ancestor_ids LIKE ?", old_ancestry.to_s, "#{old_ancestry}/%")
-    ( ( max - offset ) / batch_size ).times do |i|
-      start = offset + i * batch_size
-      stop  = offset + i * batch_size + batch_size - 1
-      scope.where( "id BETWEEN ? AND ?", start, stop ).
-        update_all("taxon_ancestor_ids = regexp_replace(taxon_ancestor_ids, '^#{old_ancestry}', '#{new_ancestry}')")
-      sleep 1
-    end
-  end
-  
+
   def update_life_lists(options = {})
     ids = options[:skip_ancestors] ? [id] : [id, ancestor_ids].flatten.compact
     if ListRule.exists?([
@@ -953,7 +918,6 @@ class Taxon < ActiveRecord::Base
     end
     
     LifeList.delay(:priority => INTEGRITY_PRIORITY).update_life_lists_for_taxon(self)
-    Taxon.delay(:priority => INTEGRITY_PRIORITY, :queue => "slow").update_listed_taxa_for(self, reject.ancestry)
     
     %w(flags).each do |association|
       send(association, :reload => true).each do |associate|

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -312,7 +312,8 @@
                 <%= t("occurrence_status_levels.absent").downcase %>
               <% end -%>
               <%= label :occurrence_status, :any do %>
-                <%= radio_button_tag :occurrence_status, :any, @occurrence_status == 'any' %>
+                <%= radio_button_tag :occurrence_status, :any,
+                      !@occurrence_status || @occurrence_status == 'any' %>
                 <%= t(:any).downcase %>
               <% end -%>
             </div>

--- a/tools/listed_taxa_from_csv.rb
+++ b/tools/listed_taxa_from_csv.rb
@@ -97,16 +97,6 @@ puts "Copied #{count} lines into #{new_path}, leftovers in #{leftovers_fname}"
 
 puts
 run_sql "COPY listed_taxa (list_id, taxon_id, place_id, taxon_range_id, establishment_means) FROM STDIN WITH CSV", new_path
-stamp = Time.now.strftime('%Y-%m-%d %H:%M:%S')
-run_sql <<-SQL
-  UPDATE listed_taxa 
-  SET 
-    taxon_ancestor_ids = taxa.ancestry,
-    created_at = '#{stamp}', 
-    updated_at = '#{stamp}'
-  FROM taxa 
-  WHERE listed_taxa.created_at IS NULL AND taxa.id = listed_taxa.taxon_id
-SQL
 
 puts
 puts "UPDATING EXISTING..."

--- a/tools/rebuild_tree.sh
+++ b/tools/rebuild_tree.sh
@@ -11,4 +11,3 @@ ruby script/runner "Taxon.find_duplicates"
 ruby script/runner "Taxon.find_duplicates"
 
 ruby script/runner 'Taxon.rebuild_without_callbacks'
-ruby script/runner 'ListedTaxon.update_all_taxon_attributes'


### PR DESCRIPTION
Relying on joining with taxa and using taxa.ancestry. There are 470k taxa and 8.1M listed_taxa so we're using a little extra space by duplicating ancestry in LT. But the wort part is all the delayed jobs we create to update LT.taxon_ancestor_ids when taxa change. This will get rid of all of those jobs.

This will not yet remove LT.taxon_ancestor_ids since that would take a while to compute again if there were a problem. We can create a migration to remove that column if this deploy works well for a while