### PR TITLE
Taxon page photo contain

### DIFF
--- a/app/assets/stylesheets/taxa/show2.css.scss
+++ b/app/assets/stylesheets/taxa/show2.css.scss
@@ -336,6 +336,21 @@ $photoPreviewThumbGutter: 1px;
 $photoPreviewThumbGutterTop: 3px;
 .PhotoPreview {
   position: relative;
+  overflow: hidden;
+  height: 590px;
+}
+.PhotoPreview .photo-bg {
+  position: absolute;
+  left: -50px;
+  top: -50px;
+  background-size: cover;
+  width: 120%;
+  height: 120%;
+  -webkit-filter: blur(50px);
+  -moz-filter: blur(50px);
+  -o-filter: blur(50px);
+  -ms-filter: blur(50px);
+  filter: blur(20px) brightness(0.5);
 }
 .PhotoPreview ul.others {
   width: 100%;

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -4,7 +4,9 @@ class TaxaController < ApplicationController
   caches_action :show, :expires_in => 1.day,
     :cache_path => Proc.new{ |c| { locale: I18n.locale, mobile: c.request.format.mobile? } },
     :if => Proc.new {|c|
-      !request.format.json? && (c.session.blank? || c.session['warden.user.user.key'].blank?)
+      !request.format.json? &&
+      (c.session.blank? || c.session['warden.user.user.key'].blank?) &&
+      c.params[:test].blank?
     }
   caches_action :describe, :expires_in => 1.day,
     :cache_path => Proc.new { |c| c.params.merge(locale: I18n.locale) },

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -33,7 +33,6 @@ class QualityMetric < ActiveRecord::Base
   def set_observation_quality_grade
     return true unless observation
     new_quality_grade = observation.get_quality_grade
-    Rails.logger.debug "[DEBUG] setting obs quality grade to #{new_quality_grade}"
     Observation.where(id: observation_id).update_all(quality_grade: new_quality_grade)
     CheckList.delay(priority: INTEGRITY_PRIORITY, queue: "slow",
       unique_hash: { "CheckList::refresh_with_observation": observation.id}).
@@ -60,8 +59,8 @@ class QualityMetric < ActiveRecord::Base
   end
 
   def elastic_index_observation
-    Rails.logger.debug "[DEBUG] indexing obs, quality: #{observation.quality_grade}"
     observation.elastic_index!
+    true
   end
 
   def self.vote(user, observation, metric, agree)

--- a/app/webpack/shared/components/cover_image.jsx
+++ b/app/webpack/shared/components/cover_image.jsx
@@ -69,8 +69,9 @@ class CoverImage extends React.Component {
         style={{
           width: "100%",
           minHeight: this.props.height,
-          backgroundSize: "cover",
+          backgroundSize: this.props.backgroundSize,
           backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
           backgroundImage: `url(${lowResUrl})`
         }}
       >
@@ -84,7 +85,12 @@ CoverImage.propTypes = {
   low: PropTypes.string,
   height: PropTypes.number.isRequired,
   className: PropTypes.string,
-  lazyLoad: PropTypes.bool
+  lazyLoad: PropTypes.bool,
+  backgroundSize: PropTypes.string
+};
+
+CoverImage.defaultProps = {
+  backgroundSize: "cover"
 };
 
 export default CoverImage;

--- a/app/webpack/taxa/shared/components/taxon_photo.jsx
+++ b/app/webpack/taxa/shared/components/taxon_photo.jsx
@@ -9,7 +9,8 @@ const TaxonPhoto = ( {
   height,
   showTaxonPhotoModal,
   className,
-  size
+  size,
+  backgroundSize
 } ) => (
   <div
     className={`TaxonPhoto ${className}`}
@@ -31,6 +32,7 @@ const TaxonPhoto = ( {
       src={ photo.photoUrl( size ) || photo.photoUrl( "small" ) }
       low={ photo.photoUrl( "small" ) }
       height={height}
+      backgroundSize={backgroundSize}
     />
   </div>
 );
@@ -43,7 +45,8 @@ TaxonPhoto.propTypes = {
   height: PropTypes.number.isRequired,
   observation: PropTypes.object,
   className: PropTypes.string,
-  size: PropTypes.string
+  size: PropTypes.string,
+  backgroundSize: PropTypes.string
 };
 
 TaxonPhoto.defaultProps = {

--- a/app/webpack/taxa/show/components/photo_preview.jsx
+++ b/app/webpack/taxa/show/components/photo_preview.jsx
@@ -43,8 +43,10 @@ class PhotoPreview extends React.Component {
 
   render( ) {
     const layout = this.props.layout;
-    const height = layout === "gallery" ? 98 : 196.5;
+    const thumbnailHeight = layout === "gallery" ? 98 : 196.5;
     let currentPhoto;
+    let bgImage;
+    let currentPhotoHeight = 590;
     const showTaxonPhotoModal = this.props.showTaxonPhotoModal;
     if ( this.state.taxonPhotos.length === 0 ) {
       return (
@@ -64,13 +66,36 @@ class PhotoPreview extends React.Component {
       );
     }
     if ( this.state.current && layout === "gallery" ) {
+      const photo = this.state.current.photo;
+      const dims = photo.dimensions( );
+      let ratio = 1;
+      if ( dims && dims.height ) {
+        ratio = dims.width / dims.height;
+      }
+      let backgroundSize = "cover";
+      if ( ratio > 1.3 ) {
+        backgroundSize = "contain";
+      }
+      if ( backgroundSize === "contain" ) {
+        currentPhotoHeight = 500;
+        bgImage = (
+          <div
+            className="photo-bg"
+            style={{
+              backgroundImage: `url('${this.state.current.photo.photoUrl( "small" )}')`
+            }}
+          >
+          </div>
+        );
+      }
       currentPhoto = (
         <TaxonPhoto
           taxon={this.props.taxon}
-          photo={this.state.current.photo}
+          photo={photo}
           size="large"
           showTaxonPhotoModal={showTaxonPhotoModal}
-          height={590}
+          height={currentPhotoHeight}
+          backgroundSize={backgroundSize}
         />
       );
     }
@@ -80,6 +105,7 @@ class PhotoPreview extends React.Component {
     }
     return (
       <div className={`PhotoPreview ${layout}`}>
+        { bgImage }
         { currentPhoto }
         <ul className="plain others">
           { this.state.taxonPhotos.map( tp => {
@@ -88,7 +114,7 @@ class PhotoPreview extends React.Component {
               content = (
                 <TaxonPhoto
                   photo={tp.photo}
-                  height={height}
+                  height={thumbnailHeight}
                   taxon={tp.taxon}
                   showTaxonPhotoModal={showTaxonPhotoModal}
                   className="photoItem"
@@ -108,7 +134,7 @@ class PhotoPreview extends React.Component {
                   <CoverImage
                     src={ tp.photo.photoUrl( "small" ) }
                     low={ tp.photo.photoUrl( "small" ) }
-                    height={height}
+                    height={thumbnailHeight}
                   />
                 </a>
               );
@@ -121,7 +147,7 @@ class PhotoPreview extends React.Component {
           } ) }
           <li className="viewmore">
             <a href={urlForTaxonPhotos( this.props.taxon )}
-              style={{ height: layout === "grid" ? `${height}px` : "inherit" }}
+              style={{ height: layout === "grid" ? `${thumbnailHeight}px` : "inherit" }}
             >
               <span className="inner">
                 <span>{ I18n.t( "view_more" )}</span>

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -1,12 +1,33 @@
 require File.dirname(__FILE__) + '/../spec_helper.rb'
 
 describe QualityMetric, "creation" do
+
   it "should update observation quality_grade" do
     o = make_research_grade_observation
     expect(o.quality_grade).to eq Observation::RESEARCH_GRADE
     qc = QualityMetric.make!(:observation => o, :metric => QualityMetric::METRICS.first, :agree => false)
     o.reload
     expect(o.quality_grade).to eq Observation::CASUAL
+  end
+
+  describe "elastic index" do
+    before(:each) { enable_elastic_indexing( Observation ) }
+    after(:each) { disable_elastic_indexing( Observation ) }
+
+    it "should get the updated quality_grade" do
+      o = without_delay { make_research_grade_observation }
+      o.elastic_index!
+      eo = Observation.elastic_search( id: o.id ).results[0]
+      puts "eo.description: #{eo.description}"
+      puts "o.description: #{o.description}"
+      expect( eo.id.to_i ).to eq o.id
+      expect( eo.quality_grade ).to eq Observation::RESEARCH_GRADE
+      without_delay do
+        QualityMetric.make!( observation: o, metric: QualityMetric::METRICS.first, agree: false )
+      end
+      eo = Observation.elastic_search( id: o.id ).results[0]
+      expect( eo.quality_grade ).to eq Observation::CASUAL
+    end
   end
 end
 


### PR DESCRIPTION
When we have the dimensions for a photo and it's so wide that it will probably get cropped by having it cover the available space on the taxon page, have the photo preview contain the photo instead.