### PR TITLE
Position new taxon names after existing ones (#1125)

### DIFF
--- a/app/assets/javascripts/taxon_names/taxon.js
+++ b/app/assets/javascripts/taxon_names/taxon.js
@@ -1,7 +1,7 @@
 function updatePositions(container, sortable) {
   $selection = $(sortable+':visible', container)
   $selection.each(function() {
-    $('input[name*="position"]', this).val($selection.index(this) + 1)
+    $('input[name*="position"]', this).val($selection.index(this))
     $('input[name*="position"]', this).parents('form:first').submit()
   })
 }

--- a/app/models/taxon_name.rb
+++ b/app/models/taxon_name.rb
@@ -27,6 +27,7 @@ class TaxonName < ActiveRecord::Base
   before_validation do |tn|
     tn.name = tn.name.capitalize if tn.lexicon == LEXICONS[:SCIENTIFIC_NAMES]
   end
+  before_create {|name| name.position = name.taxon.taxon_names.size}
   before_save :set_is_valid
   after_create {|name| name.taxon.set_scientific_taxon_name}
   after_save :update_unique_names

--- a/app/views/taxon_names/taxon.html.haml
+++ b/app/views/taxon_names/taxon.html.haml
@@ -16,7 +16,7 @@
       - @taxon_names.each_with_index do |tn,i|
         %li
           = form_for tn, :remote => true, :html => {:class => "inline unstacked", "data-type" => "json"} do |f|
-            = f.text_field :position, :class => "sortable-position"
+            = f.text_field :position, :class => "sortable-position", :value => i
           %span{:class => "taxon_name #{tn.lexicon.split.join('_')}#{' invalid' unless tn.is_valid?}"}
             = tn.name
           %span.meta

--- a/spec/models/taxon_name_spec.rb
+++ b/spec/models/taxon_name_spec.rb
@@ -84,6 +84,16 @@ describe TaxonName, 'creation' do
     tn = TaxonName.make!(:lexicon => TaxonName::LEXICONS[:ENGLISH], :is_valid => false)
     expect(tn.is_valid).to be false
   end
+    
+  it "should create new name positions that will place them at the end of lists" do
+    t = Taxon.make!
+    tn1 = TaxonName.make!(name: "first", taxon: t)
+    expect(tn1.position).to eq 1
+    tn2 = TaxonName.make!(name: "second", taxon: t)
+    expect(tn2.position).to eq 2
+    tn2 = TaxonName.make!(name: "third", taxon: t)
+    expect(tn2.position).to eq 3
+  end
 end
 
 describe TaxonName, "strip_author" do


### PR DESCRIPTION
I experimented with a nil default for taxon name position, but hit sorting comparison errors.

In this alternative, new taxon names get created with position equal to the number of names for the taxon (not including itself). This can create gaps, but sorts correctly, and the current situation can create gaps already. There also seem to be fallback orderings by ID in place that handle duplicate positions.

When the "Manage names" ordering interface is loaded, name positions are reset to be consecutive starting at zero for the default as the original poster suggested. 