### PR TITLE
ES index updates

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -1093,7 +1093,7 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
     'apply_project_rules_for', 'not_matching_project_rules_for', 'list_id',
     'taxon_ids', 'not_in_place', 'unobserved_by_user_id', 'radius', 'geo',
     'oauth_application_id', 'collection_preview', 'term_id', 'term_value_id',
-    'without_term_value_id', 'without_taxon_id', 'not_user_id' ];
+    'without_term_value_id', 'without_taxon_id', 'not_user_id', 'scaled', 'cache' ];
   gridTileSuffix = appendValidParamsToURL( gridTileSuffix, _.extend(
     options, { validParams: paramKeys, endpoint: "grid" } ));
   pointTileSuffix = appendValidParamsToURL( pointTileSuffix, _.extend(

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -719,13 +719,16 @@ class TaxaController < ApplicationController
       end
       obs
     else
-      filters = [ { exists: { field: "photos" } } ]
+      filters = [ { bool: { should: [
+        { exists: { field: "photos_count" } },
+        { exists: { field: "photos" } }
+      ]}}]
       unless params[:q].blank?
         filters << {
           multi_match: {
             query: params[:q],
             operator: "and",
-            fields: [ :description, "taxon.names.name", "user.login", "field_values.value" ]
+            fields: [ :description, "taxon.names.name", "taxon.names_*", "user.login", "field_values.value" ]
           }
         }
       end

--- a/app/es_indices/identification_index.rb
+++ b/app/es_indices/identification_index.rb
@@ -63,11 +63,9 @@ class Identification < ActiveRecord::Base
       vision: vision,
       disagreement: disagreement,
       previous_observation_taxon_id: previous_observation_taxon_id,
-      spam: known_spam? || owned_by_spammer?
+      spam: known_spam? || owned_by_spammer?,
+      taxon_id: taxon_id
     }
-    if options[:no_details]
-      json[:taxon_id] = taxon_id
-    end
     if observation && taxon && !options[:no_details]
       json.merge!({
         current_taxon: (taxon_id == observation.taxon_id),

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -140,6 +140,7 @@ class Observation < ActiveRecord::Base
         for_identification: options[:for_identification]) : nil
     }
 
+    current_ids = identifications.select(&:current?)
     unless options[:no_details]
       json.merge!({
         created_time_zone: timezone_object.blank? ? "UTC" : timezone_object.tzinfo.name,
@@ -186,9 +187,9 @@ class Observation < ActiveRecord::Base
         photo_licenses: photos.map(&:index_license_code).compact.uniq,
         sound_licenses: sounds.map(&:index_license_code).compact.uniq,
         sounds: sounds.map(&:as_indexed_json),
-        identifier_user_ids: identifications.map(&:user_id),
-        non_owner_identifier_user_ids: identifications.map(&:user_id) - [user_id],
-        identification_categories: identifications.map(&:category).uniq,
+        identifier_user_ids: current_ids.map(&:user_id),
+        non_owner_identifier_user_ids: current_ids.map(&:user_id) - [user_id],
+        identification_categories: current_ids.map(&:category).uniq,
         identifications_count: num_identifications_by_others,
         comments: comments.map(&:as_indexed_json),
         comments_count: comments.size,

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -9,29 +9,28 @@ class Observation < ActiveRecord::Base
   scope :load_for_index, -> { includes(
     { user: :flags }, :confirmed_reviews, :flags,
     :observation_links, :quality_metrics,
-    :votes_for, :stored_preferences,
-    { project_observations: :stored_preferences }, :tags,
+    :votes_for, :stored_preferences, :tags,
     { annotations: :votes_for },
+    :photos,
     { sounds: :user },
-    { photos: [ :user, :flags ] },
-    { taxon: [ { taxon_names: :place_taxon_names }, :conservation_statuses,
-      { listed_taxa_with_establishment_means: :place } ] },
+    { identifications: :stored_preferences }, :project_observations,
+    { taxon: [ :taxon_names, :conservation_statuses ] },
     { observation_field_values: :observation_field },
-    { identifications: [ { user: :flags }, :taxon, :stored_preferences, :flags, :taxon_change ] },
     { comments: [ { user: :flags }, :flags ] } ) }
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do
       indexes :id, type: "integer"
       indexes :uuid, type: "keyword"
+      indexes :identifier_user_ids, type: "integer"
+      indexes :non_owner_identifier_user_ids, type: "integer"
+      indexes :identification_categories, type: "keyword"
+      indexes :photo_licenses, type: "keyword"
+      indexes :sound_licenses, type: "keyword"
       indexes :taxon do
         indexes :ancestry, type: "keyword"
         indexes :min_species_ancestry, type: "keyword"
         indexes :rank, type: "keyword"
         indexes :name, type: "text", analyzer: "ascii_snowball_analyzer"
-        indexes :names do
-          indexes :name, type: "text", analyzer: "ascii_snowball_analyzer"
-          indexes :locale, type: "keyword"
-        end
         indexes :statuses, type: :nested do
           indexes :authority, type: "keyword"
           indexes :status, type: "keyword"
@@ -45,26 +44,12 @@ class Observation < ActiveRecord::Base
         indexes :value, type: "keyword"
         indexes :value_ci, type: "text", analyzer: "keyword_analyzer"
         indexes :datatype, type: "keyword"
+        indexes :taxon_id, type: "integer"
       end
       indexes :annotations, type: :nested do
         indexes :uuid, type: "keyword"
         indexes :resource_type, type: "keyword"
         indexes :concatenated_attr_val, type: "keyword"
-      end
-      indexes :identifications, type: :nested do
-        indexes :uuid, type: "keyword"
-        indexes :body, type: "text", analyzer: "ascii_snowball_analyzer"
-        indexes :category, type: "keyword"
-        indexes :user do
-          indexes :login, type: "keyword"
-        end
-        indexes :taxon_change do
-          indexes :type, type: "keyword"
-        end
-        indexes :flags do
-          indexes :flag, type: "keyword"
-        end
-        indexes :created_at, type: "date"
       end
       indexes :comments do
         indexes :uuid, type: "keyword"
@@ -79,26 +64,8 @@ class Observation < ActiveRecord::Base
       indexes :flags do
         indexes :flag, type: "keyword"
       end
-      indexes :project_observations do
-        indexes :uuid, type: "keyword"
-        indexes :preferences do
-          indexes :name, type: "keyword", index: false
-          indexes :value, type: "keyword", index: false
-        end
-      end
-      indexes :observation_photos do
-        indexes :uuid, type: "keyword"
-      end
       indexes :user do
         indexes :login, type: "keyword"
-      end
-      indexes :photos do
-        indexes :attribution, type: "keyword", index: false
-        indexes :url, type: "keyword", index: false
-        indexes :license_code, type: "keyword"
-        indexes :flags do
-          indexes :flag, type: "keyword"
-        end
       end
       indexes :votes, type: :nested do
         indexes :vote_scope, type: "keyword"
@@ -132,7 +99,21 @@ class Observation < ActiveRecord::Base
       indexes :quality_grade, type: "keyword"
       indexes :time_zone_offset, type: "keyword", index: false
       indexes :uri, type: "keyword", index: false
+      indexes :identifications, type: :nested do
+      end
     end
+    mapping dynamic_templates: [
+      {
+        names_locales: {
+          path_match: "taxon.names_*",
+          match_mapping_type: "string",
+          mapping: {
+            type: "text",
+            analyzer: "ascii_snowball_analyzer"
+          }
+        }
+      }
+    ]
   end
 
   def as_indexed_json(options={})
@@ -196,13 +177,18 @@ class Observation < ActiveRecord::Base
           select{ |po| !po.curator_identification_id.nil? }.map(&:project_id).compact.uniq,
         project_ids_without_curator_id: project_observations.
           select{ |po| po.curator_identification_id.nil? }.map(&:project_id).compact.uniq,
-        project_observations: project_observations.map(&:as_indexed_json),
         reviewed_by: confirmed_reviews.map(&:user_id),
         tags: tags.map(&:name).compact.uniq,
         ofvs: observation_field_values.uniq.map(&:as_indexed_json),
         annotations: annotations.map(&:as_indexed_json),
+        photos_count: photos.any? ? photos.length : nil,
+        sounds_count: sounds.any? ? sounds.length : nil,
+        photo_licenses: photos.map(&:index_license_code).compact.uniq,
+        sound_licenses: sounds.map(&:index_license_code).compact.uniq,
         sounds: sounds.map(&:as_indexed_json),
-        identifications: identifications.map{ |i| i.as_indexed_json(no_details: true) },
+        identifier_user_ids: identifications.map(&:user_id),
+        non_owner_identifier_user_ids: identifications.map(&:user_id) - [user_id],
+        identification_categories: identifications.map(&:category),
         identifications_count: num_identifications_by_others,
         comments: comments.map(&:as_indexed_json),
         comments_count: comments.size,
@@ -225,14 +211,6 @@ class Observation < ActiveRecord::Base
         quality_metrics: quality_metrics.map(&:as_indexed_json),
         spam: known_spam? || owned_by_spammer?
       })
-      json[:photos] = [ ]
-      json[:observation_photos] = [ ]
-      observation_photos.sort_by{ |op| op.position || op.id }.
-        reject{ |op| op.photo.blank? }.
-        each_with_index.map{ |op, i|
-          json[:photos] << op.photo.as_indexed_json
-          json[:observation_photos] << { id: op.id, uuid: op.uuid, photo_id: op.photo.id, position: i }
-        }
 
       add_taxon_statuses(json, t) if t && json[:taxon]
     end
@@ -247,6 +225,9 @@ class Observation < ActiveRecord::Base
       o.indexed_place_ids ||= [ ]
       o.indexed_private_place_ids ||= [ ]
       o.indexed_private_places ||= [ ]
+      o.taxon_introduced ||= false
+      o.taxon_native ||= false
+      o.taxon_endemic ||= false
     }
     observations_by_id = Hash[ observations.map{ |o| [ o.id, o ] } ]
     batch_ids_string = observations_by_id.keys.join(",")
