### PR TITLE
User icons s3 cleanup

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1796,9 +1796,7 @@ class ObservationsController < ApplicationController
       @user_ids = @user_counts.map{ |c| c["user_id"] } |
         @user_taxon_counts.map{ |c| c["user_id"] }
       @users = User.where(id: @user_ids).
-        select("id, login, name, moved_to_s3,
-          local_icon_file_name, local_icon_updated_at, local_icon_content_type,
-          s3_icon_file_name, s3_icon_updated_at, s3_icon_content_type")
+        select("id, login, name, icon_file_name, icon_updated_at, icon_content_type")
       @users_by_id = @users.index_by(&:id)
     else
       @user_counts = [ ]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -540,8 +540,7 @@ class UsersController < ApplicationController
     
     # Nix the icon_url if an icon file was provided
     @display_user.icon_url = nil if params[:user].try(:[], :icon)
-    @display_user.local_icon = nil if params[:icon_delete]
-    @display_user.s3_icon = nil if params[:icon_delete]
+    @display_user.icon = nil if params[:icon_delete]
     
     locale_was = @display_user.locale
     preferred_project_addition_by_was = @display_user.preferred_project_addition_by
@@ -785,13 +784,10 @@ protected
 
   def whitelist_params
     return if params[:user].blank?
-    if !params[:icon].blank? && params[:s3_icon].blank?
-      params[:s3_icon] = params[:icon]
-    end
     params.require(:user).permit(
       :description,
       :email,
-      :s3_icon,
+      :icon,
       :icon_url,
       :lists_by_login_order,
       :lists_by_login_sort,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,40 +119,29 @@ class User < ActiveRecord::Base
     processors: [:deanimator],
     styles: {
       original: "2048x2048>",
+      large: "500x500>",
       medium: "300x300>",
       thumb: "48x48#",
       mini: "16x16#"
     }
   }
-  s3_file_options = file_options.marshal_copy
-  s3_file_options[:styles][:large] = "500x500>"
 
   if Rails.env.production?
-    has_attached_file :s3_icon, s3_file_options.merge(
+    has_attached_file :icon, file_options.merge(
       storage: :s3,
       s3_credentials: "#{Rails.root}/config/s3.yml",
       s3_host_alias: CONFIG.s3_bucket,
       bucket: CONFIG.s3_bucket,
-      path: "/attachments/users/icons/:id/:style.:s3_icon_type_extension",
+      path: "/attachments/users/icons/:id/:style.:icon_type_extension",
       default_url: ":root_url/attachment_defaults/users/icons/defaults/:style.png",
       url: ":s3_alias_url"
     )
   else
-    has_attached_file :s3_icon, s3_file_options.merge(
-      path: ":rails_root/public/attachments/:class/:attachment/:id-:style.:s3_icon_type_extension",
-      url: "#{ CONFIG.attachments_host }/attachments/:class/:attachment/:id-:style.:s3_icon_type_extension",
+    has_attached_file :icon, file_options.merge(
+      path: ":rails_root/public/attachments/:class/:attachment/:id-:style.:icon_type_extension",
+      url: "#{ CONFIG.attachments_host }/attachments/:class/:attachment/:id-:style.:icon_type_extension",
       default_url: "/attachment_defaults/:class/:attachment/defaults/:style.png"
     )
-  end
-
-  has_attached_file :local_icon, file_options.merge(
-    path: ":rails_root/public/attachments/:class/icons/:id-:style.:local_icon_type_extension",
-    url: "#{ CONFIG.attachments_host }/attachments/:class/icons/:id-:style.:local_icon_type_extension",
-    default_url: "/attachment_defaults/:class/icons/defaults/:style.png"
-  )
-
-  def icon
-    moved_to_s3 ? s3_icon : local_icon
   end
 
   # Roles
@@ -178,16 +167,13 @@ class User < ActiveRecord::Base
   after_save :update_sound_licenses
   after_save :update_observation_sites_later
   after_save :destroy_messages_by_suspended_user
-  after_save :set_moved_to_s3
   after_update :set_community_taxa_if_pref_changed
   after_create :create_default_life_list
   after_create :set_uri
   after_destroy :create_deleted_user
   
   validates_presence_of :icon_url, :if => :icon_url_provided?, :message => 'is invalid or inaccessible'
-  validates_attachment_content_type :local_icon, :content_type => [/jpe?g/i, /png/i, /gif/i],
-    :message => "must be JPG, PNG, or GIF"
-  validates_attachment_content_type :s3_icon, :content_type => [/jpe?g/i, /png/i, /gif/i],
+  validates_attachment_content_type :icon, :content_type => [/jpe?g/i, /png/i, /gif/i],
     :message => "must be JPG, PNG, or GIF"
 
   validates_presence_of     :login
@@ -431,12 +417,6 @@ class User < ActiveRecord::Base
   def update_observation_sites
     observations.update_all(site_id: site_id)
     Observation.elastic_index!(scope: Observation.by(self))
-  end
-
-  def set_moved_to_s3
-    if !moved_to_s3 && s3_icon.file?
-      update_column(:moved_to_s3, true)
-    end
   end
 
   def merge(reject)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -35,7 +35,7 @@
       <%= image_and_content image_tag( @user.icon.url(:thumb), class: "usericon" ) do %>
         <%= link_to_toggle t(:change_icon), "#iconfield" %>
         <div id="iconfield" style="display: none">
-          <%= f.file_field :s3_icon, label: false, accept: "image/jpg,image/jpeg,image/png,image/gif" %>
+          <%= f.file_field :icon, label: false, accept: "image/jpg,image/jpeg,image/png,image/gif" %>
           <div>
             <%= check_box_tag :icon_delete %>
             <label for="icon_delete"><%=t :delete_icon? %></label>

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -11,24 +11,16 @@ module Paperclip
   end
 end
 
-Paperclip.interpolates("local_icon_type_extension") do |attachment, style|
-  ext = attachment.instance.local_icon_file_name.split(".").last.downcase
+Paperclip.interpolates("icon_type_extension") do |attachment, style|
+  ext = attachment.instance.icon_file_name.split(".").last.downcase
   unless %w(jpg jpeg png gif).include?(ext)
-    ext = attachment.instance.local_icon_content_type.split("/").last
-  end
-  ext
-end
-
-Paperclip.interpolates("s3_icon_type_extension") do |attachment, style|
-  ext = attachment.instance.s3_icon_file_name.split(".").last.downcase
-  unless %w(jpg jpeg png gif).include?(ext)
-    ext = attachment.instance.s3_icon_content_type.split("/").last
+    ext = attachment.instance.icon_content_type.split("/").last
   end
   ext
 end
 
 Paperclip.interpolates("root_url") do |attachment, style|
-  FakeView.root_url
+  FakeView.root_url.chomp("/")
 end
 
 Paperclip::UploadedFileAdapter.content_type_detector = Paperclip::FileCommandContentTypeDetector

--- a/db/migrate/20160929155608_restore_user_icon.rb
+++ b/db/migrate/20160929155608_restore_user_icon.rb
@@ -1,0 +1,27 @@
+class RestoreUserIcon < ActiveRecord::Migration
+  def up
+    rename_column :users, :s3_icon_file_name, :icon_file_name
+    rename_column :users, :s3_icon_content_type, :icon_content_type
+    rename_column :users, :s3_icon_file_size, :icon_file_size
+    rename_column :users, :s3_icon_updated_at, :icon_updated_at
+
+    remove_column :users, :local_icon_file_name
+    remove_column :users, :local_icon_content_type
+    remove_column :users, :local_icon_file_size
+    remove_column :users, :local_icon_updated_at
+    remove_column :users, :moved_to_s3
+  end
+
+  def down
+    rename_column :users, :icon_file_name, :s3_icon_file_name
+    rename_column :users, :icon_content_type, :s3_icon_content_type
+    rename_column :users, :icon_file_size, :s3_icon_file_size
+    rename_column :users, :icon_updated_at, :s3_icon_updated_at
+
+    add_column :users, :local_icon_file_name, :string
+    add_column :users, :local_icon_content_type, :string
+    add_column :users, :local_icon_file_size, :integer
+    add_column :users, :local_icon_updated_at, :datetime
+    add_column :users, :moved_to_s3, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3999,9 +3999,6 @@ CREATE TABLE users (
     deleted_at timestamp without time zone,
     time_zone character varying(255),
     description text,
-    local_icon_file_name character varying(255),
-    local_icon_content_type character varying(255),
-    local_icon_file_size integer,
     life_list_id integer,
     observations_count integer DEFAULT 0,
     identifications_count integer DEFAULT 0,
@@ -4016,7 +4013,6 @@ CREATE TABLE users (
     remember_created_at timestamp without time zone,
     suspended_at timestamp without time zone,
     suspension_reason character varying(255),
-    local_icon_updated_at timestamp without time zone,
     uri character varying(255),
     locale character varying(255),
     site_id integer,
@@ -4029,11 +4025,10 @@ CREATE TABLE users (
     longitude double precision,
     test_groups character varying,
     lat_lon_acc_admin_level integer,
-    s3_icon_file_name character varying,
-    s3_icon_content_type character varying,
-    s3_icon_file_size integer,
-    s3_icon_updated_at timestamp without time zone,
-    moved_to_s3 boolean DEFAULT false
+    icon_file_name character varying,
+    icon_content_type character varying,
+    icon_file_size integer,
+    icon_updated_at timestamp without time zone
 );
 
 
@@ -8146,4 +8141,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160809221754');
 INSERT INTO schema_migrations (version) VALUES ('20160818234437');
 
 INSERT INTO schema_migrations (version) VALUES ('20160920151846');
+
+INSERT INTO schema_migrations (version) VALUES ('20160929155608');
 

--- a/spec/controllers/observation_controller_api_spec.rb
+++ b/spec/controllers/observation_controller_api_spec.rb
@@ -209,7 +209,7 @@ shared_examples_for "an ObservationsController" do
     it "should include comment user icons" do
       o = Observation.make!
       c = Comment.make!(:parent => o)
-      c.user.update_attributes(:s3_icon => open(File.dirname(__FILE__) + '/../fixtures/files/egg.jpg'))
+      c.user.update_attributes(:icon => open(File.dirname(__FILE__) + '/../fixtures/files/egg.jpg'))
       get :show, :format => :json, :id => o.id
       response_obs = JSON.parse(response.body)
       expect(response_obs['comments'].first['user']['user_icon_url']).not_to be_blank
@@ -226,7 +226,7 @@ shared_examples_for "an ObservationsController" do
     it "should include identification user icons" do
       o = Observation.make!
       i = Identification.make!(:observation => o)
-      i.user.update_attributes(:s3_icon => open(File.dirname(__FILE__) + '/../fixtures/files/egg.jpg'))
+      i.user.update_attributes(:icon => open(File.dirname(__FILE__) + '/../fixtures/files/egg.jpg'))
       get :show, :format => :json, :id => o.id
       response_obs = JSON.parse(response.body)
       expect(response_obs['identifications'].first['user']['user_icon_url']).not_to be_blank

--- a/spec/controllers/users_controller_api_spec.rb
+++ b/spec/controllers/users_controller_api_spec.rb
@@ -18,24 +18,24 @@ shared_examples_for "a signed in UsersController" do
 
   describe "update" do
     it "should remove the user icon with icon_delete param" do
-      user.s3_icon = File.open( File.join( Rails.root, "spec", "fixtures", "files", "cuthona_abronia-tagged.jpg" ) )
+      user.icon = File.open( File.join( Rails.root, "spec", "fixtures", "files", "cuthona_abronia-tagged.jpg" ) )
       user.save!
-      expect( user.s3_icon_file_name ).not_to be_blank
+      expect( user.icon_file_name ).not_to be_blank
       put :update, id: user.id, format: :json, icon_delete: true
       expect( response ).to be_success
       user.reload
-      expect( user.s3_icon_file_name ).to be_blank
+      expect( user.icon_file_name ).to be_blank
     end
     it "should not remove the user icon with no user[icon] param" do
-      user.s3_icon = File.open( File.join( Rails.root, "spec", "fixtures", "files", "cuthona_abronia-tagged.jpg" ) )
+      user.icon = File.open( File.join( Rails.root, "spec", "fixtures", "files", "cuthona_abronia-tagged.jpg" ) )
       user.save!
-      expect( user.s3_icon_file_name ).not_to be_blank
+      expect( user.icon_file_name ).not_to be_blank
       new_desc = "show me the tarweeds"
       put :update, id: user.id, format: :json, user: { description: new_desc }
       expect( response ).to be_success
       user.reload
       expect( user.description ).to eq new_desc
-      expect( user.s3_icon_file_name ).not_to be_blank
+      expect( user.icon_file_name ).not_to be_blank
     end
   end
 


### PR DESCRIPTION
Transition from the temporary state where we have both a `local_icon` and `s3_icon`, back to a stable state with a single `icon` which lives in S3