### PR TITLE
Shows the Similar tab on taxon pages for genera

### DIFF
--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -12806,6 +12806,8 @@ I18n.translations["en"] = {
   "other": "Other",
   "other_species_commonly_misidentified_as_this_species": "Other species commonly misidentified as this species",
   "other_species_commonly_misidentified_as_this_species_in_place_html": "Other species commonly misidentified as this species in <a href=\"%{url}\">%{place}</a>\n",
+  "other_taxa_commonly_misidentified_as_this_rank": "Other taxa commonly misidentified as this %{rank}",
+  "other_taxa_commonly_misidentified_as_this_rank_in_place_html": "Other taxa commonly misidentified as this %{rank} in <a href=\"%{url}\">%{place}</a>\n",
   "output_taxon": "Output taxon",
   "overview": "Overview",
   "per_day": "Per Day",
@@ -13347,6 +13349,7 @@ I18n.translations["en"] = {
   "sign_out": "Sign Out",
   "sign_up": "Sign Up",
   "similar_species": "Similar Species",
+  "similar_taxa": "Similar Taxa",
   "site_admin_tools": "Site admin tools",
   "skip_to_next_page": "Skip to next page",
   "some_observations_failed_to_be_added": "Some observations failed to be added to projects",
@@ -13747,6 +13750,10 @@ I18n.translations["en"] = {
   "x_matching_taxa_html": {
     "one": "<span class=\"count\">1</span> matching taxon",
     "other": "<span class=\"count\">%{count}</span> matching taxa"
+  },
+  "x_misidentifications_of_species_in_this_rank": {
+    "one": "1 misidentification of species in this %{rank}",
+    "other": "%{count} misidentifications of species in this %{rank}"
   },
   "x_misidentifications_of_this_species": {
     "one": "1 misidentification of this species",

--- a/app/webpack/taxa/show/components/similar_tab.jsx
+++ b/app/webpack/taxa/show/components/similar_tab.jsx
@@ -3,12 +3,17 @@ import PropTypes from "prop-types";
 import { Grid, Row, Col } from "react-bootstrap";
 import TaxonThumbnail from "./taxon_thumbnail";
 
-const SimilarTab = ( { results, place, showNewTaxon, config } ) => {
+const SimilarTab = ( {
+  results,
+  place,
+  showNewTaxon,
+  config
+} ) => {
   let content;
   if ( results && results.length > 0 ) {
     content = (
       <div className="thumbnails">
-        { results.map( result =>
+        { results.map( result => (
           <TaxonThumbnail
             taxon={result.taxon}
             key={`similar-taxon-${result.taxon.id}`}
@@ -16,16 +21,16 @@ const SimilarTab = ( { results, place, showNewTaxon, config } ) => {
             badgeTip={I18n.t( "x_misidentifications_of_this_species", { count: result.count } )}
             height={190}
             truncate={20}
-            onClick={ e => {
+            onClick={e => {
               if ( !showNewTaxon ) return true;
               if ( e.metaKey || e.ctrlKey ) return true;
               e.preventDefault( );
               showNewTaxon( result.taxon );
               return false;
-            } }
-            config={ config }
+            }}
+            config={config}
           />
-        ) }
+        ) ) }
       </div>
     );
   } else if ( results ) {
@@ -38,18 +43,18 @@ const SimilarTab = ( { results, place, showNewTaxon, config } ) => {
       <Row>
         <Col xs={12}>
           <h2>
-            {
-              place ?
+            { place
+              ? (
                 <span
-                  dangerouslySetInnerHTML={ { __html:
-                    I18n.t(
+                  dangerouslySetInnerHTML={{
+                    __html: I18n.t(
                       "other_species_commonly_misidentified_as_this_species_in_place_html",
                       { place: place.display_name, url: `/places/${place.id}` }
                     )
-                  } }
-                ></span>
-                :
-                I18n.t( "other_species_commonly_misidentified_as_this_species" )
+                  }}
+                />
+              )
+              : I18n.t( "other_species_commonly_misidentified_as_this_species" )
             }
           </h2>
           { content }

--- a/app/webpack/taxa/show/components/similar_tab.jsx
+++ b/app/webpack/taxa/show/components/similar_tab.jsx
@@ -7,30 +7,41 @@ const SimilarTab = ( {
   results,
   place,
   showNewTaxon,
-  config
+  config,
+  taxon
 } ) => {
   let content;
+  const rank = I18n.t( `ranks.${taxon.rank}`, { defaultValue: taxon.rank } ).toLowerCase( );
   if ( results && results.length > 0 ) {
     content = (
       <div className="thumbnails">
-        { results.map( result => (
-          <TaxonThumbnail
-            taxon={result.taxon}
-            key={`similar-taxon-${result.taxon.id}`}
-            badgeText={result.count}
-            badgeTip={I18n.t( "x_misidentifications_of_this_species", { count: result.count } )}
-            height={190}
-            truncate={20}
-            onClick={e => {
-              if ( !showNewTaxon ) return true;
-              if ( e.metaKey || e.ctrlKey ) return true;
-              e.preventDefault( );
-              showNewTaxon( result.taxon );
-              return false;
-            }}
-            config={config}
-          />
-        ) ) }
+        { results.map( result => {
+          let tip = I18n.t( "x_misidentifications_of_this_species", { count: result.count } );
+          if ( taxon.rank_level > 10 ) {
+            tip = I18n.t( "x_misidentifications_of_species_in_this_rank", {
+              count: result.count,
+              rank: I18n.t( `ranks.${result.taxon.rank}`, { defaultValue: result.taxon.rank } ).toLowerCase( )
+            } );
+          }
+          return (
+            <TaxonThumbnail
+              taxon={result.taxon}
+              key={`similar-taxon-${result.taxon.id}`}
+              badgeText={result.count}
+              badgeTip={tip}
+              height={190}
+              truncate={20}
+              onClick={e => {
+                if ( !showNewTaxon ) return true;
+                if ( e.metaKey || e.ctrlKey ) return true;
+                e.preventDefault( );
+                showNewTaxon( result.taxon );
+                return false;
+              }}
+              config={config}
+            />
+          );
+        } ) }
       </div>
     );
   } else if ( results ) {
@@ -38,25 +49,43 @@ const SimilarTab = ( {
   } else {
     content = <div className="loading status">{ I18n.t( "loading" ) }</div>;
   }
+  let title = I18n.t( "other_species_commonly_misidentified_as_this_species" );
+  if ( taxon.rank_level > 10 ) {
+    if ( place ) {
+      title = (
+        <span
+          dangerouslySetInnerHTML={{
+            __html: I18n.t(
+              "other_taxa_commonly_misidentified_as_this_rank_in_place_html",
+              {
+                rank,
+                place: place.display_name,
+                url: `/places/${place.id}`
+              }
+            )
+          }}
+        />
+      );
+    } else {
+      title = I18n.t( "other_taxa_commonly_misidentified_as_this_rank", { rank } );
+    }
+  } else if ( place ) {
+    title = (
+      <span
+        dangerouslySetInnerHTML={{
+          __html: I18n.t(
+            "other_species_commonly_misidentified_as_this_species_in_place_html",
+            { place: place.display_name, url: `/places/${place.id}` }
+          )
+        }}
+      />
+    );
+  }
   return (
     <Grid className="SimilarTab">
       <Row>
         <Col xs={12}>
-          <h2>
-            { place
-              ? (
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: I18n.t(
-                      "other_species_commonly_misidentified_as_this_species_in_place_html",
-                      { place: place.display_name, url: `/places/${place.id}` }
-                    )
-                  }}
-                />
-              )
-              : I18n.t( "other_species_commonly_misidentified_as_this_species" )
-            }
-          </h2>
+          <h2>{ title }</h2>
           { content }
         </Col>
       </Row>
@@ -68,7 +97,8 @@ SimilarTab.propTypes = {
   results: PropTypes.array,
   place: PropTypes.object,
   showNewTaxon: PropTypes.func,
-  config: PropTypes.object
+  config: PropTypes.object,
+  taxon: PropTypes.object
 };
 
 export default SimilarTab;

--- a/app/webpack/taxa/show/components/taxon_page_tabs.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_tabs.jsx
@@ -188,7 +188,9 @@ class TaxonPageTabs extends React.Component {
                   role="presentation"
                   className={`${genusOrSpecies ? "" : "hidden"} ${chosenTab === "similar" ? "active" : ""}`}
                 >
-                  <a href="#similar-tab" role="tab" data-toggle="tab">{ I18n.t( "similar_species" ) }</a>
+                  <a href="#similar-tab" role="tab" data-toggle="tab">
+                    { speciesOrLower ? I18n.t( "similar_species" ) : I18n.t( "similar_taxa" ) }
+                  </a>
                 </li>
                 { curationTab }
               </ul>

--- a/app/webpack/taxa/show/components/taxon_page_tabs.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_tabs.jsx
@@ -46,6 +46,7 @@ class TaxonPageTabs extends React.Component {
     } = this.props;
     const test = $.deparam.querystring( ).test;
     const speciesOrLower = taxon && taxon.rank_level <= 10;
+    const genusOrSpecies = taxon && ( taxon.rank_level === 20 || taxon.rank_level === 10 );
     let curationTab;
     if ( currentUser && currentUser.id ) {
       const isCurator = currentUser.roles.indexOf( "curator" ) >= 0 || currentUser.roles.indexOf( "admin" ) >= 0;
@@ -185,7 +186,7 @@ class TaxonPageTabs extends React.Component {
                 </li>
                 <li
                   role="presentation"
-                  className={`${speciesOrLower ? "" : "hidden"} ${chosenTab === "similar" ? "active" : ""}`}
+                  className={`${genusOrSpecies ? "" : "hidden"} ${chosenTab === "similar" ? "active" : ""}`}
                 >
                   <a href="#similar-tab" role="tab" data-toggle="tab">{ I18n.t( "similar_species" ) }</a>
                 </li>
@@ -244,7 +245,7 @@ class TaxonPageTabs extends React.Component {
           </div>
           <div
             role="tabpanel"
-            className={`tab-pane ${speciesOrLower ? "" : "hidden"} ${chosenTab === "similar" ? "active" : ""}`}
+            className={`tab-pane ${genusOrSpecies ? "" : "hidden"} ${chosenTab === "similar" ? "active" : ""}`}
             id="similar-tab"
           >
             <SimilarTabContainer />

--- a/app/webpack/taxa/show/containers/similar_tab_container.js
+++ b/app/webpack/taxa/show/containers/similar_tab_container.js
@@ -6,7 +6,8 @@ function mapStateToProps( state ) {
   return {
     results: state.taxon.similar,
     place: state.config.chosenPlace,
-    config: state.config
+    config: state.config,
+    taxon: state.taxon.taxon
   };
 }
 

--- a/app/webpack/taxa/show/containers/taxon_page_tabs_container.js
+++ b/app/webpack/taxa/show/containers/taxon_page_tabs_container.js
@@ -16,11 +16,16 @@ import {
 
 function mapStateToProps( state ) {
   const speciesTabs = ["map", "articles", "interactions", "taxonomy", "status", "similar"];
-  const aboveSpeciesTabs = ["map", "articles", "highlights", "taxonomy"];
+  const genusTabs = ["map", "articles", "highlights", "taxonomy", "similar"];
+  const aboveGenusTabs = ["map", "articles", "highlights", "taxonomy"];
   let chosenTab;
   if (
-    ( state.taxon.taxon.rank_level <= 10 && speciesTabs.indexOf( state.config.chosenTab ) >= 0 ) ||
-    ( state.taxon.taxon.rank_level > 10 && aboveSpeciesTabs.indexOf( state.config.chosenTab ) >= 0 )
+    ( state.taxon.taxon.rank_level <= 10 && speciesTabs.indexOf( state.config.chosenTab ) >= 0 )
+    || ( state.taxon.taxon.rank_level === 20 && genusTabs.indexOf( state.config.chosenTab ) >= 0 )
+    || (
+      state.taxon.taxon.rank_level > 20
+      && aboveGenusTabs.indexOf( state.config.chosenTab ) >= 0
+    )
   ) {
     chosenTab = state.config.chosenTab;
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,8 +33,11 @@ en:
     one: '<span class="count">1</span> matching taxon'
     other: '<span class="count">%{count}</span> matching taxa'
   x_misidentifications_of_this_species:
-      one: "1 misidentification of this species"
-      other: "%{count} misidentifications of this species"
+    one: "1 misidentification of this species"
+    other: "%{count} misidentifications of this species"
+  x_misidentifications_of_species_in_this_rank:
+    one: "1 misidentification of species in this %{rank}"
+    other: "%{count} misidentifications of species in this %{rank}"
   x_observations:
     one: "1 observation"
     other: "%{count} observations"
@@ -2652,6 +2655,9 @@ en:
   other_species_commonly_misidentified_as_this_species: Other species commonly misidentified as this species
   other_species_commonly_misidentified_as_this_species_in_place_html: |
     Other species commonly misidentified as this species in <a href="%{url}">%{place}</a>
+  other_taxa_commonly_misidentified_as_this_rank: Other taxa commonly misidentified as this %{rank}
+  other_taxa_commonly_misidentified_as_this_rank_in_place_html: |
+    Other taxa commonly misidentified as this %{rank} in <a href="%{url}">%{place}</a>
   our_blog: Our Blog
   out_of_range: Out of range
   output_taxon: Output taxon
@@ -3604,6 +3610,7 @@ en:
   sign_up: Sign Up
   sign_up_exclamation: Sign up!
   similar_species: Similar Species
+  similar_taxa: Similar Taxa
   simple: Simple
   sign_in_exclamation: Sign in!
   single_observation: Single observation


### PR DESCRIPTION
Works by looking for misidentifications of species in the genus, not of the genus itself, so it's kind of a half-measure.