### PR TITLE
Separate place IDs in observation index

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -631,7 +631,7 @@ class UsersController < ApplicationController
   end
 
   def api_token
-    payload = { user_id: current_user.id, user_login: current_user.login }
+    payload = { user_id: current_user.id }
     if doorkeeper_token && (a = doorkeeper_token.application)
       payload[:oauth_application_id] = a.becomes( OauthApplication ).id
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -631,7 +631,7 @@ class UsersController < ApplicationController
   end
 
   def api_token
-    payload = { user_id: current_user.id }
+    payload = { user_id: current_user.id, user_login: current_user.login }
     if doorkeeper_token && (a = doorkeeper_token.application)
       payload[:oauth_application_id] = a.becomes( OauthApplication ).id
     end

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -268,9 +268,9 @@ class Observation < ActiveRecord::Base
           end
           o.indexed_private_place_ids = o.indexed_private_places.map(&:id)
           unless o.geoprivacy == Observation::PRIVATE
-            o.indexed_place_ids = o.indexed_private_places.select do |p|
+            o.indexed_place_ids = o.indexed_private_places.select {|p|
               p.bbox_publicly_contains_observation?( o )
-            end
+            }.map(&:id)
           end
         end
       end

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -418,7 +418,7 @@ class ListedTaxon < ActiveRecord::Base
   
   def sync_parent_check_list
     return true unless list.is_a?(CheckList)
-    return true if @skip_sync_with_parent
+    return true if skip_sync_with_parent
     list.delay(priority: INTEGRITY_PRIORITY,
       unique_hash: { "CheckList::sync_with_parent": list_id }).
       sync_with_parent(:time_since_last_sync => updated_at)
@@ -426,7 +426,7 @@ class ListedTaxon < ActiveRecord::Base
   end
   
   def sync_species_if_infraspecies
-    return true if @skip_species_for_infraspecies
+    return true if skip_species_for_infraspecies
     return true unless list.is_a?(CheckList) && taxon
     return true unless taxon.infraspecies?
     ListedTaxon.delay(priority: INTEGRITY_PRIORITY, run_at: 1.hour.from_now,
@@ -444,8 +444,8 @@ class ListedTaxon < ActiveRecord::Base
   end
 
   def update_cache_columns
-    return true if @skip_update_cache_columns
-    return true if list.is_a?(CheckList) && (!@force_update_cache_columns || place_id.blank?)
+    return true if skip_update_cache_columns
+    return true if list.is_a?(CheckList) && (!force_update_cache_columns || place_id.blank?)
     return true if list.is_a?(CheckList) && !primary_listing
     set_cache_columns
     true
@@ -460,10 +460,10 @@ class ListedTaxon < ActiveRecord::Base
   end
   
   def update_cache_columns_for_check_list
-    return true if @skip_update_cache_columns
+    return true if skip_update_cache_columns
     return true unless list.is_a?(CheckList)
     if primary_listing
-      unless @force_update_cache_columns
+      unless force_update_cache_columns
         ListedTaxon.delay(priority: INTEGRITY_PRIORITY, run_at: 1.hour.from_now,
           queue: "slow", unique_hash: { "ListedTaxon::update_cache_columns_for": id }).
           update_cache_columns_for(id)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -11,6 +11,12 @@ class Observation < ActiveRecord::Base
   }
   notifies_subscribers_of :user, :notification => "created_observations",
     :queue_if => lambda { |observation| !observation.bulk_import }
+  
+  # Why aren't we using after_save? Because we need this to run before the
+  # after_create created by notifiesi_subscribers_of :public_places runs
+  after_create :update_observations_places
+  after_update :update_observations_places
+  
   notifies_subscribers_of :public_places, :notification => "new_observations", 
     :on => :create,
     :queue_if => lambda {|observation|
@@ -364,7 +370,6 @@ class Observation < ActiveRecord::Base
              :update_public_positional_accuracy,
              :update_mappable,
              :set_captive,
-             :update_observations_places,
              :set_taxon_photo,
              :create_observation_review
   after_create :set_uri, :update_user_counter_caches
@@ -2134,6 +2139,58 @@ class Observation < ActiveRecord::Base
     ).ceil
   end
 
