### PR TITLE
Add bounding box to places index

### DIFF
--- a/app/assets/stylesheets/taxa/show/wikipedia.css.scss
+++ b/app/assets/stylesheets/taxa/show/wikipedia.css.scss
@@ -87,7 +87,11 @@
   }
 
   th {
-    padding: 0.4em;
+    background-color: #e3e3e3 !important;
+  }
+
+  th, td {
+    padding: 10px;
   }
 
 }

--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -40,6 +40,8 @@ class Place < ActiveRecord::Base
       user: user ? user.as_indexed_json(no_details: true) : nil,
       geometry_geojson: (place_geometry && !index_without_geometry) ?
         ElasticModel.geom_geojson(place_geometry.simplified_geom) : nil,
+      bounding_box_geojson: ( place_geometry && !index_without_geometry ) ?
+        ElasticModel.geom_geojson( place_geometry.bounding_box_geom ) : nil,
       location: ElasticModel.point_latlon(latitude, longitude),
       point_geojson: ElasticModel.point_geojson(latitude, longitude)
     }

--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -17,6 +17,7 @@ class Place < ActiveRecord::Base
       indexes :id, type: "integer"
       indexes :place_type, type: "integer"
       indexes :geometry_geojson, type: "geo_shape"
+      indexes :bounding_box_geojson, type: "geo_shape"
       indexes :location, type: "geo_point", lat_lon: true
       indexes :point_geojson, type: "geo_shape"
       indexes :bbox_area, type: "double"

--- a/app/models/place_geometry.rb
+++ b/app/models/place_geometry.rb
@@ -125,6 +125,12 @@ class PlaceGeometry < ActiveRecord::Base
       select("id, cleangeometry(ST_Buffer(ST_SimplifyPreserveTopology(geom, #{ tolerance }),0)) as simpl").first.simpl
   end
 
+  def bounding_box_geom
+    return if !geom
+    PlaceGeometry.where( id: id ).
+      select( "id, ST_Envelope( geom ) AS bounding_box" ).first.bounding_box
+  end
+
   def self.update_observations_places(place_geometry_id)
     if pg = PlaceGeometry.where(id: place_geometry_id).first
       Place.update_observations_places(pg.place_id)

--- a/db/migrate/20170110185648_add_bounding_box_to_places_index.rb
+++ b/db/migrate/20170110185648_add_bounding_box_to_places_index.rb
@@ -1,4 +1,21 @@
 class AddBoundingBoxToPlacesIndex < ActiveRecord::Migration
-  def change
+  def up
+    Place.__elasticsearch__.client.indices.put_mapping(
+      index: Place.index_name,
+      type: Place.document_type,
+      body: {
+        Place.document_type => {
+          properties: {
+            bounding_box_geojson: {
+              type: "geo_shape"
+            }
+          }
+        }
+      }
+    )
+  end
+
+  def down
+    # There IS no return
   end
 end

--- a/db/migrate/20170110185648_add_bounding_box_to_places_index.rb
+++ b/db/migrate/20170110185648_add_bounding_box_to_places_index.rb
@@ -1,0 +1,4 @@
+class AddBoundingBoxToPlacesIndex < ActiveRecord::Migration
+  def change
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -8723,3 +8723,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161216041939');
 
 INSERT INTO schema_migrations (version) VALUES ('20161220213126');
 
+INSERT INTO schema_migrations (version) VALUES ('20170110185648');
+


### PR DESCRIPTION
This adds the bounding box of the place geometry to the places index. It basically does the same thing as the geom, so its in the index as a GeoJSON polygon, and thus has some redundant data, particularly the first and last coordinates. Happy to change that and use the Google-style sw / ne point format if that's preferable.

The intent here is to have the bounding boxes available to anyone consuming places so they can do simple geo stuff and zoom maps accordingly. Proximate need is to zoom the map on the taxon page appropriately when the user chooses a place.