### PR TITLE
make observation fields text urls clickable

### DIFF
--- a/app/webpack/observations/show/components/observation_field_value.jsx
+++ b/app/webpack/observations/show/components/observation_field_value.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from "react";
 import { Popover, OverlayTrigger } from "react-bootstrap";
 import SplitTaxon from "../../../shared/components/split_taxon";
+import ObservationFieldText from "../../../shared/components/observation_field_text";
 
 class ObservationFieldValue extends React.Component {
   render( ) {
@@ -14,6 +15,8 @@ class ObservationFieldValue extends React.Component {
     }
     if ( ofv.datatype === "dna" ) {
       value = ( <div className="dna">{ ofv.value } { loading }</div> );
+    } else if ( ofv.datatype === "text" ) {
+      value = ( <ObservationFieldText text={ofv.value} /> );
     } else {
       if ( ofv.datatype === "taxon" && ofv.taxon ) {
         value = ( <SplitTaxon

--- a/app/webpack/shared/components/observation_field_text.jsx
+++ b/app/webpack/shared/components/observation_field_text.jsx
@@ -1,0 +1,19 @@
+import React, { PropTypes } from "react";
+
+class ObservationFieldText extends React.Component {
+  render( ) {
+    const text = this.props.text;
+    const isLink = /https?:\/\//.test( text );
+    const LinkElement = ( isLink ) ? "a" : "span";
+
+    return (
+       <LinkElement href={text}>{text}</LinkElement>
+    );
+  }
+}
+
+ObservationFieldText.propTypes = {
+  text: PropTypes.string
+};
+
+export default ObservationFieldText;


### PR DESCRIPTION
@kueda When the observation field has format of `text`,  if value contains an url, make a link.

Issue https://github.com/inaturalist/inaturalist/issues/1501

<img width="406" alt="screen shot 2017-11-07 at 7 56 55 am" src="https://user-images.githubusercontent.com/6968611/32503854-256f6ae8-c393-11e7-9163-3a35547ad1f2.png">
