### PR TITLE
Inactive taxa validations

### DIFF
--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -249,7 +249,7 @@ class TaxaController < ApplicationController
       if parent = @taxon.parent
         if @taxon.is_active && !parent.is_active && (taxon_change = parent.taxon_changes.where( "committed_on IS NULL" ).first)
           flash[:notice] += " Heads up: the parent of this active taxon is inactive " + 
-            "but its the output of this <a href='/taxa_changes/#{taxon_change.id}'>" + 
+            "but its the output of this <a href='/taxon_changes/#{taxon_change.id}'>" + 
             "draft taxon change</a> that we assume you'll commit shortly."
         end
       end
@@ -286,7 +286,7 @@ class TaxaController < ApplicationController
       end
       if @taxon.is_active && !@taxon.parent.is_active && (taxon_change = @taxon.parent.taxon_changes.where( "committed_on IS NULL" ).first)
         flash[:notice] += " Heads up: the parent of this active taxon is inactive " + 
-          "but its the output of this <a href='/taxa_changes/#{taxon_change.id}'>" + 
+          "but its the output of this <a href='/taxon_changes/#{taxon_change.id}'>" + 
           "draft taxon change</a> that we assume you'll commit shortly."
       end
       Taxon.refresh_es_index

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -246,10 +246,12 @@ class TaxaController < ApplicationController
           "#{locked_ancestor.name}</a>).  Please consider merging this " + 
           "into an existing taxon instead."
       end
-      if @taxon.is_active && !@taxon.parent.is_active && (taxon_change = @taxon.parent.taxon_changes.where( "committed_on IS NULL" ).first)
-        flash[:notice] += " Heads up: the parent of this active taxon is inactive " + 
-          "but its the output of this <a href='/taxa_changes/#{taxon_change.id}'>" + 
-          "draft taxon change</a> that we assume you'll commit shortly."
+      if parent = @taxon.parent
+        if @taxon.is_active && !parent.is_active && (taxon_change = parent.taxon_changes.where( "committed_on IS NULL" ).first)
+          flash[:notice] += " Heads up: the parent of this active taxon is inactive " + 
+            "but its the output of this <a href='/taxa_changes/#{taxon_change.id}'>" + 
+            "draft taxon change</a> that we assume you'll commit shortly."
+        end
       end
       redirect_to :action => 'show', :id => @taxon
     else

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -246,6 +246,11 @@ class TaxaController < ApplicationController
           "#{locked_ancestor.name}</a>).  Please consider merging this " + 
           "into an existing taxon instead."
       end
+      if @taxon.is_active && !@taxon.parent.is_active && (taxon_change = @taxon.parent.taxon_changes.where( "committed_on IS NULL" ).first)
+        flash[:notice] += " Heads up: the parent of this active taxon is inactive " + 
+          "but its the output of this <a href='/taxa_changes/#{taxon_change.id}'>" + 
+          "draft taxon change</a> that we assume you'll commit shortly."
+      end
       redirect_to :action => 'show', :id => @taxon
     else
       render :action => 'new'
@@ -276,6 +281,11 @@ class TaxaController < ApplicationController
           "locked taxon (<a href='/taxa/#{locked_ancestor.id}'>" + 
           "#{locked_ancestor.name}</a>).  Please consider merging this " + 
           "into an existing taxon instead."
+      end
+      if @taxon.is_active && !@taxon.parent.is_active && (taxon_change = @taxon.parent.taxon_changes.where( "committed_on IS NULL" ).first)
+        flash[:notice] += " Heads up: the parent of this active taxon is inactive " + 
+          "but its the output of this <a href='/taxa_changes/#{taxon_change.id}'>" + 
+          "draft taxon change</a> that we assume you'll commit shortly."
       end
       Taxon.refresh_es_index
       redirect_to taxon_path(@taxon)

--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -165,7 +165,7 @@ class TaxonChangesController < ApplicationController
       return
     end
     
-    if @taxon_change.active_children_conflict? ####unless move children to output option
+    if !@taxon_chante.move_children? && @taxon_change.active_children_conflict?
       flash[:error] = "Input taxon cannot have active children, move them first, or select the 'Move children to output?' option".html_safe
       redirect_back_or_default( taxon_changes_path )
       return

