### PR TITLE
Try adding observations_count to places index

### DIFF
--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -52,7 +52,8 @@ class Place < ActiveRecord::Base
         ElasticModel.geom_geojson( place_geometry.bounding_box_geom ) : nil,
       location: ElasticModel.point_latlon(latitude, longitude),
       point_geojson: ElasticModel.point_geojson(latitude, longitude),
-      without_check_list: check_list_id.blank? ? true : nil
+      without_check_list: check_list_id.blank? ? true : nil,
+      observations_count: INatAPIService.observations( per_page: 0, verifiable: true, place_id: id ).total_results
     }
   end
 

--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -35,6 +35,7 @@ class Place < ActiveRecord::Base
 
   def as_indexed_json(options={})
     preload_for_elastic_index
+    obs_result = INatAPIService.observations( per_page: 0, verifiable: true, place_id: id )
     {
       id: id,
       slug: slug,
@@ -53,7 +54,7 @@ class Place < ActiveRecord::Base
       location: ElasticModel.point_latlon(latitude, longitude),
       point_geojson: ElasticModel.point_geojson(latitude, longitude),
       without_check_list: check_list_id.blank? ? true : nil,
-      observations_count: INatAPIService.observations( per_page: 0, verifiable: true, place_id: id ).total_results
+      observations_count: obs_result ? obs_result.total_entries : nil
     }
   end
 


### PR DESCRIPTION
This does address my concern of improving scores for large places in universal search, but it's also kind of a messy solution in which places get re-indexed infrequently and generally only in response to obs updates (not creation). Are we ok with that? It's fine for my purposes since I only need rough numbers, but if someone is expecting these counts to be exactly accurate they're going to disappointed.