+  def private_sw_latlon
+    return nil unless georeferenced?
+    lat = private_latitude.blank? ? latitude : private_latitude
+    lon = private_longitude.blank? ? longitude : private_longitude
+    return [lat, lon] if positional_accuracy.blank?
+    positional_accuracy_degrees = positional_accuracy / (2*Math::PI*PLANETARY_RADIUS) * 360.0
+    [
+      lat - positional_accuracy_degrees,
+      lon - positional_accuracy_degrees,
+    ]
+  end
+
+  def sw_latlon
+    return nil unless georeferenced?
+    if coordinates_obscured?
+      half_cell = COORDINATE_UNCERTAINTY_CELL_SIZE / 2
+      positional_accuracy_degrees = positional_accuracy.to_i / (2*Math::PI*PLANETARY_RADIUS) * 360.0
+      max_half_cell = [half_cell, positional_accuracy_degrees].max
+      return [
+        private_latitude - max_half_cell,
+        private_longitude - max_half_cell
+      ]
+    end
+    private_sw_latlon
+  end
+
+  def private_ne_latlon
+    return nil unless georeferenced?
+    lat = private_latitude.blank? ? latitude : private_latitude
+    lon = private_longitude.blank? ? longitude : private_longitude
+    return [lat, lon] if positional_accuracy.blank?
+    positional_accuracy_degrees = positional_accuracy / (2*Math::PI*PLANETARY_RADIUS) * 360.0
+    [
+      lat + positional_accuracy_degrees,
+      lon + positional_accuracy_degrees,
+    ]
+  end
+
+  def ne_latlon
+    return nil unless georeferenced?
+    if coordinates_obscured?
+      half_cell = COORDINATE_UNCERTAINTY_CELL_SIZE / 2
+      positional_accuracy_degrees = positional_accuracy.to_i / (2*Math::PI*PLANETARY_RADIUS) * 360.0
+      max_half_cell = [half_cell, positional_accuracy_degrees].max
+      return [
+        private_latitude + max_half_cell,
+        private_longitude + max_half_cell
+      ]
+    end
+    private_ne_latlon
+  end
+
   #
   # Distance of a diagonal from corner to corner across the uncertainty cell
   # for this observation's coordinates.
@@ -2145,8 +2202,9 @@ class Observation < ActiveRecord::Base
     Observation.uncertainty_cell_diagonal_meters( lat, lon )
   end
 
-  def self.places_for_latlon( lat, lon, acc )
-    candidates = Place.containing_lat_lng(lat, lon).sort_by{|p| p.bbox_area || 0}
+  def self.places_for_latlon( lat, lon, acc, options = {} )
+    candidates = options[:candidates] || Place.containing_lat_lng( lat, lon )
+    candidates = candidates.sort_by{|p| p.bbox_area || 0}
 
     # At present we use PostGIS GEOMETRY types, which are a bit stupid about
     # things crossing the dateline, so we need to do an app-layer check.
@@ -2169,19 +2227,15 @@ class Observation < ActiveRecord::Base
   
   def places
     return [] unless georeferenced?
-    lat = private_latitude || latitude
-    lon = private_longitude || longitude
-    acc = private_positional_accuracy || positional_accuracy
-    Observation.places_for_latlon( lat, lon, acc )
+    candidates = observations_places.map(&:place)
+    candidates.select{|p| p.bbox_privately_contains_observation?( self ) }
   end
   
   def public_places
     return [] unless georeferenced?
     return [] if geoprivacy == PRIVATE
-    lat = private_latitude || latitude
-    lon = private_longitude || longitude
-    acc = public_positional_accuracy || positional_accuracy
-    Observation.places_for_latlon( lat, lon, acc )
+    candidates = observations_places.map(&:place)
+    candidates.select{|p| p.bbox_publicly_contains_observation?( self ) }
   end
 
   def self.system_places_for_latlon( lat, lon, options = {} )

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -884,6 +884,18 @@ class Place < ActiveRecord::Base
     bbox.contains?(pt)
   end
 
+  def bbox_privately_contains_observation?( o )
+    sw = o.private_sw_latlon
+    ne = o.private_ne_latlon
+    bbox_contains_lat_lng?( *sw ) && bbox_contains_lat_lng?( *ne )
+  end
+
+  def bbox_publicly_contains_observation?( o )
+    sw = o.sw_latlon
+    ne = o.ne_latlon
+    bbox_contains_lat_lng?( *sw ) && bbox_contains_lat_lng?( *ne )
+  end
+
   def kml_url
     FakeView.place_geometry_kml_url(:place => self)
   end

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -15,7 +15,7 @@
     <%= csrf_meta_tag %>
     <meta name="config:inaturalist_api_url" content="<%= CONFIG.node_api_url %>">
     <% if logged_in? -%>