--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -166,8 +166,8 @@ class TaxonChangesController < ApplicationController
     end
     
     if !@taxon_change.move_children? && @taxon_change.active_children_conflict?
-      flash[:error] = "Input taxon cannot have active children, move them first, or select the 'Move children to output?' option".html_safe
-      redirect_back_or_default( taxon_changes_path )
+      flash[:error] = "Input taxon cannot have active children, move them first, or select the 'Move children to output?' option"
+      redirect_back_or_default @taxon_change
       return
     end
     

--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -165,6 +165,12 @@ class TaxonChangesController < ApplicationController
       return
     end
     
+    if @taxon_change.active_children_conflict? ####unless move children to output option
+      flash[:error] = "Input taxon cannot have active children, move them first, or select the 'Move children to output?' option".html_safe
+      redirect_back_or_default( taxon_changes_path )
+      return
+    end
+    
     @taxon_change.committer = current_user
     @taxon_change.commit
     

--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -165,7 +165,7 @@ class TaxonChangesController < ApplicationController
       return
     end
     
-    if !@taxon_chante.move_children? && @taxon_change.active_children_conflict?
+    if !@taxon_change.move_children? && @taxon_change.active_children_conflict?
       flash[:error] = "Input taxon cannot have active children, move them first, or select the 'Move children to output?' option".html_safe
       redirect_back_or_default( taxon_changes_path )
       return

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -930,7 +930,7 @@ class Taxon < ActiveRecord::Base
   def active_parent_if_active
     return if parent.nil? || !is_active
     
-    if !parent.is_active && parent.taxon_changes.where( "committed_on IS NULL" ).first.nil?
+    if !parent.is_active && ( !parent.taxon_change_taxa.map{|tct| tct.taxon_change.committed_on.nil? && ( ["TaxonSplit" || "TaxonMerge"].include? tct.taxon_change.type )}.any? || !parent.taxon_changes.map{|tc| tc.committed_on.nil? && tct.taxon_change.type == "TaxonSwap"}.any? )
       errors.add( self.name, "parents of active taxa must be active or the output of a draft taxon change" )
     end
   end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -926,12 +926,12 @@ class Taxon < ActiveRecord::Base
       errors.add(self.name, "inactive taxa must only have inactive children")
     end
   end
-  
+    
   def active_parent_if_active
     return if parent.nil? || !is_active
     
-    if !parent.is_active
-      errors.add(self.name, "active taxa must have active parent")
+    if !parent.is_active && parent.taxon_changes.where( "committed_on IS NULL" ).first.nil?
+      errors.add( self.name, "parents of active taxa must be active or the output of a draft taxon change" )
     end
   end
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -10,6 +10,9 @@ class Taxon < ActiveRecord::Base
   # Allow this taxon to be grafted to locked subtrees
   attr_accessor :skip_locks
   
+  # Allow this taxon to be grafted to complete subtrees
+  attr_accessor :skip_complete
+  
   # Allow this taxon to be inactivated despite having active children
   attr_accessor :skip_only_inactive_children_if_inactive
 
@@ -978,7 +981,7 @@ class Taxon < ActiveRecord::Base
   def graftable_if_complete
     return true unless ancestry_changed?
     ct = complete_taxon
-    if ct && ( current_user.blank? || !ct.taxon_curators.where( user: current_user ).exists? )
+    if !@skip_complete && ct && ( current_user.blank? || !ct.taxon_curators.where( user: current_user ).exists? )
       errors.add( :ancestry, "includes the complete taxon #{complete_taxon}. Contact the curators of that taxon to request changes." )
     end
     true

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -938,7 +938,7 @@ class Taxon < ActiveRecord::Base
       tct.taxon_change.committed_on.nil? &&
       ( ["TaxonSplit" || "TaxonMerge"].include? tct.taxon_change.type )
     }.any?
-    errors.add( self.name, "must have a parent that is active or the output of a draft taxon change" )
+    errors.add( self.name, "must have a parent that is active or the output of a draft taxon change to be active itself" )
   end
 
   def can_only_be_featured_if_photos

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -121,7 +121,8 @@ class TaxonChange < ActiveRecord::Base
   end
 
   class PermissionError < StandardError; end
