### PR TITLE
stop updating project lists with taxa from project observations

### DIFF
--- a/app/controllers/shared/lists_module.rb
+++ b/app/controllers/shared/lists_module.rb
@@ -16,7 +16,7 @@ module Shared::ListsModule
   def show
     @find_options = set_find_options
     @view = params[:view] || params[:view_type]
-    @observable_list = observable_list(@list)
+    @observable_list = @list
     @q = params[:q] unless params[:q].blank?
     @search_taxon_ids = set_search_taxon_ids(@q)
     unless @search_taxon_ids.blank?
@@ -32,43 +32,6 @@ module Shared::ListsModule
     if default_checklist?(@list) 
       listed_taxa = handle_default_checklist_setup(@list, @q, @search_taxon_ids) 
       main_list = set_scopes(@list, @filter_taxon, listed_taxa)
-    elsif place_based_project_list?(@list) && !with_observations?
-      taxon_for_rule_filter = Taxon.find(@list.project.project_observation_rules.find{|por| por.operator == "in_taxon?"}.operand_id) rescue nil
-      acceptable_taxa_from_list = taxon_for_rule_filter ? (taxon_for_rule_filter.descendant_ids + [taxon_for_rule_filter.id]) : nil
-
-      @ignore_observed_filter_for_place = true if params[:observed] == 'f'
-      listed_taxa_with_duplicates = set_scopes_for_place_based_project_list(@list, @q, @filter_taxon, @search_taxon_ids, acceptable_taxa_from_list) 
-
-      query = listed_taxa_with_duplicates.select([:id, :taxon_id, :place_id, :last_observation_id])
-      results = ActiveRecord::Base.connection.select_all(query)
-
-      if params[:observed] == 'f'
-        listed_taxa_hash = results.inject({}) do |aggregator, listed_taxon|
-          aggregator["#{listed_taxon['taxon_id']}"] = listed_taxon['id'] if (!already_in_list_and_observed_and_not_place_based(results, listed_taxon) && not_yet_in_list_and_unobserved(aggregator, listed_taxon) || !already_in_list_and_not_place_based(results, listed_taxon)) 
-          aggregator
-        end
-        @total_observed_taxa = 0
-      else
-        listed_taxa_hash = results.inject({}) do |aggregator, listed_taxon|
-          aggregator["#{listed_taxon['taxon_id']}"] = listed_taxon['id'] if (aggregator["#{listed_taxon['taxon_id']}"].nil? || listed_taxon['place_id'].nil?)
-          aggregator
-        end
-      end
-      listed_taxa_ids = listed_taxa_hash.values.map(&:to_i)
-
-
-      listed_taxa = listed_taxa_with_duplicates.where("listed_taxa.id IN (?)", listed_taxa_ids)
-
-
-      main_list = set_scopes(@list, @filter_taxon, listed_taxa)
-
-      @listed_taxa = main_list.where(@find_options[:conditions]).
-        paginate(page: @find_options[:page], per_page: @find_options[:per_page]).
-        order(@find_options[:order])
-
-      @total_listed_taxa =  main_list.count
-      @total_observed_taxa ||= main_list.confirmed_and_not_place_based.count
-      @iconic_taxon_counts = get_iconic_taxon_counts_for_place_based_project(@list, @iconic_taxa, @listed_taxa)
     else
       main_list = set_scopes(@list, @filter_taxon, @list.listed_taxa)
     end
@@ -429,29 +392,6 @@ private
   def get_other_check_lists(list, place)
     place.check_lists.where("id != ?", list.id).limit(500)
   end
-  
-  def set_scopes_for_place_based_project_list(list, q, filter_taxon, search_taxon_ids, acceptable_taxa_from_list)
-    unpaginated_listed_taxa = ListedTaxon.from_place_or_list(list.project.place_id, list.id)
-    unpaginated_listed_taxa = unpaginated_listed_taxa.with_occurrence_status_levels_approximating_present
-    if acceptable_taxa_from_list
-      unpaginated_listed_taxa = unpaginated_listed_taxa.acceptable_taxa(acceptable_taxa_from_list)
-    end
-    if q
-      unpaginated_listed_taxa = unpaginated_listed_taxa.filter_by_taxa(search_taxon_ids)
-    end
-    unpaginated_listed_taxa
-  end
-
-  def set_scopes_for_place_based_project_list_with_observed_from_place(list, q, filter_taxon, search_taxon_ids, acceptable_taxa_from_list)
-    unpaginated_listed_taxa = ListedTaxon.from_place_or_list_with_observed_from_place(list.project.place_id, list.id)
-    if acceptable_taxa_from_list
-      unpaginated_listed_taxa = unpaginated_listed_taxa.acceptable_taxa(acceptable_taxa_from_list)
-    end
-    if q
-      unpaginated_listed_taxa = unpaginated_listed_taxa.filter_by_taxa(search_taxon_ids)
-    end
-    unpaginated_listed_taxa
-  end
 
   def handle_default_checklist_setup(list, q, search_taxon_ids)
     unpaginated_listed_taxa = ListedTaxon.find_listed_taxa_from_default_list(list.place_id)
