### PR TITLE
Automatic captive

### DIFF
--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -555,7 +555,7 @@ class ListedTaxon < ActiveRecord::Base
     end
   end
   
-  # Retrievest the first and last observations and the month counts. Note that
+  # Retrieve the first and last observations and the month counts. Note that
   # at present first_observation has a different meaning depending on the
   # list: for check lists it means the first observation added to iNat (i.e.
   # sorted by ID), but for everything else it means first observation by date

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1826,13 +1826,19 @@ class Observation < ActiveRecord::Base
 
   def update_quality_metrics
     if captive_flag.yesish?
-      QualityMetric.vote(user, self, QualityMetric::WILD, false)
+      QualityMetric.vote( user, self, QualityMetric::WILD, false )
     elsif captive_flag.noish? && force_quality_metrics
-      QualityMetric.vote(user, self, QualityMetric::WILD, true)
-    elsif captive_flag.noish? && (qm = quality_metrics.detect{|m| m.user_id == user_id && m.metric == QualityMetric::WILD})
-      qm.update_attributes(:agree => true)
-    elsif force_quality_metrics && (qm = quality_metrics.detect{|m| m.user_id == user_id && m.metric == QualityMetric::WILD})
+      QualityMetric.vote( user, self, QualityMetric::WILD, true )
+    elsif captive_flag.noish? && ( qm = quality_metrics.detect{|m| m.user_id == user_id && m.metric == QualityMetric::WILD} )
+      qm.update_attributes( agree: true)
+    elsif force_quality_metrics && ( qm = quality_metrics.detect{|m| m.user_id == user_id && m.metric == QualityMetric::WILD} )
       qm.destroy
+    end
+    system_captive_vote = quality_metrics.detect{ |m| m.user_id.blank? && m.metric == QualityMetric::WILD }
+    if probably_captive?
+      QualityMetric.vote( nil, self, QualityMetric::WILD, false ) unless system_captive_vote
+    elsif system_captive_vote
+      system_captive_vote.destroy
     end
     true
   end
@@ -2578,6 +2584,30 @@ class Observation < ActiveRecord::Base
   # use acts_as_votable, faves_count seems clearer.
   def faves_count
     cached_votes_total
+  end
+
+  def probably_captive?
+    return false unless taxon_id
+    place = system_places[0]
+    return false unless place
+    buckets = Observation.elastic_search(
+      filters: [
+        { term: { "taxon.ancestor_ids": taxon_id } },
+        { term: { place_ids: place.id } },
+      ],
+      earliest_sort_field: "id",
+      size: 0,
+      aggregate: {
+        captive: {
+          terms: { field: "captive", size: 15 }
+        }
+      }
+    ).results.response.response.aggregations.captive.buckets
+    captive_stats = Hash[ buckets.map{ |b| [ b["key"], b["doc_count" ] ] } ]
+    total = captive_stats.values.sum
+    ratio = captive_stats[1].to_f / total
+    puts "total: #{total}, ratio: #{ratio}, place: #{place}"
+    total > 10 && ratio > 0.8
   end
 
   def self.dedupe_for_user(user, options = {})

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2585,7 +2585,9 @@ class Observation < ActiveRecord::Base
   def probably_captive?
     target_taxon = community_taxon || taxon
     return false unless target_taxon
-    return false if target_taxon.rank_level > Taxon::GENUS_LEVEL
+    if target_taxon.rank_level.blank? || target_taxon.rank_level.to_i > Taxon::GENUS_LEVEL
+      return false
+    end
     place = system_places.detect do |p|
       [
         Place::COUNTRY_LEVEL, Place::STATE_LEVEL, Place::COUNTY_LEVEL

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -65,7 +65,7 @@ class QualityMetric < ActiveRecord::Base
   end
 
   def self.vote(user, observation, metric, agree)
-    qm = observation.quality_metrics.find_or_initialize_by(metric: metric, user_id: user.id)
-    qm.update_attributes(:agree => agree)
+    qm = observation.quality_metrics.find_or_initialize_by( metric: metric, user_id: user.try(:id) )
+    qm.update_attributes( agree: agree )
   end
 end

--- a/app/views/quality_metrics/_quality_metric_row.html.erb
+++ b/app/views/quality_metrics/_quality_metric_row.html.erb
@@ -24,7 +24,11 @@
           </td>
           <td width="100%">
             <% for qm in existing_quality_metrics.select{|qm| qm.metric == metric && qm.agree?} %>
-              <%= link_to user_image(qm.user, :title => qm.user.login, :alt => qm.user.login), person_by_login_path(qm.user.login) %>
+              <% if qm.user %>
+                <%= link_to user_image(qm.user, title: qm.user.login, alt: qm.user.login), person_by_login_path(qm.user.login) %>
+              <% else %>
+                <%= image_tag @site.logo_square.url, style: "height: 16px", title: SITE_NAME %>
+              <% end %>
             <% end %>
           </td>
           <td class="small meta"><%= (score * 100).round %>%</td>
@@ -39,7 +43,11 @@
           </td>
           <td>
             <% for qm in existing_quality_metrics.select{|qm| qm.metric == metric && !qm.agree?} %>
-              <%= link_to user_image(qm.user, :title => qm.user.login, :alt => qm.user.login), person_by_login_path(qm.user.login) %>
+              <% if qm.user %>
+                <%= link_to user_image(qm.user, :title => qm.user.login, :alt => qm.user.login), person_by_login_path(qm.user.login) %>
+              <% else %>
+                <%= image_tag @site.logo_square.url, style: "height: 16px", title: SITE_NAME %>
+              <% end %>
             <% end %>
           </td>
           <td class="small meta percent"><%= ((1 - score) * 100).round %>%</td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4372,6 +4372,18 @@ en:
               the observation no longer needs an ID <em>and</em> the community ID is above family
             </li>
           </ul>
+          <p>
+            And if that wasn't complicated enough, there are also situations where the system gets a vote:
+          </p>
+          <ul>
+            <li>
+              The system will vote that the observation is not wild/naturalized
+              if there are at least 10 other observations of this taxon in the
+              smallest county-, state-, or country-equivalent place that
+              contains this observation and 80% or more of those observations
+              have been marked as not wild/naturalized.
+            </li>
+          </ul>
         score_desc: "score = cumulative count / (cumulative count + disagreement count + ancestor disagreements)"
       user_stats:
         user_stats_desc: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4378,8 +4378,8 @@ en:
           <ul>
             <li>
               The system will vote that the observation is not wild/naturalized
-              if there are at least 10 other observations of this taxon in the
-              smallest county-, state-, or country-equivalent place that
+              if there are at least 10 other observations of a genus or lower in
+              the smallest county-, state-, or country-equivalent place that
               contains this observation and 80% or more of those observations
               have been marked as not wild/naturalized.
             </li>


### PR DESCRIPTION
Automatically add a captive vote to observations in places where there are mostly captive observations of that taxon. More specifically, vote captive if the community taxon or taxon is genus or lower AND there are at least 10 observations of that taxon in the smallest enclosing county, state, or country AND more than 80% of those observations have been marked as captive. So pretty conservative, actually, but should deal with the most common cultivated plants, dogs, cats, etc.