-
+  class ActiveChildrenError < StandardError; end
+  
   # Override in subclasses
   def commit
     unless committable_by?( committer )

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -89,7 +89,12 @@ class TaxonChange < ActiveRecord::Base
   
   def rank_level_conflict?
     return false unless ["TaxonSwap", "TaxonMerge"].include? type
-    return false unless input_taxa_rank_level_conflict = input_taxa[0].descendants.where( "rank_level >= ?", output_taxa[0].rank_level ).first
+    if type == "TaxonSwap"
+      input_taxa_rank_level_conflict = input_taxa[0].descendants.where( "rank_level >= ?", output_taxa[0].rank_level ).first
+    elsif type == "TaxonMerge"
+      input_taxa_rank_level_conflict  = output_taxa.map{|ot| ot.descendants.where( "rank_level >= ?", input_taxa[0].rank_level ).first }.first
+    end
+    return false unless input_taxa_rank_level_conflict 
     input_taxa_rank_level_conflict
   end
 

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -363,7 +363,9 @@ class TaxonChange < ActiveRecord::Base
     end
     move_child = Proc.new do |child|
       child.skip_locks = true
+      child.skip_complete = true
       output_taxon.skip_locks = true
+      output_taxon.skip_complete = true
       child.move_to_child_of( output_taxon )
     end
     if target_input_taxon.rank_level &&

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -94,7 +94,7 @@ class TaxonChange < ActiveRecord::Base
   end
 
   def active_children_conflict?
-    return false if move_children? || !input_taxa[0].children.any?{ |e| e.is_active }
+    return false if move_children? || !input_taxa.map{|t| t.children.any?{ |e| e.is_active }}.any?
     return true
   end
   

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -148,7 +148,7 @@ class TaxonChange < ActiveRecord::Base
       raise RankLevelError, "Output taxon rank level not coarser than all input taxon descendant rank levels"
       return
     end
-    input_taxa.each {|t| t.update_attribute(:is_active, false)}
+    input_taxa.each {|t| t.update_attributes(is_active: false, skip_only_inactive_children_if_inactive: move_children? )}
     output_taxa.each {|t| t.update_attribute(:is_active, true)}
     update_attribute(:committed_on, Time.now)
   end

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -88,14 +88,13 @@ class TaxonChange < ActiveRecord::Base
   end
   
   def rank_level_conflict?
-    return false unless type == "TaxonSwap"
+    return false unless ["TaxonSwap", "TaxonMerge"].include? type
     return false unless input_taxa_rank_level_conflict = input_taxa[0].descendants.where( "rank_level >= ?", output_taxa[0].rank_level ).first
     input_taxa_rank_level_conflict
   end
 
   def active_children_conflict?
-    return false unless type == "TaxonSwap"
-    return false unless input_taxa_active_children_conflict = input_taxa[0].children.any?{ |e| e.is_active }
+    return false if move_children? || !input_taxa[0].children.any?{ |e| e.is_active }
     return true
   end
   

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -96,7 +96,7 @@ class TaxonChange < ActiveRecord::Base
   def active_children_conflict?
     return false unless type == "TaxonSwap"
     return false unless input_taxa_active_children_conflict = input_taxa[0].children.any?{ |e| e.is_active }
-    input_taxa_active_children_conflict
+    return true
   end
   
   def committable_by?( u )
@@ -134,7 +134,6 @@ class TaxonChange < ActiveRecord::Base
 
   class PermissionError < StandardError; end
   class ActiveChildrenError < StandardError; end
-
   class RankLevelError < StandardError; end
 
   # Override in subclasses

--- a/spec/models/taxon_merge_spec.rb
+++ b/spec/models/taxon_merge_spec.rb
@@ -15,6 +15,15 @@ def setup_taxon_merge
   @merge.reload
 end
 
+def clean_taxon_merge
+  @merge.destroy
+  @input_taxon1.destroy
+  @input_taxon2.destroy
+  @input_taxon3.destroy
+  @output_taxon.destroy
+  @input_ancestor.destroy
+end
+
 describe "create" do
   it "should not allow a single input taxon" do
     setup_taxon_merge