@@ -471,14 +411,6 @@ private
     return [ ] if listed_taxa.nil?
     iconic_taxa = Taxon::ICONIC_TAXA
     counts = ListedTaxon.from("(#{listed_taxa.to_sql}) AS listed_taxa").joins(:taxon).group("taxa.iconic_taxon_id").count
-    iconic_taxa.map do |iconic_taxon|
-      [iconic_taxon, counts[iconic_taxon.id] || 0]
-    end
-  end
-
-  def get_iconic_taxon_counts_for_place_based_project(list, iconic_taxa = nil, listed_taxa = nil)
-    iconic_taxa ||= Taxon::ICONIC_TAXA
-    counts = listed_taxa.joins(:taxon).group("taxa.iconic_taxon_id").count
     iconic_taxa.map do |iconic_taxon|
       [iconic_taxon, counts[iconic_taxon.id] || 0]
     end
@@ -715,24 +647,12 @@ private
     TaxonName.where("taxon_id IN (?)", taxon_ids).group_by(&:taxon_id)
   end
 
-  def observable_list(list)
-    (list.type == "ProjectList" && list.project.show_from_place) ? list.project.place.check_list : list
-  end
-
   def allow_batch_adding(list, current_user)
-    if(list.type == "ProjectList")
-      list.editable_by?(current_user) && !list.project.show_from_place
-    else
-      list.editable_by?(current_user)
-    end
+    list.editable_by?(current_user)
   end
 
   def place_based_list?(list)
-    list.type == "CheckList" || place_based_project_list?(list)
-  end
-
-  def place_based_project_list?(list)
-    list.type == "ProjectList" && list.project.show_from_place
+    list.type == "CheckList"
   end
 
   def default_checklist?(list)

--- a/app/models/life_list.rb
+++ b/app/models/life_list.rb
@@ -180,13 +180,8 @@ class LifeList < List
   def self.reload_from_observations(list)
     list = List.find_by_id(list) unless list.is_a?(List)
     return unless list
-    if list.is_a?(ProjectList)
-      ProjectList.repair_observed(list)
-      ProjectList.add_taxa_from_observations(list)
-    else
-      repair_observed(list)
-      add_taxa_from_observations(list)
-    end
+    repair_observed(list)
+    add_taxa_from_observations(list)
   end
   
   def self.repair_observed(list)

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -303,9 +303,7 @@ class List < ActiveRecord::Base
     listed_taxa = ListedTaxon.
       where("listed_taxa.taxon_id IN (?) AND listed_taxa.list_id IN (?)", taxon_ids, target_list_ids)
     if respond_to?(:create_new_listed_taxa_for_refresh)
-      unless self == ProjectList && observation && observation.quality_grade == 'casual' #only RG for projects
-        create_new_listed_taxa_for_refresh(taxon, listed_taxa, target_list_ids)
-      end
+      create_new_listed_taxa_for_refresh(taxon, listed_taxa, target_list_ids)
     end
     listed_taxa.each do |lt|
       Rails.logger.info "[INFO #{Time.now}] List.refresh_with_observation, refreshing #{lt}"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,7 +22,6 @@ class Project < ActiveRecord::Base
   has_many :assessments, :dependent => :destroy
   
   before_save :strip_title
-  before_save :unset_show_from_place_if_no_place
   before_save :reset_last_aggregated_at
   before_save :remove_times_from_non_bioblitzes
   after_create :create_the_project_list
@@ -191,11 +190,6 @@ class Project < ActiveRecord::Base
 
   def strip_title
     self.title = title.strip
-    true
-  end
-
-  def unset_show_from_place_if_no_place
-    self.show_from_place = false if place.blank? || place.check_list.blank?
     true
   end
 
