### PR TITLE
Use 403 Forbidden status  when returning permission errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -365,7 +365,7 @@ class ApplicationController < ActionController::Base
           return redirect_to record
         end
         format.json do
-          return render :json => {:error => msg}
+          return render json: { error: msg }, status: :forbidden
         end
       end
     end
@@ -380,7 +380,7 @@ class ApplicationController < ActionController::Base
           return redirect_to @guide
         end
         format.json do
-          return render :json => {:error => msg}
+          return render json: { error: msg }, status: :forbidden
         end
       end
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -116,7 +116,7 @@ class CommentsController < ApplicationController
           redirect_to @comment
         end
         format.json do
-          render :json => {:error => msg}
+          render :json => {:error => msg}, status: :forbidden
         end
       end
       return
@@ -172,7 +172,7 @@ class CommentsController < ApplicationController
           redirect_to @comment
         end
         format.json do
-          render :json => {:error => msg}
+          render :json => {:error => msg}, status: :forbidden
         end
       end
       return 

--- a/app/controllers/listed_taxa_controller.rb
+++ b/app/controllers/listed_taxa_controller.rb
@@ -55,7 +55,7 @@ class ListedTaxaController < ApplicationController
               :errors => msg,
               :full_messages => msg
             },
-            :status => :unprocessable_entity,
+            :status => :forbidden,
             :status_text => msg
         end
       end
@@ -159,7 +159,7 @@ class ListedTaxaController < ApplicationController
           return redirect_to lists_path
         end
         format.json do
-          return render(:json => {:error => msg})
+          return render(:json => {:error => msg}, status: :forbidden)
         end
       end
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -125,7 +125,7 @@ class MessagesController < ApplicationController
           flash[:error] = msg
           return redirect_back_or_default(messages_url)
         end
-        format.json { render :json => {:error => msg} }
+        format.json { render :json => {:error => msg}, status: :forbidden }
       end
     end
   end

--- a/app/controllers/observation_sounds_controller.rb
+++ b/app/controllers/observation_sounds_controller.rb
@@ -113,7 +113,7 @@ class ObservationSoundsController < ApplicationController
           return redirect_to record
         end
         format.json do
-          return render :json => {:error => msg}
+          return render :json => {:error => msg}, status: :forbidden
         end
       end
       return false

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -733,7 +733,7 @@ class ObservationsController < ApplicationController
           redirect_to(@observation || observations_path)
         end
         format.json do
-          render :status => :unprocessable_entity, :json => {:error => msg}
+          render :status => :forbidden, :json => {:error => msg}
         end
       end
       return
@@ -1449,7 +1449,7 @@ class ObservationsController < ApplicationController
           redirect_back_or_default @observation
         end
         format.json do
-          render :status => 401, :json => {:error => msg}
+          render :status => :forbidden, :json => {:error => msg}
         end
       end
       return
@@ -1923,7 +1923,7 @@ class ObservationsController < ApplicationController
       return
     end
     if flow_task.user_id != current_user.id
-      render status: :unprocessable_entity, text: "You don't have permission to do that"
+      render status: :forbidden, text: "You don't have permission to do that"
       return
     end
     if flow_task.outputs.exists?
@@ -2502,7 +2502,7 @@ class ObservationsController < ApplicationController
           return redirect_to @observation
         end
         format.json do
-          return render :json => {:error => msg}
+          return render :json => {:error => msg}, status: :forbidden
         end
       end
     end

--- a/spec/controllers/observation_photos_controller_api_spec.rb
+++ b/spec/controllers/observation_photos_controller_api_spec.rb
@@ -34,7 +34,7 @@ shared_examples_for "an ObservationPhotosController" do
       other_o = make_research_grade_observation
       other_p = other_o.photos.first
       post :create, format: :json, observation_photo: { observation_id: observation.id, photo_id: other_p.id }
-      expect( response ).not_to be_success
+      expect( response.status ).to eq 403
       observation.reload
       expect( observation.photos ).to be_blank
     end
@@ -107,11 +107,18 @@ shared_examples_for "an ObservationPhotosController" do
     end
   end
 
-  it "should destroy" do
-    p = LocalPhoto.make!(:user => user)
-    op = make_observation_photo(:photo => p, :observation => observation)
-    delete :destroy, :format => :json, :id => op.id
-    expect(ObservationPhoto.find_by_id(op.id)).to be_blank
+  describe "destroy" do
+    it "should destroy" do
+      p = LocalPhoto.make!(:user => user)
+      op = make_observation_photo(:photo => p, :observation => observation)
+      delete :destroy, :format => :json, :id => op.id
+      expect(ObservationPhoto.find_by_id(op.id)).to be_blank
+    end
+    it "should return 403 Forbidden if user doesn't own the observation" do
+      op = make_observation_photo
+      delete :destroy, format: :json, id: op.id
+      expect( response.status ).to eq 403
+    end
   end
 
 end


### PR DESCRIPTION
Hopefully this won't be too disruptive, but I suspect it will change some response statuses from the API.