### PR TITLE
Purging photos

### DIFF
--- a/app/models/deleted_photo.rb
+++ b/app/models/deleted_photo.rb
@@ -1,4 +1,5 @@
 class DeletedPhoto < ActiveRecord::Base
   belongs_to :user
   belongs_to :photo
+  scope :still_in_s3, ->{ where(removed_from_s3: false) }
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -8,7 +8,7 @@ class Photo < ActiveRecord::Base
   has_many :observations, :through => :observation_photos
   has_many :taxa, :through => :taxon_photos
   
-  attr_accessor :api_response
+  attr_accessor :api_response, :orphan
   serialize :metadata
 
   include Shared::LicenseModule
@@ -298,10 +298,10 @@ class Photo < ActiveRecord::Base
 
   def create_deleted_photo
     DeletedPhoto.create(
-      :photo_id => id,
-      :user_id => user_id
+      photo_id: id,
+      user_id: user_id,
+      orphan: orphan || false
     )
-    true
   end
 
 end

--- a/db/migrate/20160913224325_add_fields_to_deleted_photos.rb
+++ b/db/migrate/20160913224325_add_fields_to_deleted_photos.rb
@@ -1,0 +1,6 @@
+class AddFieldsToDeletedPhotos < ActiveRecord::Migration
+  def change
+    add_column :deleted_photos, :removed_from_s3, :boolean, default: false, null: false
+    add_column :deleted_photos, :orphan, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -758,7 +758,9 @@ CREATE TABLE deleted_photos (
     user_id integer,
     photo_id integer,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    removed_from_s3 boolean DEFAULT false NOT NULL,
+    orphan boolean DEFAULT false NOT NULL
 );
 
 
@@ -8140,3 +8142,4 @@ INSERT INTO schema_migrations (version) VALUES ('20160809221754');
 
 INSERT INTO schema_migrations (version) VALUES ('20160818234437');
 
+INSERT INTO schema_migrations (version) VALUES ('20160913224325');


### PR DESCRIPTION
- Adds 2 columns to deleted_photos: `removed_from_s3` and `orphan`
- Adds a rake task to delete orphaned photos, creating DeletedPhotos with `orphan=true`
- Updates `delete_expired_photos` to delete orphans from s3 after just 1 month, and also sets `removed_from_s3` on DeletedPhotos purged from S3