### PR TITLE
Allow tables and lists in user text without adding excess whitespace

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -57,7 +57,7 @@ class Post < ActiveRecord::Base
   ALLOWED_TAGS = %w(
     a abbr acronym b blockquote br cite code dl dt em embed h1 h2 h3 h4 h5 h6 hr i
     iframe img li object ol p param pre s small strike strong sub sup tt ul
-    table tr td th
+    table thead tfoot tr td th
     audio source
     div
   )


### PR DESCRIPTION
Closes #1934, but is specific to places where we're parsing user text with Rails, e.g. journal posts and taxon changes. Table and list rendering for comments and obs descriptions remains unchanged.