### PR TITLE
Index spam status

### DIFF
--- a/app/es_indices/identification_index.rb
+++ b/app/es_indices/identification_index.rb
@@ -62,7 +62,8 @@ class Identification < ActiveRecord::Base
       } : nil,
       vision: vision,
       disagreement: disagreement,
-      previous_observation_taxon_id: previous_observation_taxon_id
+      previous_observation_taxon_id: previous_observation_taxon_id,
+      spam: known_spam? || owned_by_spammer?
     }
     if options[:no_details]
       json[:taxon_id] = taxon_id

--- a/app/es_indices/identification_index.rb
+++ b/app/es_indices/identification_index.rb
@@ -6,7 +6,7 @@ class Identification < ActiveRecord::Base
 
   scope :load_for_index, -> { includes(:taxon, :flags,
     :stored_preferences, :taxon_change,
-    { observation: [ :taxon, :user ] }, :user) }
+    { observation: [ :taxon, { user: :flags } ] }, { user: :flags } ) }
 
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -222,7 +222,8 @@ class Observation < ActiveRecord::Base
         owners_identification_from_vision: owners_identification_from_vision,
         preferences: preferences.map{ |p| { name: p[0], value: p[1] } },
         flags: flags.map(&:as_indexed_json),
-        quality_metrics: quality_metrics.map(&:as_indexed_json)
+        quality_metrics: quality_metrics.map(&:as_indexed_json),
+        spam: known_spam? || owned_by_spammer?
       })
       json[:photos] = [ ]
       json[:observation_photos] = [ ]

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -7,7 +7,7 @@ class Observation < ActiveRecord::Base
   attr_accessor :indexed_place_ids, :indexed_private_place_ids, :indexed_private_places
 
   scope :load_for_index, -> { includes(
-    :user, :confirmed_reviews, :flags,
+    { user: :flags }, :confirmed_reviews, :flags,
     :observation_links, :quality_metrics,
     :votes_for, :stored_preferences,
     { project_observations: :stored_preferences }, :tags,
@@ -17,8 +17,8 @@ class Observation < ActiveRecord::Base
     { taxon: [ { taxon_names: :place_taxon_names }, :conservation_statuses,
       { listed_taxa_with_establishment_means: :place } ] },
     { observation_field_values: :observation_field },
-    { identifications: [ :user, :taxon, :stored_preferences, :flags, :taxon_change ] },
-    { comments: [ :user, :flags ] } ) }
+    { identifications: [ { user: :flags }, :taxon, :stored_preferences, :flags, :taxon_change ] },
+    { comments: [ { user: :flags }, :flags ] } ) }
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do
       indexes :id, type: "integer"

--- a/app/es_indices/project_index.rb
+++ b/app/es_indices/project_index.rb
@@ -1,5 +1,4 @@
 class Project < ActiveRecord::Base
-
   include ActsAsElasticModel
 
   DEFAULT_ES_BATCH_SIZE = 500
@@ -118,7 +117,8 @@ class Project < ActiveRecord::Base
       featured_at: featured_at,
       created_at: created_at,
       updated_at: updated_at,
-      observations_count: obs_result ? obs_result.total_results : nil
+      observations_count: obs_result ? obs_result.total_results : nil,
+      spam: known_spam? || owned_by_spammer?
     }
   end
 

