### PR TITLE
Do not suggest a login beginning with a number (#1139)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,7 +162,7 @@ class User < ActiveRecord::Base
   # Regexes from restful_authentication
   LOGIN_PATTERN     = "[A-z][\\\w\\\-_]+"
   login_regex       = /\A#{ LOGIN_PATTERN }\z/                          # ASCII, strict
-  bad_login_message = "use only letters, numbers, and -_ please.".freeze
+  bad_login_message = "begin with a letter and use only letters, numbers, and -_ please.".freeze
   email_name_regex  = '[\w\.%\+\-]+'.freeze
   domain_head_regex = '(?:[A-Z0-9\-]+\.)+'.freeze
   domain_tld_regex  = '(?:[A-Z]+)'.freeze
@@ -561,7 +561,7 @@ class User < ActiveRecord::Base
     requested_login = requested_login.to_s
     requested_login = "naturalist" if requested_login.blank?
     # strip out everything but letters and numbers so we can pass the login format regex validation
-    requested_login = requested_login.downcase.split('').select do |l| 
+    requested_login = requested_login.sub(/^\d*/, '').downcase.split('').select do |l| 
       ('a'..'z').member?(l) || ('0'..'9').member?(l)
     end.join('')
     suggested_login = requested_login

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -623,6 +623,13 @@ describe User do
       expect(suggestion).not_to be_blank
       expect(suggestion.size).to be <= User::MAX_LOGIN_SIZE
     end
+    
+    it "should not suggest logins that begin with a number" do
+      suggestion = User.suggest_login("2bornot2b")
+      expect(suggestion).not_to be_blank
+      expect(suggestion).not_to start_with '2'
+    end
+    
   end
 
   describe "community taxa preference" do


### PR DESCRIPTION
I've clarified the error message when signing up with an invalid login name, and prevent suggesting a login beginning with a number for new OAuth accounts to address #1139.

I've used this to get familiar with the code, happy to know if I'm in need of more schoolin'.