### PR TITLE
Free up memory during non-bulk indexing

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -831,6 +831,7 @@ class Observation < ActiveRecord::Base
       t.establishment_means_in_place?(ListedTaxon::NATIVE_EQUIVALENTS, places, closest: true)
     json[:taxon][:endemic] = preloaded ? taxon_endemic :
       t.establishment_means_in_place?("endemic", places)
+    t.listed_taxa_with_establishment_means.reset
   end
 
 end


### PR DESCRIPTION
- unset associations loaded only for indexing when indexing is done
- periodically force garbage collecting after indexing individual instances