### PR TITLE
Common ancestor IDs for ambiguous splits

### DIFF
--- a/app/controllers/identifications_controller.rb
+++ b/app/controllers/identifications_controller.rb
@@ -26,6 +26,8 @@ class IdentificationsController < ApplicationController
       search_params[:current] = "true"
     elsif params[:current].noish?
       search_params[:current] = "false"
+    else
+      search_params[:current] = "any"
     end
     if params[:for] == "others"
       search_params[:own_observation] = "false"

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -174,21 +174,23 @@ class TaxonChange < ActiveRecord::Base
       Observation.search_in_batches( taxon_ids: input_taxon_ids ) do |batch|
         yield batch
       end
-    elsif reflection.klass == Identification
-      page = 1
-      loop do
-        results = Identification.elastic_paginate(
-          filters: [
-            { terms: { "taxon.ancestor_ids" => input_taxon_ids } },
-            { term: { current: true } }
-          ],
-          page: page,
-          per_page: 100
-        )
-        break if results.blank?
-        yield results
-        page += 1
-      end
+    # Omitting using ES for idents now until the ident index gets fully 
+    # rebuilt. This should be slower but more reliable
+    # elsif reflection.klass == Identification
+    #   page = 1
+    #   loop do
+    #     results = Identification.elastic_paginate(
+    #       filters: [
+    #         { terms: { "taxon.ancestor_ids" => input_taxon_ids } },
+    #         { term: { current: true } }
+    #       ],
+    #       page: page,
+    #       per_page: 100
+    #     )
+    #     break if results.blank?
+    #     yield results
+    #     page += 1
+    #   end
     else
       reflection.klass.where( "#{reflection.foreign_key} IN (?)", input_taxon_ids ).find_in_batches do |batch|
         yield batch

--- a/app/views/taxon_changes/show.html.haml
+++ b/app/views/taxon_changes/show.html.haml
@@ -40,7 +40,7 @@
                 = "(#{tc.committed_on.blank? ? "Draft" : "Committed on #{tc.committed_on}"})"
                 = link_to t(:view), tc, :class => "readmore"
           %p.ui
-            You should probably delete this taxon change, or at least come figure
+            You should probably delete this taxon change, or at least figure
             out some kind of solution with the person / people who made the other
             change(s).
       - if @taxon_change.draft? && @taxon_change.is_a?( TaxonSplit )
@@ -66,7 +66,7 @@
           = succeed "." do
             = link_to_taxon @taxon_change.output_ancestor, sciname: true
           This happens when we can't automatically assign an identification to one of the output taxa.
-          = link_to "Review observations of <span class='sciname'>#{@taxon_change.output_ancestor.name}</span>".html_safe, identify_observations_path( taxon_id: @taxon_change.output_ancestor.id, rank: @taxon_change.output_ancestor.rank ), class: "viewmore taxon #{@taxon_change.output_ancestor.rank}"
+          = link_to "Review identifications of <span class='sciname'>#{@taxon_change.input_taxon.name}</span> #{@taxon_change.input_taxon.id}".html_safe, identifications_path( taxon_id: @taxon_change.input_taxon.id, current: "any" ), class: "viewmore taxon #{@taxon_change.input_taxon.rank}"
 
       #pageheader
         .breadcrumbs

--- a/app/views/taxon_changes/show.html.haml
+++ b/app/views/taxon_changes/show.html.haml
@@ -43,13 +43,31 @@
             You should probably delete this taxon change, or at least come figure
             out some kind of solution with the person / people who made the other
             change(s).
-      - if @taxon_change.draft? && @taxon_change.is_a?( TaxonSplit) && !@taxon_change.automatable?
+      - if @taxon_change.draft? && @taxon_change.is_a?( TaxonSplit )
         .alert.alert-warning
           %strong= "#{t(:heads_up)}:"
-          This taxon split has output taxa that do not have atlases. This means
-          that records associated with its input taxa cannot be automatically
-          assigned to output taxa when this split is committed and
-          the community will have to add new IDs for these records.
+          - if @taxon_change.automatable?
+            When you commit this change, identifications will be re-assigned to
+            the output taxa based on their atlases. If some or all of the
+            outputs lack atlases, or if atlases overlap for a given record,
+            identifications will be replaced with identifications of the nearest
+            common ancestor taxon,
+            = link_to_taxon @taxon_change.output_ancestor, sciname: true
+          - else
+            This taxon split has output taxa that either do not have atlases or
+            don't share a common ancestor, so the records associated with its
+            input taxa cannot be automatically assigned to output taxa when this
+            split is committed and the community will have to add new IDs for
+            these records.
+      - elsif @taxon_change.is_a?( TaxonSplit ) && @taxon_change.automatable?
+        .alert.alert-warning
+          %strong= "#{t(:heads_up)}:"
+          Some or all of the identifications affected by this split may have been replaced with identifications of 
+          = succeed "." do
+            = link_to_taxon @taxon_change.output_ancestor, sciname: true
+          This happens when we can't automatically assign an identification to one of the output taxa.
+          = link_to "Review observations of <span class='sciname'>#{@taxon_change.output_ancestor.name}</span>".html_safe, identify_observations_path( taxon_id: @taxon_change.output_ancestor.id, rank: @taxon_change.output_ancestor.rank ), class: "viewmore taxon #{@taxon_change.output_ancestor.rank}"
+
       #pageheader
         .breadcrumbs
           %strong= link_to "&laquo #{t :back_to_taxon_changes}".html_safe, taxon_changes_path, :class => 'crumb'