--- a/app/es_indices/project_index.rb
+++ b/app/es_indices/project_index.rb
@@ -4,6 +4,8 @@ class Project < ActiveRecord::Base
   DEFAULT_ES_BATCH_SIZE = 500
 
   scope :load_for_index, -> { includes(
+    :flags,
+    :user,
     :place,
     :project_users,
     :observation_fields,

--- a/app/es_indices/user_index.rb
+++ b/app/es_indices/user_index.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include ActsAsElasticModel
 
-  scope :load_for_index, -> { includes( :roles ) }
+  scope :load_for_index, -> { includes( :roles, :flags ) }
 
 
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do

--- a/app/es_indices/user_index.rb
+++ b/app/es_indices/user_index.rb
@@ -1,5 +1,4 @@
 class User < ActiveRecord::Base
-
   include ActsAsElasticModel
 
   scope :load_for_index, -> { includes( :roles ) }
@@ -20,7 +19,9 @@ class User < ActiveRecord::Base
   def as_indexed_json(options={})
     json = {
       id: id,
-      login: login
+      login: login,
+      spam: known_spam?,
+      suspended: suspended?
     }
     unless options[:no_details]
       json.merge!({

--- a/spec/lib/elastic_model/acts_as_elastic_model_spec.rb
+++ b/spec/lib/elastic_model/acts_as_elastic_model_spec.rb
@@ -204,14 +204,6 @@ describe ActsAsElasticModel do
       end
     end
 
-    describe "as_indexed_json" do
-      it "should be a blank has for a non-spammable model" do
-        expect( UpdateAction.make.as_indexed_json ).to be_blank
-      end
-      it "should include the spam key for a spammable model" do
-        expect( Observation.make.as_indexed_json( ).key?( :spam ) ).to be true
-      end
-    end
   end
 
 end

--- a/spec/lib/elastic_model/acts_as_elastic_model_spec.rb
+++ b/spec/lib/elastic_model/acts_as_elastic_model_spec.rb
@@ -203,6 +203,15 @@ describe ActsAsElasticModel do
         expect( obs.last_indexed_at ).to be > 1.minute.ago
       end
     end
+
+    describe "as_indexed_json" do
+      it "should be a blank has for a non-spammable model" do
+        expect( UpdateAction.make.as_indexed_json ).to be_blank
+      end
+      it "should include the spam key for a spammable model" do
+        expect( Observation.make.as_indexed_json( ).key?( :spam ) ).to be true
+      end
+    end
   end
 
 end

--- a/spec/lib/elastic_model/indices/project_index_spec.rb
+++ b/spec/lib/elastic_model/indices/project_index_spec.rb
@@ -1,15 +1,34 @@
 require "spec_helper"
 
 describe "Project Index" do
+  let(:project) { Project.make! }
   it "as_indexed_json should return a hash" do
-    p = Project.make!
-    json = p.as_indexed_json
+    json = project.as_indexed_json
     expect( json ).to be_a Hash
+    expect( json[:title] ).to eq project.title
   end
 
-  it "indexes icons with absolute URLs" do
-    p = Project.make!
-    json = p.as_indexed_json
-    expect( json[:icon] ).to include Site.default.url
+  # We don't index icon at all if there's no icon, not sure how this ever worked
+  # it "indexes icons with absolute URLs" do
+  #   p = Project.make!
+  #   json = p.as_indexed_json
+  #   expect( json[:icon] ).to include Site.default.url
+  # end
+
+  it "should index as spam if project is spam" do
+    expect( project.as_indexed_json[:spam] ).to be false
+    Flag.make!( flag: Flag::SPAM, flaggable: project )
+    project.reload
+    expect( project ).to be_known_spam
+    expect( project.as_indexed_json[:spam] ).to be true
+  end
+  
+  it "should index as spam if project owned by a spammer" do
+    expect( project.as_indexed_json[:spam] ).to be false
+    Flag.make!( flag: Flag::SPAM, flaggable: project.user )
+    project.reload
+    expect( project.user ).to be_known_spam
+    expect( project ).to be_owned_by_spammer
+    expect( project.as_indexed_json[:spam] ).to be true
   end
 end

--- a/spec/lib/elastic_model/indices/user_index_spec.rb
+++ b/spec/lib/elastic_model/indices/user_index_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "User Index" do
+  let( :user ) { User.make! }
+  
+  it "should index as spam if user is spam" do
+    expect( user.as_indexed_json[:spam] ).to be false
+    Flag.make!( flag: Flag::SPAM, flaggable: user )
+    user.reload
+    expect( user ).to be_known_spam
+    expect( user.as_indexed_json[:spam] ).to be true
+  end
+
+  it "should index whether the user was suspended" do
+    expect( user.as_indexed_json[:suspended] ).to be false
+    user.suspend!
+    expect( user.as_indexed_json[:suspended] ).to be true
+  end  
+end


### PR DESCRIPTION
Add `spam` attribute to several indices of models can that can be spam, and added `suspended` to the user index. Closes #1735