### PR TITLE
Larger polygon tiles

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -941,17 +941,17 @@ var appendValidParamsToURL = function( url, options ) {
 };
 
 google.maps.Map.prototype.addPlaceLayer = function( options ) {
-  _.defaults( options, { validParams: [ 'color' ] });
+  _.defaults( options, { validParams: [ "color", "tile_size" ] });
   return this.addPostgisLayerByEndpoint( "places", options.place.id, options );
 };
 
 google.maps.Map.prototype.addTaxonRangeLayer = function( options ) {
-  _.defaults( options, { validParams: [ 'color' ] });
+  _.defaults( options, { validParams: [ "color", "tile_size" ] });
   return this.addPostgisLayerByEndpoint( "taxon_ranges", options.taxon.id, options );
 };
 
 google.maps.Map.prototype.addTaxonPlacesLayer = function( options ) {
-  _.defaults( options, { validParams: [ 'confirmed_color', 'unconfirmed_color' ] });
+  _.defaults( options, { validParams: [ "confirmed_color", "unconfirmed_color", "tile_size" ] });
   return this.addPostgisLayerByEndpoint( "taxon_places", options.taxon.id, options );
 };
 
@@ -985,6 +985,7 @@ google.maps.Map.prototype.addPostgisLayerByEndpoint = function( endpoint, endpoi
   this.setTilt(0);
   var tileservers = postgisTileservers( );
   var options = options || { };
+  options.tile_size = 512;
   var tileURLs = _.map( tileservers , function( base ) {
     return appendValidParamsToURL(
       base + "/" + endpoint + "/" + endpointID + "/{z}/{x}/{y}.png", options );
@@ -997,6 +998,7 @@ google.maps.Map.prototype.addPostgisLayerByEndpoint = function( endpoint, endpoi
 // to add a checkbox toggle for this new layer
 google.maps.Map.prototype.addLayerAndControl = function( tilejson, options ) {
   options = options || { }
+  tilejson.interactive = false;
   var layer = new wax.g.connector( tilejson );
   layer.title = options.title;
   var layerID = this.overlayMapTypes.push( layer );
@@ -1239,7 +1241,6 @@ google.maps.Map.prototype.addTileLayer = function(tileURLs, options) {
     // wax needs template or it won't fire on events
     "template": "{{species_guess}}"
   }, options);
-  waxOptions.tileSize = ( options.tileSize === 512 ) ? 512 : 256;
   var layer = new wax.g.connector( waxOptions );
   var layerID =  this.overlayMapTypes.push( layer );
   if( options.disabled ) {

--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -989,7 +989,7 @@ google.maps.Map.prototype.addPostgisLayerByEndpoint = function( endpoint, endpoi
     return appendValidParamsToURL(
       base + "/" + endpoint + "/" + endpointID + "/{z}/{x}/{y}.png", options );
   });
-  return this.addLayerAndControl( { tiles: tileURLs }, options );
+  return this.addLayerAndControl( { tiles: tileURLs, tileSize: 512 }, options );
 };
 
 // Convenience method that likely isn't called outside this file.
@@ -1000,15 +1000,12 @@ google.maps.Map.prototype.addLayerAndControl = function( tilejson, options ) {
   var layer = new wax.g.connector( tilejson );
   layer.title = options.title;
   var layerID = this.overlayMapTypes.push( layer );
-  if( options.interactivity ) {
-    layer.interactivity = this.addTileInteractivity( tilejson, layerID );
-  }
   if( options.disabled ) {
     // even though the layer is meant to be disabled (unselected) by default
     // we need to secure the layerID so that we can add the layer in the proper
     // places when the user selects it. That is why the layer is added
     // above and immediately set to null here.
-    this.overlayMapTypes.setAt( layerID - 1, emptyLayer);
+    this.overlayMapTypes.setAt( layerID - 1, emptyLayer );
   }
   if( this._overlayControl ) {
     this._overlayControl.addWindshaftOverlayControl(
@@ -1112,6 +1109,7 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
     "has",
     "has",
     "hrank",
+    "id_above",
     "iconic_taxa",
     "iconic_taxa",
     "ident_taxon_id",
@@ -1148,6 +1146,7 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
     "reviewed",
     "scaled",
     "search_on",
+    "skip_top_hits",
     "sounds",
     "swlat",
     "swlng",
@@ -1158,6 +1157,7 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
     "term_id",
     "term_value_id",
     "threatened",
+    "tile_size",
     "ttl",
     "unobserved_by_user_id",
     "user_after",
@@ -1183,7 +1183,8 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
     interactivity: options.interactivity === false ? false : 'id',
     interactionsURL: intereactionsServer( ) + gridTileSuffix,
     disabled: options.disabled,
-    infoWindowCallback: options.infoWindowCallback
+    infoWindowCallback: options.infoWindowCallback,
+    tileSize: ( Number( options.tile_size ) === 512 ) ? 512 : 256
   });
   pointLayer = this.addTileLayer( _.map( tileservers , function( base ) {
       return base + pointTileSuffix;
@@ -1193,7 +1194,8 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
     gridminzoom: gridmaxzoom + 1,
     interactionsURL: intereactionsServer( ) + pointTileSuffix,
     disabled: options.disabled,
-    infoWindowCallback: options.infoWindowCallback
+    infoWindowCallback: options.infoWindowCallback,
+    tileSize: ( Number( options.tile_size ) === 512 ) ? 512 : 256
   });
   gridLayer.layer.title = title;
   pointLayer.layer.title = title;
@@ -1232,19 +1234,20 @@ google.maps.Map.prototype.addTileLayer = function(tileURLs, options) {
     })
   }
   // finish preparing the tile options hash
-  var tilejson = $.extend(true, { }, {
+  var waxOptions = $.extend(true, { }, {
     tiles: tileURLs,
     // wax needs template or it won't fire on events
     "template": "{{species_guess}}"
   }, options);
-  var layer = new wax.g.connector( tilejson );
+  waxOptions.tileSize = ( options.tileSize === 512 ) ? 512 : 256;
+  var layer = new wax.g.connector( waxOptions );
   var layerID =  this.overlayMapTypes.push( layer );
   if( options.disabled ) {
     this.overlayMapTypes.setAt( layerID - 1, emptyLayer);
   }
   // add a utfgrid data layer and custom JS events to catch interactivity
   if( options.interactivity ) {
-    layer.interactivity = this.addTileInteractivity( tilejson, layerID, options );
+    layer.interactivity = this.addTileInteractivity( waxOptions, layerID, options );
   }
   // return the layer and index of this layer in the current stack
   return { layer: layer, layerID: layerID };
@@ -1259,7 +1262,7 @@ google.maps.Map.prototype.utfgridURL = function( tileURL ) {
 google.maps.Map.prototype.addTileInteractivity = function( tilejson, layerID, options ) {
   var map = this;
   var interactionOn = false;
-  var waxInteraction = wax.g.interaction( );
+  var waxInteraction = wax.g.interaction( { tileSize: tilejson.tileSize || 256 });
   var oldFeature = waxInteraction.screen_feature;
   map.createInfoWindow( );
 

--- a/app/assets/javascripts/wax.g.js
+++ b/app/assets/javascripts/wax.g.js
@@ -6,6 +6,7 @@
  * 2015-08-05 pleary - Specify jsonpCallbackName so varnish can cache responses
  * 2015-08-19 pleary - Remove click timeout to avoid delay in popups
  * 2018-07-02 pleary - Some fixes for Google maps renderer in JS v3.32
+ * 2019-04-04 pleary - Configurable tile size; optional interactive
  */
 
 !function (name, context, definition) {
@@ -3504,7 +3505,7 @@ wax.g.connector = function(options) {
     this.tileDimension = options.tileSize || 256;
 
     // non-configurable options
-    this.interactive = true;
+    this.interactive = options.interactive !== false;
     this.tileSize = new google.maps.Size(this.tileDimension, this.tileDimension);
 
     // DOM element cache

--- a/app/assets/javascripts/wax.g.js
+++ b/app/assets/javascripts/wax.g.js
@@ -2312,15 +2312,16 @@ wax.gi = function(grid_tile, options) {
 // It takes one options object, which current accepts a single option:
 // `resolution` determines the number of pixels per grid element in the grid.
 // The default is 4.
-wax.gm = function() {
-
+wax.gm = function( options ) {
+    options = options || { };
     var resolution = 4,
         grid_tiles = {},
         manager = {},
         tilejson,
         formatter,
         minZoom,
-        maxZoom;
+        maxZoom,
+        tileSize = options.tileSize || 256;
 
     var gridUrl = function(url) {
         if (url) {
@@ -2388,7 +2389,8 @@ wax.gm = function() {
             if (err) return callback(err, null);
             callback(null, wax.gi(t, {
                 formatter: formatter,
-                resolution: resolution
+                resolution: resolution,
+                tileSize: tileSize
             }));
         });
         return manager;
@@ -2484,8 +2486,9 @@ wax.hash = function(options) {
 };
 wax = wax || {};
 
-wax.interaction = function() {
-    var gm = wax.gm(),
+wax.interaction = function( options ) {
+    options = options || { };
+    var gm = wax.gm( options ),
         interaction = {},
         _downLock = false,
         _clickTimeout = null,
@@ -2499,7 +2502,8 @@ wax.interaction = function() {
         detach,
         parent,
         map,
-        tileGrid;
+        tileGrid,
+        tileSize = options.tileSize || 256;
 
     var defaultEvents = {
         mousemove: onMove,
@@ -2519,9 +2523,9 @@ wax.interaction = function() {
         var g = grid();
         for (var i = 0; i < g.length; i++) {
             if ((g[i][0] < e.y) &&
-               ((g[i][0] + 256) > e.y) &&
+               ((g[i][0] + tileSize) > e.y) &&
                 (g[i][1] < e.x) &&
-               ((g[i][1] + 256) > e.x)) return g[i][2];
+               ((g[i][1] + tileSize) > e.x)) return g[i][2];
         }
         return false;
     }
@@ -2649,6 +2653,7 @@ wax.interaction = function() {
         var ignoreThisZoom = (zoom < gm.minZoom() || zoom > gm.maxZoom());
         var tile = ignoreThisZoom ? 'undefined' : getTile(pos);
         if (!tile) callback(null);
+
         gm.getGrid(tile.src, function(err, g) {
             if (err || !g) return callback(null);
             var feature = g.tileFeature(pos.x, pos.y, tile);
@@ -3379,7 +3384,7 @@ wax.g.hash = function(map) {
 wax = wax || {};
 wax.g = wax.g || {};
 
-wax.g.interaction = function() {
+wax.g.interaction = function( options ) {
     var dirty = false, _grid, map;
     var tileloadListener = null,
         idleListener = null;
@@ -3431,7 +3436,7 @@ wax.g.interaction = function() {
 
 
 
-    return wax.interaction()
+    return wax.interaction( options )
         .attach(attach)
         .detach(detach)
         .parent(function() {
@@ -3496,10 +3501,11 @@ wax.g.connector = function(options) {
     this.maxZoom = options.maxzoom || 22;
     this.name = options.name || '';
     this.description = options.description || '';
+    this.tileDimension = options.tileSize || 256;
 
     // non-configurable options
     this.interactive = true;
-    this.tileSize = new google.maps.Size(256, 256);
+    this.tileSize = new google.maps.Size(this.tileDimension, this.tileDimension);
 
     // DOM element cache
     this.cache = {};
@@ -3509,7 +3515,7 @@ wax.g.connector = function(options) {
 // Get a tile element from a coordinate, zoom level, and an ownerDocument.
 wax.g.connector.prototype.getTile = function(coord, zoom, ownerDocument) {
     var key = zoom + '/' + coord.x + '/' + coord.y;
-    var img = this.cache[key] = new Image(256, 256);
+    var img = this.cache[key] = new Image(this.tileDimension, this.tileDimension);
     if (zoom < this.minZoom || zoom > this.maxZoom) {
       this.cache[key].src = this.options.blankImage
       this.cache[key].style.display = 'none'


### PR DESCRIPTION
- Updates wax.g to allow for configurable tile size
- Use 512x512px tiles for non-interactive polygon tiles