### PR TITLE
Locale priority for common names

### DIFF
--- a/app/controllers/identifications_controller.rb
+++ b/app/controllers/identifications_controller.rb
@@ -131,6 +131,12 @@ class IdentificationsController < ApplicationController
       end
       format.json do
         pagination_headers_for( @identifications )
+        @identifications.each do |i|
+          i.taxon.current_user = current_user if i.taxon && current_user
+          i.observation.taxon.current_user = current_user if i.observation.taxon && current_user
+          i.observation.localize_place = current_user.try(:place) || @site.place
+          i.observation.localize_locale = current_user.try(:locale) || @site.locale
+        end
         taxon_options = {
           only: [:id, :name, :rank],
           methods: [:default_name, :photo_url, :iconic_taxon_name]

--- a/app/models/taxon_name.rb
+++ b/app/models/taxon_name.rb
@@ -227,27 +227,19 @@ class TaxonName < ActiveRecord::Base
       place_names = []
     end
     locale = options[:locale]
+    locale = options[:user].try(:locale) if locale.blank?
     locale = options[:site].try(:locale) if locale.blank?
     locale = I18n.locale if locale.blank?
     language_name = language_for_locale( locale )
     locale_names = common_names.select {|n| n.localizable_lexicon == language_name }
-    # unknames = common_names.select {|n| n.lexicon.blank? || n.lexicon.downcase == 'unspecified' }
 
     # We want Maori names to show up in New Zealand even for English speakers, but we don't want North American English names to show in Mexcio
-
     locale_and_place_names = place_names.select {|n| n.localizable_lexicon == language_name }
     
     if locale_and_place_names.length > 0
-      # puts "choosing locale and place name"
       locale_and_place_names.first
     elsif locale_names.length > 0
-      # puts "choosing locale name"
       locale_names.first
-    # elsif place_names.length > 0
-    #   puts "choosing place name"
-    #   place_names.first
-    else
-      # puts "not choosing any name"
     end
   end
 

--- a/app/models/taxon_name.rb
+++ b/app/models/taxon_name.rb
@@ -229,17 +229,25 @@ class TaxonName < ActiveRecord::Base
     locale = options[:locale]
     locale = options[:site].try(:locale) if locale.blank?
     locale = I18n.locale if locale.blank?
-    language_name = language_for_locale( locale ) || "english"
+    language_name = language_for_locale( locale )
     locale_names = common_names.select {|n| n.localizable_lexicon == language_name }
-    engnames = common_names.select {|n| n.is_english? }
-    unknames = common_names.select {|n| n.lexicon.blank? || n.lexicon.downcase == 'unspecified' }
+    # unknames = common_names.select {|n| n.lexicon.blank? || n.lexicon.downcase == 'unspecified' }
+
+    # We want Maori names to show up in New Zealand even for English speakers, but we don't want North American English names to show in Mexcio
+
+    locale_and_place_names = place_names.select {|n| n.localizable_lexicon == language_name }
     
-    if place_names.length > 0
-      place_names.first
+    if locale_and_place_names.length > 0
+      # puts "choosing locale and place name"
+      locale_and_place_names.first
     elsif locale_names.length > 0
+      # puts "choosing locale name"
       locale_names.first
-    elsif unknames.length > 0
-      unknames.first
+    # elsif place_names.length > 0
+    #   puts "choosing place name"
+    #   place_names.first
+    else
+      # puts "not choosing any name"
     end
   end
 

--- a/app/models/taxon_name.rb
+++ b/app/models/taxon_name.rb
@@ -212,19 +212,23 @@ class TaxonName < ActiveRecord::Base
     common_names = common_names.sort_by{|tn| [tn.position, tn.id]}
     
     if place
-      place_names = common_names.select{|tn| tn.place_taxon_names.detect{|ptn| ptn.place_id == place.id}}
-      if place_names.blank?
+      exact_place_names = common_names.select{|tn| tn.place_taxon_names.detect{|ptn| ptn.place_id == place.id}}
+      place_names = []
+      if exact_place_names.blank?
         place_names = common_names.select{|tn| tn.place_taxon_names.detect{|ptn| 
           place.self_and_ancestor_ids.include?(ptn.place_id)
         }}
       end
-      place_names = place_names.sort_by {|tn|
+      name_sorter = Proc.new do |tn|
         ptn = tn.place_taxon_names.detect{|ptn| ptn.place_id == place.id}
         ptn ||= tn.place_taxon_names.detect{|ptn| place.self_and_ancestor_ids.include?(ptn.place_id)}
         [ptn.position, tn.position, tn.id]
-      }
+      end
+      place_names = place_names.sort_by( &name_sorter )
+      exact_place_names = exact_place_names.sort_by( &name_sorter )
     else
       place_names = []
+      exact_place_names = []
     end
     locale = options[:locale]
     locale = options[:user].try(:locale) if locale.blank?
@@ -235,8 +239,13 @@ class TaxonName < ActiveRecord::Base
 
     # We want Maori names to show up in New Zealand even for English speakers, but we don't want North American English names to show in Mexcio
     locale_and_place_names = place_names.select {|n| n.localizable_lexicon == language_name }
+    exact_locale_and_place_names = exact_place_names.select {|n| n.localizable_lexicon == language_name }
     
-    if locale_and_place_names.length > 0
+    if exact_locale_and_place_names.length > 0
+      exact_locale_and_place_names.first
+    elsif exact_place_names.length > 0
+      exact_place_names.first
+    elsif locale_and_place_names.length > 0
       locale_and_place_names.first
     elsif locale_names.length > 0
       locale_names.first

--- a/spec/controllers/identifications_controller_api_spec.rb
+++ b/spec/controllers/identifications_controller_api_spec.rb
@@ -239,7 +239,7 @@ shared_examples_for "an IdentificationsController" do
     end
     it "should include locale-specific taxon name" do
       ident = Identification.make!( user: user, observation: make_research_grade_observation( taxon: @Calypte_anna ) )
-      tn = TaxonName.make!( taxon: ident.taxon, lexicon: TaxonName::LEXICONS["Spanish"] )
+      tn = TaxonName.make!( taxon: ident.taxon, lexicon: TaxonName::LEXICONS[:SPANISH] )
       user.update_attributes( locale: "es" )
       get :by_login, format: :json, login: user.login
       json = JSON.parse( response.body )
@@ -249,9 +249,9 @@ shared_examples_for "an IdentificationsController" do
     it "should include place-specific taxon name" do
       ident = Identification.make!( user: user, observation: make_research_grade_observation( taxon: @Calypte_anna ) )
       place = Place.make!
-      tn = TaxonName.make!( taxon: ident.taxon )
+      tn = TaxonName.make!( taxon: ident.taxon, lexicon: TaxonName::LEXICONS[:ENGLISH] )
       ptn = PlaceTaxonName.make!( taxon_name: tn, place: place )
-      user.update_attributes( place: place )
+      user.update_attributes( place: place, locale: "en" )
       get :by_login, format: :json, login: user.login
       json = JSON.parse( response.body )
       json_ident = json.detect{|i| i["id"] == ident.id }
@@ -259,7 +259,7 @@ shared_examples_for "an IdentificationsController" do
     end
     it "should include locale-specific observation taxon name" do
       ident = Identification.make!( user: user, observation: make_research_grade_observation( taxon: @Calypte_anna ) )
-      tn = TaxonName.make!( taxon: ident.observation.taxon, lexicon: TaxonName::LEXICONS["Spanish"] )
+      tn = TaxonName.make!( taxon: ident.observation.taxon, lexicon: TaxonName::LEXICONS[:SPANISH] )
       user.update_attributes( locale: "es" )
       get :by_login, format: :json, login: user.login
       json = JSON.parse( response.body )

--- a/spec/models/taxon_name_spec.rb
+++ b/spec/models/taxon_name_spec.rb
@@ -146,13 +146,13 @@ describe TaxonName, "choose_common_name" do
     expect( TaxonName.choose_common_name(tn_en.taxon.taxon_names, locale: :es) ).to be_blank
   end
 
-  it "should choose a locale=specific name for traditional Chinese" do
+  it "should choose a locale-specific name for traditional Chinese" do
     tn_en = TaxonName.make!(:name => "Queen's Wreath", :lexicon => "English", :taxon => t)
     tn_zh_tw = TaxonName.make!(:name => "藍花藤", :lexicon => "Chinese (traditional)", :taxon => t)
     expect(TaxonName.choose_common_name([tn_en, tn_zh_tw], :locale => "zh-TW")).to eq tn_zh_tw
   end
 
-  it "should choose a locale=specific name for simplified Chinese" do
+  it "should choose a locale-specific name for simplified Chinese" do
     tn_en = TaxonName.make!(:name => "Queen's Wreath", :lexicon => "English", :taxon => t)
     tn_zh_cn = TaxonName.make!(:name => "藍花藤", :lexicon => "Chinese (simplified)", :taxon => t)
     expect(TaxonName.choose_common_name([tn_en, tn_zh_cn], :locale => "zh-CN")).to eq tn_zh_cn
@@ -161,7 +161,7 @@ describe TaxonName, "choose_common_name" do
   it "should choose a place-specific name" do
     california = Place.make!
     oregon = Place.make!
-    tn_gl = TaxonName.make!(:name => "bay tree", :lexicon => "English", :taxon => t)
+    tn_en = TaxonName.make!(:name => "bay tree", :lexicon => "English", :taxon => t)
     tn_ca = TaxonName.make!(:name => "California bay laurel", :lexicon => "English", :taxon => t)
     ptn_ca = PlaceTaxonName.make!(:taxon_name => tn_ca, :place => california)
     tn_or = TaxonName.make!(:name => "Oregon myrtle", :lexicon => "English", :taxon => t)
@@ -169,42 +169,51 @@ describe TaxonName, "choose_common_name" do
     t.reload
     expect(TaxonName.choose_common_name(t.taxon_names, :place => oregon)).to eq tn_or
     expect(TaxonName.choose_common_name(t.taxon_names, :place => california)).to eq tn_ca
-    expect(TaxonName.choose_common_name(t.taxon_names)).to eq tn_gl
-  end
-  it "should choose a place-specific name regardless of locale" do
-    california = Place.make!
-    oregon = Place.make!
-    tn_gl = TaxonName.make!(:name => "bay tree", :lexicon => "English", :taxon => t)
-    tn_es = TaxonName.make!(:name => "Laurel de California", :lexicon => "Spanish", :taxon => t)
-    # ptn_ca = PlaceTaxonName.make!(:taxon_name => tn_ca, :place => california)
-    tn_or = TaxonName.make!(:name => "Oregon myrtle", :lexicon => "English", :taxon => t)
-    ptn_or = PlaceTaxonName.make!(:taxon_name => tn_or, :place => oregon)
-    t.reload
-    expect(TaxonName.choose_common_name(t.taxon_names, :place => oregon, :locale => :es)).to eq tn_or
+    expect(TaxonName.choose_common_name(t.taxon_names)).to eq tn_en
   end
 
   it "should pick a place-specific name for a parent of the requested place" do
     california = Place.make!
     oregon = Place.make!
-    tn_gl = TaxonName.make!(:name => "bay tree", :lexicon => "English", :taxon => t)
+    tn_en = TaxonName.make!(:name => "bay tree", :lexicon => "English", :taxon => t)
     tn_ca = TaxonName.make!(:name => "California bay laurel", :lexicon => "English", :taxon => t)
     ptn_ca = PlaceTaxonName.make!(:taxon_name => tn_ca, :place => california)
     t.reload
     p = Place.make!(:parent => california, :name => "Alameda County")
     expect(p.self_and_ancestor_ids).to include(california.id)
     expect(TaxonName.choose_common_name(t.taxon_names, :place => p)).to eq tn_ca
-    expect(TaxonName.choose_common_name(t.taxon_names)).to eq tn_gl
+    expect(TaxonName.choose_common_name(t.taxon_names)).to eq tn_en
   end
 
   it "should pick names based on the site's place" do
     california = Place.make!
     oregon = Place.make!
-    tn_gl = TaxonName.make!(name: "bay tree", lexicon: "English", taxon: t)
+    tn_en = TaxonName.make!(name: "bay tree", lexicon: "English", taxon: t)
     tn_es = TaxonName.make!(name: "Laurel de California", lexicon: "Spanish", taxon: t)
     tn_or = TaxonName.make!(name: "Oregon myrtle", lexicon: "English", taxon: t)
     ptn_or = PlaceTaxonName.make!(taxon_name: tn_or, place: oregon)
     t.reload
     Site.default.update_attributes( place: oregon )
     expect(TaxonName.choose_common_name( t.taxon_names, site: Site.default ) ).to eq tn_or
+  end
+
+  it "should favor a locale within a place" do
+    p = Place.make!
+    tn_en = TaxonName.make!( name: "bay tree", lexicon: "English", taxon: t )
+    tn_es = TaxonName.make!( name: "Laurel de California", lexicon: "Spanish", taxon: t )
+    ptn_tn_en = PlaceTaxonName.make!( taxon_name: tn_en, place: p, position: 1 )
+    ptn_tn_es = PlaceTaxonName.make!( taxon_name: tn_es, place: p, position: 2 )
+    t.reload
+    expect( TaxonName.choose_common_name( t.taxon_names, place: p, locale: "es" ) ).to eq tn_es
+  end
+
+  it "should not pick a name if it doesn't match the locale even if it matches the place" do
+    p = Place.make!
+    tn_en = TaxonName.make!( name: "bay tree", lexicon: "English", taxon: t )
+    tn_es = TaxonName.make!( name: "Laurel de California", lexicon: "Spanish", taxon: t )
+    ptn_tn_en = PlaceTaxonName.make!( taxon_name: tn_en, place: p, position: 1 )
+    ptn_tn_es = PlaceTaxonName.make!( taxon_name: tn_es, place: p, position: 2 )
+    t.reload
+    expect( TaxonName.choose_common_name( t.taxon_names, place: p, locale: "ja" ) ).to be_blank
   end
 end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -377,12 +377,6 @@ describe Taxon, "common_name" do
     tn_un = TaxonName.make!(:taxon => t, :name => "run away!", :lexicon => 'unspecified')
     expect(t.common_name).to eq(tn_en)
   end
-  it "should default to unknown if no English" do
-    t = Taxon.make!
-    tn_es = TaxonName.make!(:taxon => t, :name => "Diablo Rojo", :lexicon => TaxonName::LEXICONS[:SPANISH])
-    tn_un = TaxonName.make!(:taxon => t, :name => "run away!", :lexicon => 'unspecified')
-    expect(t.common_name).to eq(tn_un)
-  end
   it "should not default to first common if no English or unknown" do
     t = Taxon.make!
     tn_es = TaxonName.make!(:taxon => t, :name => "Diablo Rojo", :lexicon => TaxonName::LEXICONS[:SPANISH])


### PR DESCRIPTION
Some more complications for common name choice (see https://www.inaturalist.org/journal/bodofzt/18372-canada-usa-north-america and https://groups.google.com/d/topic/inaturalist/P8iNMY0WYNM/discussion). Now priority looks like this:

1. Name that matches both language and the exact place (e.g. user's place is Mexico and name's place is Mexico, but not user's place is Mexico and name's place is North America)
1. Name that matches the exact place
1. Name that matches locale and place (including ancestor places)
1. Name that matches locale

One things that are no longer happening are showing names that match an ancestor place but not a locale, e.g. showing a Mexican user an English name b/c that name was associated with North America. Another is that we are not showing a language from an unknown locale by default, and there is less reliance on English as a default locale.