### PR TITLE
List leaves roll up

### DIFF
--- a/app/models/life_list.rb
+++ b/app/models/life_list.rb
@@ -23,6 +23,15 @@ class LifeList < List
   #
   def add_taxon(taxon, options = {})
     taxon_id = taxon.is_a?(Taxon) ? taxon.id : taxon
+    
+    # Make sure the parent species is added for infraspecies
+    taxon = taxon.is_a?(Taxon) ? taxon : Taxon.find(taxon_id)
+    if taxon.rank_level < Taxon::SPECIES_LEVEL && taxon.species
+      unless listed_taxon = listed_taxa.find_by_taxon_id(taxon.species.id)
+        lt = ListedTaxon.create(options.merge(list: self, taxon_id: taxon.species.id))
+      end
+    end
+    
     if listed_taxon = listed_taxa.find_by_taxon_id(taxon_id)
       return listed_taxon
     end

--- a/app/models/life_list.rb
+++ b/app/models/life_list.rb
@@ -26,7 +26,7 @@ class LifeList < List
     
     # Make sure the parent species is added for infraspecies
     taxon = taxon.is_a?(Taxon) ? taxon : Taxon.find(taxon_id)
-    if taxon.rank_level < Taxon::SPECIES_LEVEL && taxon.species
+    if !taxon.rank_level.nil? && taxon.rank_level < Taxon::SPECIES_LEVEL && taxon.species
       unless listed_taxon = listed_taxa.find_by_taxon_id(taxon.species.id)
         lt = ListedTaxon.create(options.merge(list: self, taxon_id: taxon.species.id))
       end

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -371,7 +371,7 @@ class ListedTaxon < ActiveRecord::Base
     return true unless l.is_a?(LifeList)
     return true unless l.user
     return true unless l.user.life_list_id == self.list_id 
-    User.where(id: l.user_id).update_all(life_list_taxa_count: l.listed_taxa.count)
+    User.where(id: l.user_id).update_all( life_list_taxa_count: l.listed_taxa.with_leaves( l.listed_taxa.to_sql ).confirmed.count )
     true
   end
   

--- a/app/views/lists/by_login.html.erb
+++ b/app/views/lists/by_login.html.erb
@@ -96,13 +96,20 @@
               <%= truncate(strip_tags(list.description =~ /^Every species seen by / ? list.description.gsub('Every species seen by', t(:every_species_seen_by)) : list.description), :length => 75) %>
               <%= link_to "#{t(:view)} &raquo;".html_safe, list_path(list), :style => "white-space: nowrap" %>
             </div>
-
             <div class="barchart">
-              <%= render :partial => "shared/barchart_datum", :locals => { 
-                :value => list.listed_taxa.where("last_observation_id IS NOT NULL").count, 
-                :max => list.listed_taxa.count, 
-                :label_text => t(:of) + " #{list.listed_taxa.count} " + t(:observed).downcase,
-                :min_value_label_width => 30 } %>
+              <% if @life_list.id == list.id %>
+                <%= render :partial => "shared/barchart_datum", :locals => { 
+                  :value => list.listed_taxa.with_leaves(list.listed_taxa.to_sql).confirmed.count, 
+                  :max => list.listed_taxa.with_leaves(list.listed_taxa.to_sql).confirmed.count, 
+                  :label_text => t(:taxa).downcase,
+                  :min_value_label_width => 30 } %>
+              <% else %>
+                <%= render :partial => "shared/barchart_datum", :locals => { 
+                  :value => list.listed_taxa.where("last_observation_id IS NOT NULL").count, 
+                  :max => list.listed_taxa.count, 
+                  :label_text => t(:of) + " #{list.listed_taxa.count} " + t(:observed).downcase,
+                  :min_value_label_width => 30 } %>
+              <% end %>    
               <div class="clear"></div>
             </div>
             

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -208,11 +208,19 @@
               &nbsp;
             </div>
             <div class="barchart">
-              <%= render :partial => "shared/barchart_datum", :locals => {
-                :value => @total_observed_taxa,
-                :max => @total_listed_taxa,
-                :label_text => "#{t(:of)} #{@total_listed_taxa} #{t(:taxa_observed)}",
-                :min_value_label_width => 30 } %>
+              <% if @observed -%>
+                <%= render :partial => "shared/barchart_datum", :locals => {
+                  :value => @total_listed_taxa,
+                  :max => @total_listed_taxa,
+                  :label_text => t(:taxa).downcase,
+                  :min_value_label_width => 30 } %>
+              <% else -%>
+                <%= render :partial => "shared/barchart_datum", :locals => {
+                  :value => @total_observed_taxa,
+                  :max => @total_listed_taxa,
+                  :label_text => "#{t(:of)} #{@total_listed_taxa} #{t(:taxa_observed)}",
+                  :min_value_label_width => 30 } %>
+              <% end -%>
             </div>
           </a>
           <% for grouper, count in @iconic_taxon_counts.sort_by{ |_key, value| -1.0 * value }.to_h -%>

--- a/spec/models/life_list_spec.rb
+++ b/spec/models/life_list_spec.rb
@@ -23,7 +23,7 @@ describe LifeList do
       @list.reload
       expect(@list.taxon_ids).to include(@child.id)
   
-      new_child = Taxon.make!(:parent => @taxon)
+      new_child = Taxon.make!(:parent => @taxon, rank: Taxon::SUBSPECIES)
       obs.update_attributes(:taxon => new_child)
       @list.reload
       expect(@list.taxon_ids).not_to include(new_child.id)
@@ -31,6 +31,16 @@ describe LifeList do
       LifeList.reload_from_observations(@list)
       @list.reload
       expect(@list.taxon_ids).not_to include(@child.id)
+    end
+    
+    it "should add the species on reload if a subspecies was observed" do
+      @new_list = LifeList.make!
+      subspecies = Taxon.make!(parent: @taxon, rank: Taxon::SUBSPECIES)
+      o = Observation.make!(user: @new_list.user, taxon: subspecies)
+      expect(@new_list.taxon_ids).not_to include(@taxon.id)
+      LifeList.reload_from_observations(@new_list)
+      @new_list.reload
+      expect(@new_list.taxon_ids).to include(@taxon.id)
     end
 
     it "should add taxa from place" do


### PR DESCRIPTION
Made it so that the primary Life List listed taxa count defaults to the same way parts of the site that count taxa represented by observations (e.g. Explore Species tab) to try to reduce chronic confusion here. A better solution would be to replace LifeList functionality with something powered by observation/species_counts, but the community will probably insist on offering taxonomic sort and pagination functionality.

Somewhat motivated by https://github.com/inaturalist/inaturalist/issues/1808