### PR TITLE
Nested taxon names

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -27,7 +27,15 @@ class CheckListsController < ApplicationController
       # so we can search items in other checklists for this place
       if (@q = params[:q]) && !@q.blank?
         @search_taxon_ids = Taxon.elastic_search(
-          filters: [ { match: { "names.name": { query: @q, operator: "and" } } } ]).per_page(1000).map(&:id)
+          filters: [ {
+            nested: {
+              path: "names",
+              query: {
+                match: { "names.name": { query: @q, operator: "and" } }
+              }
+            }
+          } ]
+        ).per_page(1000).map(&:id)
         @unpaginated_listed_taxa = @unpaginated_listed_taxa.filter_by_taxa(@search_taxon_ids)
       end
     end

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -341,7 +341,14 @@ class TaxaController < ApplicationController
 
     filters = [ ]
     unless @q.blank?
-      filters << { match: { "names.name": { query: @q, operator: "and" } } }
+      filters << {
+        nested: {
+          path: "names",
+          query: {
+            match: { "names.name": { query: @q, operator: "and" } }
+          }
+        }
+      }
     end
     filters << { term: { is_active: true } } if @is_active === true
     filters << { term: { is_active: false } } if @is_active === false
@@ -502,7 +509,14 @@ class TaxaController < ApplicationController
     else
       params[:is_active]
     end
-    filters = [{ match: { "names.name_autocomplete": { query: @q, operator: "and" } } }]
+    filters = [{
+      nested: {
+        path: "names",
+        query: {
+          match: { "names.name_autocomplete": { query: @q, operator: "and" } }
+        }
+      }
+    }]
     filters << { term: { is_active: true } } if @is_active === true
     filters << { term: { is_active: false } } if @is_active === false
     @taxa = Taxon.elastic_paginate(
@@ -513,7 +527,14 @@ class TaxaController < ApplicationController
     )
     # attempt to fetch the best exact match, which will go first
     exact_results = Taxon.elastic_paginate(
-      filters: filters + [ { match: { "names.exact_ci" => @q } } ],
+      filters: filters + [ {
+        nested: {
+          path: "names",
+          query: {
+            match: { "names.exact_ci" => @q }
+          }
+        }
+      } ],
       sort: { observations_count: "desc" },
       per_page: 1,
       page: 1

--- a/app/es_indices/taxon_index.rb
+++ b/app/es_indices/taxon_index.rb
@@ -49,7 +49,7 @@ class Taxon < ActiveRecord::Base
       indexes :listed_taxa do
         indexes :establishment_means, type: "keyword"
       end
-      indexes :names do
+      indexes :names, type: :nested do
         indexes :name, type: "text", analyzer: "ascii_snowball_analyzer"
         indexes :locale, type: "keyword"
         # NOTE: don't forget to install the proper analyzers in Elasticsearch

--- a/app/models/taxon_name.rb
+++ b/app/models/taxon_name.rb
@@ -92,6 +92,37 @@ class TaxonName < ActiveRecord::Base
     EOT
     const_set k.to_s.upcase, v
   end
+
+  LOCALES = {
+    "arabic"                => "ar",
+    "basque"                => "eu",
+    "breton"                => "br",
+    "bulgarian"             => "bg",
+    "catalan"               => "ca",
+    "chinese_traditional"   => "zh",
+    "dutch"                 => "nl",
+    "english"               => "en",
+    "french"                => "fr",
+    "galician"              => "gl",
+    "german"                => "de",
+    "finnish"               => "fi",
+    "hawaiian"              => "haw",
+    "hebrew"                => "iw",
+    "indonesian"            => "id",
+    "italian"               => "it",
+    "japanese"              => "ja",
+    "korean"                => "ko",
+    "luxembourgish"         => "lb",
+    "macedonian"            => "mk",
+    "maori"                 => "mi",
+    "maya"                  => "myn",
+    "occitan"               => "oc",
+    "portuguese"            => "pt",
+    "russian"               => "ru",
+    "scientific_names"      => "sci",
+    "spanish"               => "es"
+  }
+
   alias :is_scientific? :is_scientific_names?
   
   def to_s
@@ -232,27 +263,7 @@ class TaxonName < ActiveRecord::Base
   end
 
   def locale_for_lexicon
-    case localizable_lexicon
-    when "catalan" then "ca"
-    when "chinese_traditional" then "zh"
-    when "dutch" then "nl"
-    when "english" then "en"
-    when "french" then "fr"
-    when "german" then "de"
-    when "hawaiian" then "haw"
-    when "hebrew" then "iw"
-    when "indonesian" then "id"
-    when "italian" then "it"
-    when "japanese" then "ja"
-    when "korean" then "ko"
-    when "maori" then "mi"
-    when "maya" then "myn"
-    when "portuguese" then "pt"
-    when "scientific_names" then "sci"
-    when "spanish" then "es"
-    else
-      "und"
-    end
+    LOCALES[localizable_lexicon] || "und"
   end
 
   def index_taxon
@@ -265,24 +276,9 @@ class TaxonName < ActiveRecord::Base
 
   def self.language_for_locale(locale = nil)
     locale ||= I18n.locale
-    case locale.to_s
-    when /^ca/      then "catalan"
-    when /^en/      then "english"
-    when /^es/      then "spanish"
-    when /^fr/      then "french"
-    when /^haw/     then "hawaiian"
-    when /^id/      then "indonesian"
-    when /^it/      then "italian"
-    when /^iw/      then "hebrew"
-    when /^ja/      then "japanese"
-    when /^ko/      then "korean"
-    when /^mi/      then "maori"
-    when /^myn/     then "maya"
-    when /^nl/      then "dutch"
-    when /^pt/      then "portuguese"
-    when /^sci/     then "scientific_names"
-    when /zh.CN/i   then "chinese_simplified"
-    when /^zh/      then "chinese_traditional"
+    LOCALES.each do |language, language_locale|
+      return "chinese_simplified" if locale.to_s =~ /zh.CN/i
+      return language if locale.to_s =~ /^#{language_locale}/
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -191,6 +191,11 @@ end
 def enable_elastic_indexing(*args)
   classes = [args].flatten
   classes.each do |klass|
+    begin
+      klass.__elasticsearch__.delete_index!
+    rescue Exception => e
+      raise e unless e.class.to_s =~ /NotFound/
+    end
     klass.__elasticsearch__.create_index!
     ElasticModel.wait_until_index_exists(klass.index_name)
     klass.send :after_save, :elastic_index!


### PR DESCRIPTION
Makes names in the taxon index a nested type to support locale- and place-specific weighting in the node API. See https://github.com/inaturalist/iNaturalistAPI/issues/115 and https://github.com/inaturalist/iNaturalistAPI/issues/117

Note: this will require taking down the site to re-create the taxon index.