### PR TITLE
Provide a default per page value for external taxon searches (#1067)

### DIFF
--- a/app/assets/javascripts/jquery/plugins/inat/taxon_autocomplete.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxon_autocomplete.js.erb
@@ -166,7 +166,7 @@ $.fn.taxonAutocomplete = function( options ) {
       var thisSearch = Math.random();
       ac.searchInProgress = thisSearch;
       $.ajax({
-        url: "/taxa/search.json?per_page="+ options.perPage +
+        url: "/taxa/search.json?per_page="+ (options.perPage || 10) +
           "&include_external=1&partial=elastic&q=" + field.val( ),
         dataType: "json",
         beforeSend: function(XMLHttpRequest) {

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -402,6 +402,7 @@ class TaxaController < ApplicationController
 
     page = params[:page] ? params[:page].to_i : 1
     user_per_page = params[:per_page] ? params[:per_page].to_i : 24
+    user_per_page = 24 if user_per_page == 0
     user_per_page = 100 if user_per_page > 100
     per_page = page == 1 && user_per_page < 50 ? 50 : user_per_page
 

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -502,12 +502,13 @@ class TaxaController < ApplicationController
           @all_colors = Color.all
         end
         
-        if params[:partial]
-          partial_path = if params[:partial] == "taxon"
-            "shared/#{params[:partial]}.html.erb"
-          else
-            "taxa/#{params[:partial]}.html.erb"
-          end
+        partial_path = if params[:partial] == "taxon" 
+          "shared/#{params[:partial]}.html.erb"
+        elsif params[:partial] 
+          "taxa/#{params[:partial]}.html.erb"
+        end       
+        
+        if partial_path && lookup_context.find_all(partial_path).any?
           render :partial => partial_path, :locals => {
             :js_link => params[:js_link]
           }

--- a/spec/controllers/taxa_controller_spec.rb
+++ b/spec/controllers/taxa_controller_spec.rb
@@ -201,6 +201,22 @@ describe TaxaController do
       expect(assigns(:taxa)).to include t
     end
   end
+  
+  describe "search" do
+    before(:each) { enable_elastic_indexing([ Taxon ]) }
+    after(:each) { disable_elastic_indexing([ Taxon ]) }
+    render_views
+    it "should find a taxon by name" do
+      t = Taxon.make!
+      get :search, q: t.name
+      expect(response.body).to be =~ /<span class="sciname">.*?#{t.name}.*?<\/span>/m
+    end
+    it "should not raise an exception with an invalid per page value" do
+      t = Taxon.make!
+      get :search, q: t.name, per_page: 'foo'
+      expect(response).to be_success
+    end
+  end
 
   describe "observation_photos" do
     it "should include photos from observations" do


### PR DESCRIPTION
It looks like at least part of the problem in #1067 is that there is no default for options.perPage on external searches. This is generating a querystring with per_page=undefined, and that never shows results. This PR adds a default value of 10 like the internal request.