@@ -548,26 +542,8 @@ class Project < ActiveRecord::Base
     end
   end
 
-  def get_observed_listed_taxa_count #numerator on project/show
-    if show_from_place?
-      if p.preferred_count_by == "species"
-      elsif p.preferred_count_by == "leaves"
-      else
-      end
-    else
-      if p.preferred_count_by == "species"
-      elsif p.preferred_count_by == "leaves"
-      else
-      end
-    end
-  end
-
   def list_observed_and_total #denominator and numerator on project/show
-    if show_from_place?
-      find_observed_and_total_for_project_from_place
-    else
-      find_observed_and_total_for_project_not_from_place
-    end
+    find_observed_and_total_for_project
   end
 
   def self.slugs_to_ids(slugs)
@@ -579,36 +555,8 @@ class Project < ActiveRecord::Base
       project_id
     end.compact
   end
-
-  def find_observed_and_total_for_project_from_place
-    list = project_list
-    observable_list = place.check_list
-
-    listed_taxa_with_duplicates = ListedTaxon.from_place_or_list(list.project.place_id, list.id)
-
-    query = listed_taxa_with_duplicates.select([:id, :taxon_id, :place_id, :last_observation_id])
-    results = ActiveRecord::Base.connection.select_all(query)
-
-    listed_taxa_hash = results.inject({}) do |aggregator, listed_taxon|
-      aggregator["#{listed_taxon['taxon_id']}"] = listed_taxon['id'] if (aggregator["#{listed_taxon['taxon_id']}"].nil? || listed_taxon['place_id'].nil?)
-      aggregator
-    end
-
-    listed_taxa_ids = listed_taxa_hash.values.map(&:to_i)
-    unpaginated_listed_taxa = listed_taxa_with_duplicates.where("listed_taxa.id IN (?)", listed_taxa_ids)
-
-    unpaginated_listed_taxa = unpaginated_listed_taxa.with_taxonomic_status(true)
-    unpaginated_listed_taxa = unpaginated_listed_taxa.with_occurrence_status_levels_approximating_present
-    if preferred_count_by == "species"
-      unpaginated_listed_taxa = unpaginated_listed_taxa.with_species
-    elsif preferred_count_by == "leaves"
-      unpaginated_listed_taxa = unpaginated_listed_taxa.with_leaves(unpaginated_listed_taxa.to_sql.sub("AND (taxa.rank_level = 10)", ""))
-    end
-    
-    {numerator: unpaginated_listed_taxa.confirmed_and_not_place_based.count, denominator: unpaginated_listed_taxa.count}
-  end
-
-  def find_observed_and_total_for_project_not_from_place
+  
+  def find_observed_and_total_for_project
     unpaginated_listed_taxa = ListedTaxon.filter_by_list(project_list.id)
     unpaginated_listed_taxa = unpaginated_listed_taxa.with_taxonomic_status(true)
     if preferred_count_by == "species"

--- a/app/models/project_list.rb
+++ b/app/models/project_list.rb
@@ -1,5 +1,6 @@
-class ProjectList < LifeList
+class ProjectList < List
   belongs_to :project
+  before_validation :set_defaults
   validates_presence_of :project_id
   
   def owner
@@ -58,76 +59,22 @@ class ProjectList < LifeList
     end
     target_list_id = ProjectList.where(:project_id => project.id).first.id
     # get listed taxa for this taxon and its ancestors that are on the project list
-    listed_taxa = ListedTaxon.where(taxon_id: taxon_ids, list_id: target_list_id).
-      includes(:list)
+    listed_taxa = ListedTaxon.where(taxon_id: taxon_ids, list_id: target_list_id).includes(:list)
     listed_taxa.each do |lt|
       Rails.logger.info "[INFO #{Time.now}] ProjectList.refresh_with_project_observation, refreshing #{lt}"
       refresh_listed_taxon(lt)
     end
-    Rails.logger.info "[INFO #{Time.now}] Finished ProjectList.refresh_with_project_observation for #{project_observation.id}"
-    
-    if taxon #if the observation has a curator_id
-      if respond_to?(:create_new_listed_taxa_for_refresh)
-        create_new_listed_taxa_for_refresh(taxon, listed_taxa, [target_list_id])
-      end
-    end
-    Rails.logger.info "[INFO #{Time.now}] refresh_with_project_observation #{project_observation.id}, finished"
-  end
+    Rails.logger.info "[INFO #{Time.now}] Finished ProjectList.refresh_with_project_observation for #{project_observation.id}"    
+  end 
   
   def self.refresh_with_observation_lists(observation, options = {})
     observation = Observation.find_by_id(observation) unless observation.is_a?(Observation)
     return [] unless observation.is_a?(Observation)
