### PR TITLE
Set the locale from the Accept-Language header

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -31,7 +31,7 @@ class Site < ActiveRecord::Base
   preference :contact_email, :string
   preference :contact_url, :string
 
-  preference :locale, :string, :default => "en"
+  preference :locale, :string
 
   # default bounds for most maps, including /observations/new and the home page. Defaults to the whole world
   preference :geo_swlat, :string

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -49,6 +49,7 @@ module Logstasher
     payload[:bot] = Logstasher.is_user_agent_a_bot?(request.user_agent)
     # this can be overwritten by merging Logstasher.payload_from_user
     payload[:logged_in] = false
+    payload[:i18n_locale] = I18n.locale.to_s.downcase
     payload
   end
 


### PR DESCRIPTION
Uses the Accept-Language HTTP header to set the user's locale if it hasn't been set already.