--- a/lib/observation_search.rb
+++ b/lib/observation_search.rb
@@ -387,7 +387,7 @@ module ObservationSearch
         if params[:taxon_ids].size == 1
           scope = scope.of(taxon_ids.first)
         else
-          taxa = Taxon::ICONIC_TAXA.select{|t| taxon_ids.include?(t.id)}
+          taxa = Taxon::ICONIC_TAXA.select{|t| taxon_ids.include?(t.id) }
           if taxa.size == taxon_ids.size
             scope = scope.has_iconic_taxa(taxon_ids)
           end

--- a/spec/helpers/make_helpers.rb
+++ b/spec/helpers/make_helpers.rb
@@ -168,88 +168,50 @@ module MakeHelpers
   def load_test_taxa
     Rails.logger.debug "\n\n\n[DEBUG] loading test taxa"
     @Life = Taxon.find_by_name('Life') || Taxon.make!(:name => 'Life', :rank => "state of matter")
+    
+    set_taxon_with_rank_and_parent( "Animalia", Taxon::KINGDOM, @Life )
+    set_taxon_with_rank_and_parent( "Chordata", Taxon::PHYLUM, @Animalia )
+    set_taxon_with_rank_and_parent( "Amphibia", Taxon::CLASS, @Chordata )
+    set_taxon_with_rank_and_parent( "Anura", Taxon::ORDER, @Amphibia )
+    set_taxon_with_rank_and_parent( "Hylidae", Taxon::FAMILY, @Anura )
+    set_taxon_with_rank_and_parent( "Pseudacris", Taxon::GENUS, @Hylidae )
+    set_taxon_with_rank_and_parent( "Pseudacris regilla", Taxon::SPECIES, @Pseudacris )
 