-    project_ids, curator_identification_ids = observation.project_observations.
-      map{|po| [po.project_id, po.curator_identification_id]}.transpose
+    project_ids = observation.project_observations.map{|po| po.project_id}
     return [] if project_ids.nil?
-    target_list_and_curator_ids = ProjectList.where(project_id: project_ids).select(:id).
-      map{ |pl| pl.id }.zip(curator_identification_ids)
-    #only update listed taxa if the project_observations have no curator_identification_ids
-    #otherwise update these listed_taxa when the curator_identification_id on the project_observation changes
-    target_list_and_curator_ids.map{|pair| pair[0] unless pair[1] }.compact
+    target_list = ProjectList.where(project_id: project_ids).select(:id)
   end
-  
-  #todo, make this support options[:taxa] filtering
-  def self.add_taxa_from_observations(list, options = {})
-    sql = <<-SQL
-      SELECT DISTINCT ON (taxon_id)
-        CASE WHEN po.curator_identification_id IS NOT NULL THEN i.taxon_id ELSE observations.taxon_id END AS taxon_id, 
-        observations.id
-      FROM 
-        observations
-          JOIN project_observations po ON po.observation_id = observations.id
-          LEFT OUTER JOIN identifications i ON i.id = po.curator_identification_id
-      WHERE
-        po.project_id = #{list.project_id}
-        AND (observations.quality_grade = 'research' OR po.curator_identification_id IS NOT NULL)
-    SQL
-    scope = Observation
-    scope = scope.of(list.rule_taxon) if list.rule_taxon
-    scope = scope.in_place(list.place) if list.place
-    results = scope.find_by_sql [sql]
-    results.each do |observation|
-      list.add_taxon(observation.taxon_id, :last_observation_id => observation.id) 
-    end
-  end
-  
-  def self.repair_observed(list)
-    conditions = "po.project_id = ? AND (" +
-      "(po.curator_identification_id IS NOT NULL AND i.taxon_id != listed_taxa.taxon_id) OR " +
-      "(po.curator_identification_id IS NULL AND (o.quality_grade != 'research' OR o.taxon_id != listed_taxa.taxon_id)) " +
-    ")"
-    scope = ListedTaxon.where("list_id = ?", list)
-    scope = scope.joins("LEFT OUTER JOIN observations o ON o.id = listed_taxa.last_observation_id").
-    joins("LEFT OUTER JOIN project_observations po ON po.observation_id = listed_taxa.last_observation_id").
-    joins("LEFT OUTER JOIN identifications i ON i.id = po.curator_identification_id").
-    select("listed_taxa.id, CASE WHEN po.curator_identification_id IS NOT NULL THEN i.taxon_id ELSE o.taxon_id END AS taxon_id").
-    where(conditions, list.project_id)
-    scope.each do |entry|
-      lt = ListedTaxon.find_by_id(entry.id)
-      taxon = Taxon.find_by_id(entry.taxon_id)
-      lt.destroy unless taxon.descendant_of?(lt.taxon)
-    end
-  end
-  
+    
   private
   def set_defaults
     self.title ||= I18n.t('project_list_defaults.title', owner_name: owner_name)

--- a/app/models/project_observation.rb
+++ b/app/models/project_observation.rb
@@ -192,7 +192,7 @@ class ProjectObservation < ActiveRecord::Base
     return true if observation.blank? || observation.taxon_id.blank? || observation.bulk_import
     Project.delay(priority: USER_INTEGRITY_PRIORITY, queue: "slow",
       run_at: 1.hour.from_now, unique_hash: { "Project::refresh_project_list": project_id }).
-      refresh_project_list(project_id, :taxa => [observation.taxon_id], :add_new_taxa => id_was.nil?)
+      refresh_project_list(project_id, :taxa => [observation.taxon_id])
     true
   end
   

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -197,6 +197,7 @@
 
     <% unless @list.listed_taxa.empty? -%>
       <div id="stats" class="clear">
