### PR TITLE
Prevent submenus from closing if the user is using the search inputs

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -46,9 +46,12 @@ function openHeaderSubnav(link) {
 
 function closeHeaderSubnav(link) {
   var navtab = $(link).parents('.navtab').get(0)
-  $(navtab).removeClass('open');
-  $('.subnav', navtab).hide()
-  $(document).unbind('click', subnavClickOff);
+  
+  if ($('input:focus', navtab).length <= 0) {
+    $(navtab).removeClass('open');
+    $('.subnav', navtab).hide();
+    $(document).unbind('click', subnavClickOff);
+  }
   return false;
 }
 


### PR DESCRIPTION
This very minor thing was bugging me.

When I'm searching something up on inaturalist using the header search box (see below), the header submenus disappear if you're typing something in but accidentally move the cursor outside of the dropdown box.

This change prevents the box from closing if the user is typing something in. 

![image](https://cloud.githubusercontent.com/assets/4730591/24874277/f8da2672-1dd8-11e7-8a89-b4946fcd5edc.png)