@@ -282,6 +263,58 @@ class Observation < ActiveRecord::Base
               p.bbox_publicly_contains_observation?( o )
             }.map(&:id)
           end
+        end
+      end
+
+      taxon_establishment_places = { }
+      taxon_ids = observations.map(&:taxon_id).compact.uniq
+      puts "Fetching Listed Taxa"
+      Observation.connection.execute("
+        SELECT taxon_id, establishment_means, string_agg(place_id::text,',') as place_ids
+        FROM listed_taxa
+        WHERE taxon_id IN (#{ taxon_ids.join(',') })
+        AND place_id IN (#{ observations.map(&:indexed_private_place_ids).flatten.compact.uniq.join(',') })
+        AND establishment_means IS NOT NULL
+        GROUP BY taxon_id, establishment_means").to_a.each do |r|
+        taxon_establishment_places[r["taxon_id"]] ||= {}
+        taxon_establishment_places[r["taxon_id"]][r["establishment_means"]] = r["place_ids"].split( "," )
+      end
+      place_ids = taxon_establishment_places.values.map(&:values).flatten.uniq
+      places = {}
+      Place.connection.execute("
+        SELECT id, bbox_area
+        FROM places WHERE id IN (#{ place_ids.join(',') })").to_a.each do |r|
+        places[r["id"]] = {
+          id: r["id"].to_i,
+          bbox_area: r["bbox_area"].to_f
+        }
+      end
+      # [taxon_id][establishment_means] = [place_ids]
+      taxon_places = { }
+      taxon_endemic_place_ids = { }
+      taxon_establishment_places.each do |taxon_id, means_places|
+        taxon_places[taxon_id] ||= { }
+        taxon_endemic_place_ids[taxon_id] ||= []
+        means_places.each do |means,place_ids|
+          taxon_establishment_places[taxon_id][means] ||= []
+          # keep a hash of all places for each taxon
+          place_ids.each do |place_id|
+            taxon_places[taxon_id][place_id] ||= places[place_id].dup
+            taxon_places[taxon_id][place_id][means] = true
+          end
+          if means == "endemic"
+            taxon_endemic_place_ids[taxon_id] += place_ids.map(&:to_i)
+          end
+        end
+      end
+      observations.each do |o|
+        if o.taxon && taxon_places[o.taxon.id.to_s]
+          closest = taxon_places[o.taxon.id.to_s].values.sort_by{ |p| p[:bbox_area] || 0 }.first
+          o.taxon_introduced = !!(closest &&
+            closest.values_at(*ListedTaxon::INTRODUCED_EQUIVALENTS).compact.any?)
+          o.taxon_native = !!(closest &&
+            closest.values_at(*ListedTaxon::NATIVE_EQUIVALENTS).compact.any?)
+          o.taxon_endemic = (o.indexed_private_place_ids & taxon_endemic_place_ids[o.taxon.id.to_s]).any?
         end
       end
     end
@@ -738,19 +771,20 @@ class Observation < ActiveRecord::Base
     end
     places = indexed_private_places ||
       Place.where(id: json[:place_ids]).select(:id, :ancestry).to_a
+    preloaded = taxon_introduced.yesish? || taxon_introduced.noish?
     json[:taxon][:threatened] = t.threatened?(place: places)
-    json[:taxon][:introduced] = t.establishment_means_in_place?(
-      ListedTaxon::INTRODUCED_EQUIVALENTS, places, closest: true)
+    json[:taxon][:introduced] = preloaded ? taxon_introduced :
+      t.establishment_means_in_place?(ListedTaxon::INTRODUCED_EQUIVALENTS, places, closest: true)
     # if the taxon is introduced it cannot be native or endemic
     if json[:taxon][:introduced]
       json[:taxon][:native] = false
       json[:taxon][:endemic] = false
       return
     end
-    json[:taxon][:native] = t.establishment_means_in_place?(
-      ListedTaxon::NATIVE_EQUIVALENTS, places, closest: true)
-    json[:taxon][:endemic] = t.establishment_means_in_place?(
-      "endemic", places)
+    json[:taxon][:native] = preloaded ? taxon_native :
+      t.establishment_means_in_place?(ListedTaxon::NATIVE_EQUIVALENTS, places, closest: true)
+    json[:taxon][:endemic] = preloaded ? taxon_endemic :
+      t.establishment_means_in_place?("endemic", places)
   end
 
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -52,7 +52,8 @@ class Observation < ActiveRecord::Base
   # lists after saving.  Useful if you're saving many observations at once and
   # you want to update lists in a batch
   attr_accessor :skip_refresh_lists, :skip_refresh_check_lists, :skip_identifications,
-    :bulk_import, :skip_indexing, :editing_user_id, :skip_quality_metrics, :bulk_delete
+    :bulk_import, :skip_indexing, :editing_user_id, :skip_quality_metrics, :bulk_delete,
+    :taxon_introduced, :taxon_endemic, :taxon_native
   
   # Set if you need to set the taxon from a name separate from the species 
   # guess

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -241,7 +241,10 @@ class ObservationFieldValue < ActiveRecord::Base
       value_ci: self.value,
       user_id: user_id
     }
-    json[:taxon_id] = value if observation_field.datatype == ObservationField::TAXON
+    # make sure taxon_id is an integer
+    if observation_field.datatype == ObservationField::TAXON && value.to_s =~ /\A[+-]?\d+\Z/
+      json[:taxon_id] = value
+    end
     json
   end
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -318,8 +318,7 @@ class Photo < ActiveRecord::Base
   def as_indexed_json( options={ } )
     json = {
       id: id,
-      license_code: (license_code.blank? || license.blank? || license == 0) ?
-        nil : license_code.downcase,
+      license_code: index_license_code,
       attribution: attribution,
       url: (self.is_a?(LocalPhoto) && processing?) ? file.url(:square) : square_url,
       original_dimensions: original_dimensions,

--- a/app/models/shared/license_module.rb
+++ b/app/models/shared/license_module.rb
@@ -75,7 +75,12 @@ module Shared::LicenseModule
   def license_code
     LICENSE_INFO[license.to_i].try(:[], :code)
   end
-  
+
+  def index_license_code
+    (license_code.blank? || license.blank? || license == 0) ?
+        nil : license_code.downcase
+  end
+
   def license_url
     Shared::LicenseModule.license_url_for_number( license )
   end

--- a/app/models/sound.rb
+++ b/app/models/sound.rb
@@ -125,7 +125,7 @@ class Sound < ActiveRecord::Base
   def as_indexed_json(options={})
     {
       id: id,
-      license_code: license_code,
+      license_code: index_license_code,
       attribution: attribution,
       native_sound_id: native_sound_id,
       secret_token: try(:secret_token),

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1288,24 +1288,20 @@ class Taxon < ActiveRecord::Base
     means = [ means ] unless means.is_a?(Array)
     places = Place.param_to_array(place)
     return false if places.blank?
-    if association(:listed_taxa_with_establishment_means).loaded? || association(:listed_taxa).loaded?
-      lt = association(:listed_taxa_with_establishment_means).loaded? ?
-        listed_taxa_with_establishment_means : listed_taxa
-      place_ancestor_ids = (places.map(&:id) +
-        places.map{ |p| p.ancestry.to_s.split("/").map(&:to_i) }).flatten.uniq
-      if options[:closest]
-        most_specific_lt = lt.
-          select{ |l| l.establishment_means && place_ancestor_ids.include?(l.place_id) }.
-          sort_by{ |l| l.place.bbox_area || 0 }.first
-        return false if most_specific_lt.blank?
-        means.include?( most_specific_lt.establishment_means)
-      else
-        !!lt.
-          select{ |l| l.establishment_means && place_ancestor_ids.include?(l.place_id) }.
-          detect{ |l| means.include?( l.establishment_means) }
-      end
+    lt = association(:listed_taxa_with_establishment_means).loaded? ?
+      listed_taxa_with_establishment_means : listed_taxa
+    place_ancestor_ids = (places.map(&:id) +
+      places.map{ |p| p.ancestry.to_s.split("/").map(&:to_i) }).flatten.uniq
+    if options[:closest]
+      most_specific_lt = lt.
+        select{ |l| l.establishment_means && place_ancestor_ids.include?(l.place_id) }.
+        sort_by{ |l| l.place.bbox_area || 0 }.first
+      return false if most_specific_lt.blank?
+      means.include?( most_specific_lt.establishment_means)
     else
-      listed_taxa.with_establishment_means(means).where(place_id: places).exists?
+      !!lt.
+        select{ |l| l.establishment_means && place_ancestor_ids.include?(l.place_id) }.
+        detect{ |l| means.include?( l.establishment_means) }
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1135,6 +1135,14 @@ class User < ActiveRecord::Base
       size: 0
     )
     count = (result && result.response) ? result.response.hits.total : 0
+    new_fields_result = Observation.elastic_search(
+      filters: [
+        { term: { non_owner_identifier_user_ids: user_id } }
+      ],
+      size: 0
+    )
+    count += (new_fields_result && new_fields_result.response) ?
+      new_fields_result.response.hits.total : 0
     User.where(id: user_id).update_all(identifications_count: count)
   end
 

--- a/lib/observation_search.rb
+++ b/lib/observation_search.rb
@@ -727,21 +727,6 @@ module ObservationSearch
         map{ |b| { "user_id" => b["key"], "count_all" => b["distinct_taxa"]["value"] } }
     end
 
-    def elastic_user_identification_counts(elastic_params, limit = 500)
-      id_result = Observation.elastic_search(elastic_params.merge(size: 0,
-        aggregate: {
-          identifier_count: {
-            cardinality: {
-              field: "identifications.user.id", precision_threshold: 10000 } },
-          top_identifiers: {
-            terms: {
-              field: "identifications.user.id", size: limit } } } ) ).response
-      { total: id_result.aggregations.identifier_count.value,
-        counts: Hash[ id_result.aggregations.top_identifiers.buckets.
-          map{ |b| [ b["key"], b["doc_count"] ] } ],
-      }
-    end
-
   end
 
 end

--- a/spec/controllers/identifications_controller_api_spec.rb
+++ b/spec/controllers/identifications_controller_api_spec.rb
@@ -198,8 +198,8 @@ shared_examples_for "an IdentificationsController" do
 
   describe "by_login" do
     before(:all) { load_test_taxa }
-    before(:each) { enable_elastic_indexing( Observation ) }
-    after(:each) { disable_elastic_indexing( Observation ) }
+    before(:each) { enable_elastic_indexing( Observation, Identification ) }
+    after(:each) { disable_elastic_indexing( Observation, Identification ) }
     it "should return identifications by the selected user" do
       ident = Identification.make!( user: user )
       get :by_login, format: :json, login: user.login

--- a/spec/controllers/observation_controller_api_spec.rb
+++ b/spec/controllers/observation_controller_api_spec.rb
@@ -60,8 +60,8 @@ end
 shared_examples_for "an ObservationsController" do
 
   describe "create" do
-    before(:each) { enable_elastic_indexing( Observation ) }
-    after(:each) { disable_elastic_indexing( Observation ) }
+    before(:each) { enable_elastic_indexing( Observation, Identification ) }
+    after(:each) { disable_elastic_indexing( Observation, Identification ) }
 
     it "should create with an existing photo ID" do
       p = LocalPhoto.make!( user: user )

--- a/spec/controllers/users_controller_api_spec.rb
+++ b/spec/controllers/users_controller_api_spec.rb
@@ -83,14 +83,14 @@ shared_examples_for "a signed in UsersController" do
         user.update_attributes( preferred_photo_license: Observation::CC_BY )
         o = make_research_grade_observation( user: user )
         es_response = Observation.elastic_search( where: { id: o.id } ).results.results.first
-        expect( es_response.photos.first.license_code ).to eq Observation::CC_BY.downcase
+        expect( es_response.photo_licenses ).to include Observation::CC_BY.downcase
         put :update, id: user.id, format: :json, user: {
           preferred_photo_license: "",
           make_photo_licenses_same: "1"
         }
         Delayed::Worker.new.work_off
         es_response = Observation.elastic_search( where: { id: o.id } ).results.results.first
-        expect( es_response.photos.first.license_code ).to be_blank
+        expect( es_response.photo_licenses ).to be_blank
       end
     end
   end

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -45,33 +45,6 @@ describe "Observation Index" do
     expect( json[:created_at_details][:year] ).to eq 2014
   end
 
-  it "sorts photos by position and ID" do
-    o = Observation.make!(latitude: 3.0, longitude: 4.0)
-    p3 = LocalPhoto.make!
-    p1 = LocalPhoto.make!
-    p2 = LocalPhoto.make!
-    p4 = LocalPhoto.make!
-    p5 = LocalPhoto.make!
-    make_observation_photo(photo: p1, observation: o, position: 1)
-    make_observation_photo(photo: p2, observation: o, position: 2)
-    make_observation_photo(photo: p3, observation: o, position: 3)
-    # these without a position will be last in order of creation
-    make_observation_photo(photo: p4, observation: o)
-    make_observation_photo(photo: p5, observation: o)
-    o.reload
-    json = o.as_indexed_json
-    expect( json[:photos][0][:id] ).to eq p1.id
-    expect( json[:photos][1][:id] ).to eq p2.id
-    expect( json[:photos][2][:id] ).to eq p3.id
-    expect( json[:photos][3][:id] ).to eq p4.id
-    expect( json[:photos][4][:id] ).to eq p5.id
-  end
-
-  it "includes observation photo ID" do
-    o = make_research_grade_candidate_observation
-    expect( o.as_indexed_json[:observation_photos][0][:id] ).to eq o.observation_photos.first.id
-  end
-
   it "uses private_latitude/longitude to create private_geojson" do
     o = Observation.make!
     o.update_columns(private_latitude: 3.0, private_longitude: 4.0, private_geom: nil)
@@ -150,14 +123,12 @@ describe "Observation Index" do
     expect( o.as_indexed_json[:taxon][:endemic] ).to be true
   end
 
-  it "indexes identifications" do
+  it "indexes identifier_user_ids" do
     o = Observation.make!
     Identification.where(observation_id: o.id).destroy_all
     5.times{ Identification.make!(observation: o) }
     json = o.as_indexed_json
-    expect( json[:identifications].length ).to eq 5
-    expect( json[:identifications].first ).to eq o.identifications.first.
-      as_indexed_json(no_details: true)
+    expect( json[:identifier_user_ids].length ).to eq 5
   end
 
   it "indexes owners_identification_from_vision" do
@@ -322,12 +293,16 @@ describe "Observation Index" do
     end
 
     it "filters by presence of attributes" do
-      [ { http_param: :with_photos, es_field: "photos.url" },
-        { http_param: :with_sounds, es_field: "sounds" },
+      [ { http_param: :with_photos, es_field: ["photos.url", "photos_count"] },
+        { http_param: :with_sounds, es_field: ["sounds", "sounds_count"] },
         { http_param: :with_geo, es_field: "geojson" },
         { http_param: :identified, es_field: "taxon" },
       ].each do |filter|
-        f = { exists: { field: filter[:es_field] } }
+        if filter[:es_field].is_a?( Array )
+          f = { bool: { should: filter[:es_field].map{ |ff| { exists: { field: ff } } } } }
+        else
+          f = { exists: { field: filter[:es_field] } }
+        end
         expect( Observation.params_to_elastic_query({
           filter[:http_param] => "true" }) ).to include(
             filters: [ f ] )
@@ -396,13 +371,25 @@ describe "Observation Index" do
 
     it "filters by photo license" do
       expect( Observation.params_to_elastic_query({ photo_license: "any" }) ).to include(
-        filters: [ { exists: { field: "photos.license_code" } } ] )
+        filters: [ { bool: { should: [
+          { exists: { field: "photo_licenses" } },
+          { exists: { field: "photos.license_code" } }
+        ] } } ] )
       expect( Observation.params_to_elastic_query({ photo_license: "none" }) ).to include(
-        inverse_filters: [ { exists: { field: "photos.license_code" } } ] )
+        inverse_filters: [ { bool: { should: [
+          { exists: { field: "photo_licenses" } },
+          { exists: { field: "photos.license_code" } }
+        ] } } ] )
       expect( Observation.params_to_elastic_query({ photo_license: "CC-BY" }) ).to include(
-        filters: [ { terms: { "photos.license_code" => [ "cc-by" ] } } ] )
+        filters: [ { bool: { should: [
+          { terms: { "photo_licenses" => [ "cc-by" ] } },
+          { terms: { "photos.license_code" => [ "cc-by" ] } }
+        ] } } ] )
       expect( Observation.params_to_elastic_query({ photo_license: [ "CC-BY", "CC-BY-NC" ] }) ).to include(
-        filters: [ { terms: { "photos.license_code" => [ "cc-by", "cc-by-nc" ] } } ] )
+        filters: [ { bool: { should: [
+          { terms: { "photo_licenses" => [ "cc-by", "cc-by-nc" ] } },
+          { terms: { "photos.license_code" => [ "cc-by", "cc-by-nc" ] } }
+        ] } } ] )
     end
 
     it "filters by created_on year" do

--- a/spec/models/local_photo_spec.rb
+++ b/spec/models/local_photo_spec.rb
@@ -228,12 +228,10 @@ describe LocalPhoto, "flagging" do
   it "should change make associated observations research grade when resolved"
   it "should re-index the observation" do
     o = make_research_grade_observation
-    p = o.photos.first
-    es_p = Observation.elastic_search( where: { id: o.id } ).results.results.first.photos.first
-    expect( es_p.url ).not_to be =~ /copyright/
-    without_delay { Flag.make!( flaggable: p, flag: Flag::COPYRIGHT_INFRINGEMENT ) }
-    es_p = Observation.elastic_search( where: { id: o.id } ).results.results.first.photos.first
-    expect( es_p.url ).to be =~ /copyright/
+    original_last_indexed_at = o.last_indexed_at
+    without_delay { Flag.make!( flaggable: o.photos.first, flag: Flag::COPYRIGHT_INFRINGEMENT ) }
+    o.reload
+    expect( o.last_indexed_at ).to be > original_last_indexed_at
   end
 end
 

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -1062,21 +1062,21 @@ describe Taxon, "grafting" do
       i.reload
       expect( i.taxon ).not_to be_grafted
       expect( i.category ).to eq Identification::MAVERICK
-      es_o_idents = Observation.elastic_search( where: { id: o.id } ).results.results[0].identifications.sort_by(&:id)
-      expect( es_o_idents[0].category ).to eq Identification::IMPROVING
-      expect( es_o_idents[1].category ).to eq Identification::SUPPORTING
-      expect( es_o_idents[2].category ).to eq Identification::SUPPORTING
-      expect( es_o_idents[3].category ).to eq Identification::MAVERICK
+      categories = Observation.elastic_search( where: { id: o.id } ).results.
+        results[0].identification_categories.uniq.sort
+      expect( categories[0] ).to eq Identification::IMPROVING
+      expect( categories[1] ).to eq Identification::MAVERICK
+      expect( categories[2] ).to eq Identification::SUPPORTING
       without_delay { i.taxon.update_attributes( rank: Taxon::SPECIES ) }
       without_delay { i.taxon.update_attributes( parent: @Pseudacris ) }
       i.reload
       expect( i.taxon.ancestor_ids ).to include( @Pseudacris.id)
       expect( i.category ).to eq Identification::LEADING
-      es_o_idents = Observation.elastic_search( where: { id: o.id } ).results.results[0].identifications.sort_by(&:id)
-      expect( es_o_idents[0].category ).to eq Identification::IMPROVING
-      expect( es_o_idents[1].category ).to eq Identification::SUPPORTING
-      expect( es_o_idents[2].category ).to eq Identification::SUPPORTING
-      expect( es_o_idents[3].category ).to eq Identification::LEADING
+      categories = Observation.elastic_search( where: { id: o.id } ).results.
+        results[0].identification_categories.uniq.sort
+      expect( categories[0] ).to eq Identification::IMPROVING
+      expect( categories[1] ).to eq Identification::LEADING
+      expect( categories[2] ).to eq Identification::SUPPORTING
     end
   end
 end


### PR DESCRIPTION
Attempt to make the obs index smaller. Removes some things from the obs index (identifications, photos, project observations) and adds some non-nested items as needed to keep functionality. Also modifies obs indexing to fetch listed taxa in bulk for assessing introduced, native and endemic. Modify ES queries as needed to work with index changes.