+        <h3><%= link_to_toggle t(:stats), "#innerstats", :class => 'open' %></h3>
         <div id="innerstats"> 
           <a href="<%= url_for(params.merge(:page => 1, :taxon => nil, :iconic_taxon => nil)) %>" class="clear stat total<%= ' current' unless @filter_taxon %>">
             <div class="readable title">

--- a/db/migrate/20161110221032_remove_show_from_place_from_project.rb
+++ b/db/migrate/20161110221032_remove_show_from_place_from_project.rb
@@ -1,5 +1,5 @@
 class RemoveShowFromPlaceFromProject < ActiveRecord::Migration
   def change
-    remove_column :projects, :show_from_place
+    remove_column :projects, :show_from_place, :boolean
   end
 end

--- a/db/migrate/20161110221032_remove_show_from_place_from_project.rb
+++ b/db/migrate/20161110221032_remove_show_from_place_from_project.rb
@@ -1,0 +1,5 @@
+class RemoveShowFromPlaceFromProject < ActiveRecord::Migration
+  def change
+    remove_column :projects, :show_from_place
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6292,7 +6292,7 @@ CREATE INDEX index_listed_taxa_on_list_id_and_taxon_ancestor_ids_and_taxon_i ON 
 -- Name: index_listed_taxa_on_list_id_and_taxon_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_listed_taxa_on_list_id_and_taxon_id ON listed_taxa USING btree (list_id, taxon_id);
+CREATE INDEX index_listed_taxa_on_list_id_and_taxon_id ON listed_taxa USING btree (list_id, taxon_id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6292,7 +6292,7 @@ CREATE INDEX index_listed_taxa_on_list_id_and_taxon_ancestor_ids_and_taxon_i ON 
 -- Name: index_listed_taxa_on_list_id_and_taxon_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_listed_taxa_on_list_id_and_taxon_id ON listed_taxa USING btree (list_id, taxon_id);
+CREATE UNIQUE INDEX index_listed_taxa_on_list_id_and_taxon_id ON listed_taxa USING btree (list_id, taxon_id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -254,15 +254,6 @@ CREATE FUNCTION crc32(word text) RETURNS bigint
 
 
 --
--- Name: st_aslatlontext(geometry); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION st_aslatlontext(geometry) RETURNS text
-    LANGUAGE sql IMMUTABLE STRICT
-    AS $_$ SELECT ST_AsLatLonText($1, '') $_$;
-
-
---
 -- Name: median(anyelement); Type: AGGREGATE; Schema: public; Owner: -
 --
 
@@ -2972,7 +2963,6 @@ CREATE TABLE projects (
     end_time timestamp without time zone,
     trusted boolean DEFAULT false,
     "group" character varying(255),
-    show_from_place boolean,
     last_aggregated_at timestamp without time zone
 );
 
@@ -3147,7 +3137,7 @@ ALTER SEQUENCE rules_id_seq OWNED BY rules.id;
 --
 
 CREATE TABLE schema_migrations (
-    version character varying(255) NOT NULL
+    version character varying NOT NULL
 );
 
 
@@ -4121,9 +4111,9 @@ CREATE TABLE users (
     spam_count integer DEFAULT 0,
     last_active date,
     subscriptions_suspended_at timestamp without time zone,
-    test_groups character varying,
     latitude double precision,
     longitude double precision,
+    test_groups character varying,
     lat_lon_acc_admin_level integer,
     icon_file_name character varying,
     icon_content_type character varying,
@@ -6302,7 +6292,7 @@ CREATE INDEX index_listed_taxa_on_list_id_and_taxon_ancestor_ids_and_taxon_i ON 
 -- Name: index_listed_taxa_on_list_id_and_taxon_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_listed_taxa_on_list_id_and_taxon_id ON listed_taxa USING btree (list_id, taxon_id);
+CREATE UNIQUE INDEX index_listed_taxa_on_list_id_and_taxon_id ON listed_taxa USING btree (list_id, taxon_id);
 
 
 --
@@ -8347,4 +8337,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161012202803');
 INSERT INTO schema_migrations (version) VALUES ('20161012204604');
 
 INSERT INTO schema_migrations (version) VALUES ('20161020190217');
+
+INSERT INTO schema_migrations (version) VALUES ('20161110221032');
 


### PR DESCRIPTION
closes #1190 - I also pulled out project.show_from_place which hasn't been used in the UI since we stopped displaying project_lists by default but was still hanging around