@@ -106,6 +115,7 @@ describe TaxonMerge, "commit" do
   describe "for taxa with children" do
     before(:each) { enable_elastic_indexing( Observation, Identification ) }
     after(:each) { disable_elastic_indexing( Observation, Identification ) }
+    after(:each) { clean_taxon_merge }
 
     before(:each) do
       @merge.update_attributes( move_children: true )

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -231,7 +231,7 @@ describe Taxon, "updating" do
     expect(parent.errors).not_to be_blank
   end
   
-  it "should prevent updating a taxon to be inactive if it has active children" do #unless done by a taxon swap with the automatic thing checked
+  it "should prevent updating a taxon to be inactive if it has active children" do
     taxon = Taxon.make!(name: 'balderdash', rank: Taxon::GENUS )
     child = Taxon.make!(name: 'balderdash foo', rank: Taxon::SPECIES, parent: taxon )
     taxon.valid?
@@ -239,6 +239,16 @@ describe Taxon, "updating" do
     taxon.update_attributes( is_active: false )
     expect(taxon.errors).not_to be_blank
   end
+  
+  it "should allow updating a taxon to be inactive if it has active children but move children is checked" do
+    taxon = Taxon.make!(name: 'balderdash', rank: Taxon::GENUS )
+    child = Taxon.make!(name: 'balderdash foo', rank: Taxon::SPECIES, parent: taxon )
+    taxon.valid?
+    expect(taxon.errors).to be_blank
+    taxon.update_attributes( is_active: false, skip_only_inactive_children_if_inactive: true )
+    expect(taxon.errors).to be_blank
+  end
+  
   
   it "should prevent updating a taxon to be active if it has an inactive parent" do
     parent = Taxon.make!(name: 'balderdash', rank: Taxon::GENUS, is_active: false )

--- a/spec/models/taxon_swap_spec.rb
+++ b/spec/models/taxon_swap_spec.rb
@@ -364,6 +364,15 @@ describe TaxonSwap, "commit" do
       @swap.commit
     }.to raise_error TaxonChange::ActiveChildrenError
   end
+  
+  it "should not raise an error if input taxon has active children but move children is checked" do
+    child = Taxon.make!( rank: Taxon::GENUS, parent: @swap.input_taxon )
+    @swap.update_attributes( move_children: true )
+    expect {
+      @swap.commit
+    }.not_to raise_error TaxonChange::ActiveChildrenError
+  end
+  
 
   describe "for input taxa with reverted changes" do
     it "should not die in an infinite loop" do

--- a/spec/models/taxon_swap_spec.rb
+++ b/spec/models/taxon_swap_spec.rb
@@ -270,6 +270,7 @@ describe TaxonSwap, "commit" do
       @swap.commit
     }.to raise_error TaxonChange::PermissionError
   end
+  
   it "should raise an error if commiter is not a taxon curator of a complete ancestor of the output taxon" do
     superfamily = Taxon.make!( rank: Taxon::SUPERFAMILY, complete: true )
     tc = TaxonCurator.make!( taxon: superfamily )
@@ -277,6 +278,13 @@ describe TaxonSwap, "commit" do
     expect {
       @swap.commit
     }.to raise_error TaxonChange::PermissionError
+  end
+  
+  it "should raise an error if input taxon has active children" do
+    child = Taxon.make!( rank: Taxon::GENUS, parent: @swap.input_taxon )
+    expect {
+      @swap.commit
+    }.to raise_error TaxonChange::ActiveChildrenError
   end
 
   describe "for input taxa with reverted changes" do


### PR DESCRIPTION
The goal of this is to try to reduce the number of active taxa with ancestries that include inactive nodes by more strongly validating what curators can do. Specifically, this should make it so that:

1) taxon changes won't commit if the inputs have active children unless they are swaps/merges and 'move children' is checked (e.g. curator should manually move children before committing change)

1) active taxa can't be created/updated to be active with inactive parents (unless inactive parent is an output of a draft change since curators may have to manually move children to inactive output taxa before committing as described above)

2) taxa can't be updated to inactive if they have active children

@kueda I've done a pretty rigorous job testing this and playing with it on staging but would appreciate your feedback and any testing
