### PR TITLE
site specific announcements can also be locale specific

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -452,7 +452,11 @@ class UsersController < ApplicationController
         scope = scope.where( site_id: nil )
         @announcements = scope.in_locale( I18n.locale )
         @announcements = scope.in_locale( I18n.locale.to_s.split('-').first ) if @announcements.blank?
-        @announcements = base_scope.where( site_id: @site ) if @announcements.blank?
+        if @announcements.blank?
+          @announcements = base_scope.where( "site_id = ? AND locales IN (?)",  @site, [] )
+          @announcements << base_scope.in_locale( I18n.locale ).where( site_id: @site )
+          @announcements = @announcements.flatten
+        end
         @subscriptions = current_user.subscriptions.includes(:resource).
           where("resource_type in ('Place', 'Taxon')").
           limit(5)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -12,7 +12,11 @@ class WelcomeController < ApplicationController
         scope = scope.where( site_id: nil )
         @announcements = scope.in_locale( I18n.locale )
         @announcements = scope.in_locale( I18n.locale.to_s.split('-').first ) if @announcements.blank?
-        @announcements = base_scope.where( site_id: @site ) if @announcements.blank?
+        if @announcements.blank?
+          @announcements = base_scope.where( "site_id = ? AND locales IN (?)",  @site, [] )
+          @announcements << base_scope.in_locale( I18n.locale ).where( site_id: @site )
+          @announcements = @announcements.flatten
+        end
         @google_webmaster_verification = @site.google_webmaster_verification if @site
         
         if logged_in?


### PR DESCRIPTION
The Canada site wants different announcements if the locale is French or English. Currently, if the Site is set, it fetches announcements of all locales for that site. This change is meant to only fetch announcements with a specific locale for a site if announcements have both site and locale set.