-    unless @Animalia = Taxon.find_by_name('Animalia')
-      @Animalia = Taxon.make!(:name => 'Animalia', :rank => 'kingdom', :is_iconic => true)
-    end
-    @Animalia.update_attributes(:parent => @Life)
-
-    unless @Chordata = Taxon.find_by_name('Chordata')
-      @Chordata = Taxon.make!(:name => 'Chordata', :rank => "phylum")
-    end
-    @Chordata.update_attributes(:parent => @Animalia)
-
-    unless @Amphibia = Taxon.find_by_name('Amphibia')
-      @Amphibia = Taxon.make!(:name => 'Amphibia', :rank => "class", :is_iconic => true)
-    end
-    @Amphibia.update_attributes(:parent => @Chordata)
-
-    unless @Anura = Taxon.find_by_name('Anura')
-      @Anura = Taxon.make!(:name => 'Anura', :rank => "order")
-    end
-    @Anura.update_attributes(:parent => @Amphibia)
-
-    unless @Hylidae = Taxon.find_by_name('Hylidae')
-      @Hylidae = Taxon.make!(:name => 'Hylidae', :rank => "family")
-    end
-    @Hylidae.update_attributes(:parent => @Anura)
-
-    unless @Pseudacris = Taxon.find_by_name('Pseudacris')
-      @Pseudacris = Taxon.make!(:name => 'Pseudacris', :rank => "genus")
-    end
-    @Pseudacris.update_attributes(:parent => @Hylidae)
-
-    unless @Pseudacris_regilla = Taxon.find_by_name('Pseudacris regilla')
-      @Pseudacris_regilla = Taxon.make!(:name => 'Pseudacris regilla', :rank => "species")
-    end
-    @Pseudacris_regilla.update_attributes(:parent => @Pseudacris)
-
-    unless @Aves = Taxon.find_by_name('Aves')
-      @Aves = Taxon.make!(:name => "Aves", :rank => "class", :is_iconic => true)
-    end
-    @Aves.update_attributes(:parent => @Chordata)
-
-    unless @Apodiformes = Taxon.find_by_name('Apodiformes')
-      @Apodiformes = Taxon.make!(:name => "Apodiformes", :rank => "order")
-    end
-    @Apodiformes.update_attributes(:parent => @Aves)
-
-    unless @Trochilidae = Taxon.find_by_name('Trochilidae')
-      @Trochilidae = Taxon.make!(:name => "Trochilidae", :rank => "family")
-    end
-    @Trochilidae.update_attributes(:parent => @Apodiformes)
-
-    unless @Calypte = Taxon.find_by_name('Calypte')
-      @Calypte = Taxon.make!(:name => "Calypte", :rank => "genus")
-    end
-    @Calypte.update_attributes(:parent => @Trochilidae)
-
-    unless @Calypte_anna = Taxon.find_by_name('Calypte anna')
-      @Calypte_anna = Taxon.make!(:name => "Calypte anna", :rank => "species")
-      @Calypte_anna.taxon_names << TaxonName.make!(:name => "Anna's Hummingbird", 
-        :taxon => @Calypte_anna, 
-        :lexicon => TaxonName::LEXICONS[:ENGLISH])
-    end
-    @Calypte_anna.update_attributes(:parent => @Calypte)
-
-    unless @Plantae = Taxon.find_by_name('Plantae')
-      @Plantae = Taxon.make!(:name => "Plantae", :rank => "kingdom")
-    end
-    @Plantae.update_attributes(:parent => @Life)
-
-    unless @Magnoliophyta = Taxon.find_by_name('Magnoliophyta')
-      @Magnoliophyta = Taxon.make!(:name => "Magnoliophyta", :rank => "phylum")
-    end
-    @Magnoliophyta.update_attributes(:parent => @Plantae)
-
-    unless @Magnoliopsida = Taxon.find_by_name('Magnoliopsida')
-      @Magnoliopsida = Taxon.make!(:name => "Magnoliopsida", :rank => "class")
-    end
-    @Magnoliopsida.update_attributes(:parent => @Magnoliophyta)
+    set_taxon_with_rank_and_parent( "Aves", Taxon::CLASS, @Chordata )
+    set_taxon_with_rank_and_parent( "Apodiformes", Taxon::ORDER, @Aves )
+    set_taxon_with_rank_and_parent( "Trochilidae", Taxon::FAMILY, @Apodiformes )
+    set_taxon_with_rank_and_parent( "Calypte", Taxon::GENUS, @Trochilidae )
+    set_taxon_with_rank_and_parent( "Calypte anna", Taxon::SPECIES, @Calypte )
+    @Calypte_anna.taxon_names << TaxonName.make!(
+      name: "Anna's Hummingbird", 
+      taxon: @Calypte_anna, 
+      lexicon: TaxonName::LEXICONS[:ENGLISH]
+    )
+    
+    set_taxon_with_rank_and_parent( "Plantae", Taxon::KINGDOM, @Life )
+    set_taxon_with_rank_and_parent( "Magnoliophyta", Taxon::PHYLUM, @Plantae )
+    set_taxon_with_rank_and_parent( "Magnoliopsida", Taxon::CLASS, @Magnoliophyta )
+    set_taxon_with_rank_and_parent( "Myrtales", Taxon::ORDER, @Magnoliopsida )
+    set_taxon_with_rank_and_parent( "Onagraceae", Taxon::FAMILY, @Myrtales )
+    set_taxon_with_rank_and_parent( "Clarkia", Taxon::GENUS, @Onagraceae )
+    set_taxon_with_rank_and_parent( "Clarkia amoena", Taxon::GENUS, @Clarkia )
 
     Taxon.reset_iconic_taxa_constants_for_tests
 
     Rails.logger.debug "[DEBUG] DONE loading test taxa\n\n\n"
+  end
+
+  def set_taxon_with_rank_and_parent( name, rank, parent)
+    varname = name.gsub( /\s+/, "_" )
+    if existing_in_memory = instance_variable_get( "@#{varname}" )
+      return existing_in_memory
+    end
+    if existing_in_db = Taxon.find_by_name( name )
+      instance_variable_set( "@#{varname}", existing_in_db )
+      return instance_variable_get( "@#{varname}" )
+    end
+    instance_variable_set( "@#{varname}", Taxon.make!( name: name, rank: rank, parent: parent ) )
+    instance_variable_get( "@#{varname}" )
   end
 
   def make_check_listed_taxon( options = {} )

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -1903,16 +1903,16 @@ describe Observation do
     end
     it "should filter by taxon_ids[] if all taxa are iconic" do
       load_test_taxa
-      o1 = Observation.make!(taxon: @Aves)
-      o2 = Observation.make!(taxon: @Amphibia)
-      o3 = Observation.make!(taxon: @Animalia)
+      o1 = Observation.make!( taxon: @Aves )
+      o2 = Observation.make!( taxon: @Amphibia )
+      o3 = Observation.make!( taxon: @Animalia )
       expect( @Aves ).to be_is_iconic
       expect( @Amphibia ).to be_is_iconic
       expect( @Animalia ).to be_is_iconic
-      observations = Observation.query(taxon_ids: [@Aves.id, @Amphibia.id]).all
-      expect( observations ).to include(o1)
-      expect( observations ).to include(o2)
-      expect( observations ).not_to include(o3)
+      observations = Observation.query( taxon_ids: [@Aves.id, @Amphibia.id] ).to_a
+      expect( observations ).to include( o1 )
+      expect( observations ).to include( o2 )
+      expect( observations ).not_to include( o3 )
     end
   end
 


### PR DESCRIPTION
Instead of ignoring identifications for taxon splits where the choice of output taxon is uncertain, this change adds new IDs of the closest common ancestor taxon of all the output taxa. Closes #1235.