### PR TITLE
Remove annotations when they are no longer relevant (closes #1696)

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -175,6 +175,9 @@ class Annotation < ActiveRecord::Base
   def self.reassess_annotations_for_taxon_ids( taxon_ids )
     Annotation.
         joins(
+          controlled_value: [
+            { controlled_term_taxa: :taxon }
+          ],
           controlled_attribute: {
             controlled_term_taxa: {
               taxon: :taxon_ancestors
@@ -183,10 +186,18 @@ class Annotation < ActiveRecord::Base
         ).
         where( "taxon_ancestors.ancestor_taxon_id IN (?)", taxon_ids ).
         includes(
-          :resource,
-          controlled_attribute: {
-            controlled_term_taxa: :taxon
-          }
+          { resource: :taxon },
+          controlled_value: [
+            :taxa,
+            :excepted_taxa,
+            { controlled_term_taxa: :taxon }
+          ],
+          controlled_attribute: [
+            :values,
+            :taxa,
+            :excepted_taxa,
+            { controlled_term_taxa: :taxon }
+          ]
         ).
         find_each do |a|
       a.destroy unless a.valid?

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -166,4 +166,32 @@ class Annotation < ActiveRecord::Base
     end
   end
 
+  def self.reassess_annotations_for_taxon_ids( taxon_ids )
+    Annotation.
+        joins(
+          controlled_attribute: {
+            controlled_term_taxa: {
+              taxon: :taxon_ancestors
+            }
+          }
+        ).
+        where( "taxon_ancestors.ancestor_taxon_id IN (?)", taxon_ids ).
+        includes(
+          :resource,
+          controlled_attribute: {
+            controlled_term_taxa: :taxon
+          }
+        ).
+        find_each do |a|
+      a.destroy unless a.valid?
+    end
+    
+  end
+
+  def self.reassess_annotations_for_attribute_id( attribute_id )
+    Annotation.where( controlled_attribute_id: attribute_id ).find_each do |a|
+      a.destroy unless a.valid?
+    end
+  end
+
 end

--- a/app/models/controlled_term_taxon.rb
+++ b/app/models/controlled_term_taxon.rb
@@ -2,8 +2,10 @@ class ControlledTermTaxon < ActiveRecord::Base
   belongs_to :controlled_term, inverse_of: :controlled_term_taxa
   belongs_to :taxon, inverse_of: :controlled_term_taxa
 
-  after_save :index_controlled_term
+  after_save :index_controlled_term, :reassess_annotations_after_save_later
   after_destroy :index_controlled_term
+
+  validates_presence_of :controlled_term_id, :taxon_id
 
   def index_controlled_term
     ids_to_index = [id]
@@ -11,5 +13,14 @@ class ControlledTermTaxon < ActiveRecord::Base
       ids_to_index += controlled_term.attrs.map(&:id)
     end
     ControlledTerm.elastic_index!( ids: ids_to_index.uniq )
+    true
   end
+
+  def reassess_annotations_after_save_later
+    Annotation.delay( priority: INTEGRITY_PRIORITY, queue: "slow",
+      unique_hash: { "Annotation::reassess_annotations_for_attribute_id": controlled_term_id } ).
+      reassess_annotations_for_attribute_id( controlled_term_id )
+    true
+  end
+
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -375,7 +375,8 @@ class Observation < ActiveRecord::Base
              :update_mappable,
              :set_captive,
              :set_taxon_photo,
-             :create_observation_review
+             :create_observation_review,
+             :reassess_annotations
   after_create :set_uri, :update_user_counter_caches
   before_destroy :keep_old_taxon_id
   after_destroy :refresh_lists_after_destroy, :refresh_check_lists,
@@ -2520,6 +2521,14 @@ class Observation < ActiveRecord::Base
     return true unless taxon_id_was.blank?
     return true unless editing_user_id && editing_user_id == user_id
     ObservationReview.where( observation_id: id, user_id: user_id ).first_or_create.touch
+    true
+  end
+
+  def reassess_annotations
+    return true unless taxon_id_changed?
+    annotations.each do |a|
+      a.destroy unless a.valid?
+    end
     true
   end
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -426,6 +426,10 @@ class Taxon < ActiveRecord::Base
     Identification.delay( priority: INTEGRITY_PRIORITY, queue: "slow",
       unique_hash: { "Identification::update_disagreement_identifications_for_taxon": id }).
       update_disagreement_identifications_for_taxon(id)
+    annotation_taxon_ids_to_reassess = [ancestry_was.to_s.split( "/" ).map(&:to_i), id].flatten.compact.sort
+    Annotation.delay( priority: INTEGRITY_PRIORITY, queue: "slow",
+      unique_hash: { "Annotation::reassess_annotations_for_taxon_ids": annotation_taxon_ids_to_reassess.join( "-" ) } ).
+      reassess_annotations_for_taxon_ids( annotation_taxon_ids_to_reassess )
     true
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2894,6 +2894,7 @@ en:
     Projects let you pool your observations with other people on %{site_name}.
     Whether you're starting a citizen science effort or keeping tabs on
     the birds in your neighborhood, Projects are the way to go.
+  projects_from_everywhere: Projects from Everywhere
   projects_from_place: "Projects from %{place}"
   projects_in_x: "Projects in %{x}"
   projects_you_admin: Projects You Admin

--- a/db/migrate/20180518231918_add_foreign_key_indices_to_annotations.rb
+++ b/db/migrate/20180518231918_add_foreign_key_indices_to_annotations.rb
@@ -1,0 +1,7 @@
+class AddForeignKeyIndicesToAnnotations < ActiveRecord::Migration
+  def change
+    add_index :annotations, :controlled_attribute_id
+    add_index :annotations, :controlled_value_id
+    add_index :annotations, :user_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6463,10 +6463,31 @@ CREATE INDEX fk_flags_user ON flags USING btree (user_id);
 
 
 --
+-- Name: index_annotations_on_controlled_attribute_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_annotations_on_controlled_attribute_id ON annotations USING btree (controlled_attribute_id);
+
+
+--
+-- Name: index_annotations_on_controlled_value_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_annotations_on_controlled_value_id ON annotations USING btree (controlled_value_id);
+
+
+--
 -- Name: index_annotations_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_annotations_on_resource_id_and_resource_type ON annotations USING btree (resource_id, resource_type);
+
+
+--
+-- Name: index_annotations_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_annotations_on_user_id ON annotations USING btree (user_id);
 
 
 --
@@ -9309,4 +9330,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180501172628');
 INSERT INTO schema_migrations (version) VALUES ('20180504213719');
 
 INSERT INTO schema_migrations (version) VALUES ('20180518192353');
+
+INSERT INTO schema_migrations (version) VALUES ('20180518231918');
 


### PR DESCRIPTION
Removes taxon-specific annotations when taxonomy or taxon associations change.