### PR TITLE
Taxon change validation updates

### DIFF
--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -160,7 +160,7 @@ class TaxonChangesController < ApplicationController
     
     @taxon = @taxon_change.rank_level_conflict?
     if @taxon
-      flash[:error] = "Output taxon rank level finer than rank level of input taxon #{view_context.link_to( @taxon.name, @taxon )}".html_safe
+      flash[:error] = "Output taxon rank level not coarser than rank level of active children of input taxon #{view_context.link_to( @taxon.name, @taxon )}".html_safe
       redirect_back_or_default( taxon_changes_path )
       return
     end

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -101,11 +101,13 @@ class TaxonChange < ActiveRecord::Base
   def active_children_conflict?
     return false if move_children?
     # inputs can't have active children
-    if ["TaxonSwap", "TaxonSplit"].include? type
+    if ["TaxonSwap", "TaxonSplit", "TaxonDrop"].include? type
       return false if !input_taxa.map{|t| t.children.any?{ |e| e.is_active }}.any?
     # unless they are also inputs
     elsif type == "TaxonMerge"
       return false if !input_taxa.map{|t| t.children.any?{ |e| e.is_active && (!input_taxa.pluck(:id).include? e.id) }}.any?
+    elsif type == "TaxonStage"
+      return false
     end
     return true
   end


### PR DESCRIPTION
Since adding the taxon change validations a few weeks ago, a few common legit use cases surfaced that the validations were preventing. They were:
1) merging a species and all its active spp into some other taxon - which is more efficient than multiple taxon changes - was prevented by the active children validation
2) swapping a sp into its synonymous ssp was prevented by the rank level validation
this branch contains caveats for both of those cases