-      <meta name="inaturalist-api-token" content="<%= JsonWebToken.encode(user_id: current_user.id) %>">
+      <meta name="inaturalist-api-token" content="<%= JsonWebToken.encode(user_id: current_user.id, user_login: current_user.login) %>">
     <% end -%>
     <% if !@site.twitter_username.blank? -%>
       <meta name="twitter:site" content="<%= @site.twitter_username %>">

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -15,7 +15,7 @@
     <%= csrf_meta_tag %>
     <meta name="config:inaturalist_api_url" content="<%= CONFIG.node_api_url %>">
     <% if logged_in? -%>
-      <meta name="inaturalist-api-token" content="<%= JsonWebToken.encode(user_id: current_user.id, user_login: current_user.login) %>">
+      <meta name="inaturalist-api-token" content="<%= JsonWebToken.encode( user_id: current_user.id ) %>">
     <% end -%>
     <% if !@site.twitter_username.blank? -%>
       <meta name="twitter:site" content="<%= @site.twitter_username %>">

--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -121,8 +121,14 @@ function fetchCurrentObservation( observation = null ) {
         return newObs;
       } )
       .then( o => {
-        if ( o.place_ids && o.place_ids.length > 0 ) {
-          const placeIDs = _.take( o.place_ids, 100 );
+        let placeIDs;
+        if ( o.private_place_ids && o.private_place_ids.length > 0 ) {
+          placeIDs = o.private_place_ids;
+        } else {
+          placeIDs = o.place_ids;
+        }
+        if ( placeIDs && placeIDs.length > 0 ) {
+          placeIDs = _.take( o.place_ids, 100 );
           return iNaturalistJS.places.fetch(
             placeIDs, { per_page: 100, no_geom: true }
           ).then( response => {

--- a/app/webpack/observations/identify/ducks/suggestions.js
+++ b/app/webpack/observations/identify/ducks/suggestions.js
@@ -72,6 +72,12 @@ export default function reducer(
           newState.query.taxon_id = observation.taxon.id;
         }
       }
+      let placeIDs;
+      if ( observation.private_place_ids && observation.private_place_ids.length > 0 ) {
+        placeIDs = observation.private_place_ids;
+      } else {
+        placeIDs = observation.place_ids;
+      }
       if ( observation.places ) {
         const place = _
           .sortBy( observation.places, p => p.bbox_area )
@@ -79,8 +85,8 @@ export default function reducer(
         newState.query.place_id = place.id;
         newState.query.place = place;
         newState.query.defaultPlace = place;
-      } else if ( observation.place_ids && observation.place_ids.length > 0 ) {
-        newState.query.place_id = observation.place_ids[observation.place_ids.length - 1];
+      } else if ( placeIDs && placeIDs.length > 0 ) {
+        newState.query.place_id = placeIDs[placeIDs.length - 1];
       }
       newState.detailTaxon = null;
       newState.detailPhotoIndex = 0;

--- a/app/webpack/observations/show/ducks/observation_places.js
+++ b/app/webpack/observations/show/ducks/observation_places.js
@@ -27,7 +27,16 @@ export function fetchObservationPlaces( ) {
     }
     const params = { lat: observation.latitude, lng: observation.longitude,
       no_geom: true, order_by: "admin_and_distance" };
-    return inatjs.places.fetch( observation.place_ids, params ).then( response => {
+    let placeIDs;
+    if ( observation.private_place_ids && observation.private_place_ids.length > 0 ) {
+      placeIDs = observation.private_place_ids;
+    } else {
+      placeIDs = observation.place_ids;
+    }
+    if ( !placeIDs || placeIDs.length === 0 ) {
+      return null;
+    }
+    return inatjs.places.fetch( placeIDs, params ).then( response => {
       dispatch( setObservationPlaces( response.results ) );
     } ).catch( e => { } );
   };


### PR DESCRIPTION
Closes #1663 by making the `place_ids` attribute in the observation index just the publicly visible places, and adds a new `private_place_ids` for all the places visible to the observer. This will involve re-indexing all geo-referenced observations, but I think we can do that without taking down the site, since the `place_ids` attribute will continue to work. People searching for obs in contexts where they should see private coordinates will miss some observations for a week, I guess, until the indexing is complete and we've released the changes to the node API.