### PR TITLE
Trips

### DIFF
--- a/app/assets/javascripts/trips/form.js
+++ b/app/assets/javascripts/trips/form.js
@@ -79,6 +79,7 @@ $(document).ready(function() {
         row = $('#trip_purposes .nested-fields:last')
     $(':input[name*=resource_type]', row).val('Taxon')
     $(':input[name*=resource_id]', row).val(taxon.id)
+    $(':input[name*=complete]', row).val(true)
     $('#new_goal_taxon').chooser('clear')
     $('#trip_purposes').data('last-taxon', null)
     row.attr('data-taxon-id', taxon.id)

--- a/app/assets/javascripts/trips/form.js
+++ b/app/assets/javascripts/trips/form.js
@@ -79,7 +79,7 @@ $(document).ready(function() {
         row = $('#trip_purposes .nested-fields:last')
     $(':input[name*=resource_type]', row).val('Taxon')
     $(':input[name*=resource_id]', row).val(taxon.id)
-    $(':input[name*=complete]', row).val(true)
+    $( ':input[name*=complete]', row ).val( true )
     $('#new_goal_taxon').chooser('clear')
     $('#trip_purposes').data('last-taxon', null)
     row.attr('data-taxon-id', taxon.id)

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -88,8 +88,8 @@ class TripsController < ApplicationController
           FakeView.image_url(@trip.user.icon.url(:original))
         end
         @shareable_description = FakeView.shareable_description( @trip.body ) if @trip.body
-        trip_purpose_taxon_ids = @trip.trip_purposes.where(complete: true).map(&:resource_id).flatten.uniq
-        @target_list_taxa = Taxon.find(trip_purpose_taxon_ids).select{|t| (t.ancestor_ids & trip_purpose_taxon_ids).count == 0 }
+        trip_purpose_taxon_ids = @trip.trip_purposes.where( complete: true ).map( &:resource_id ).flatten.uniq
+        @target_list_taxa = Taxon.find( trip_purpose_taxon_ids ).select{ |t| ( t.ancestor_ids & trip_purpose_taxon_ids ).count == 0 }
         obs = INatAPIService.observations( {
           latitude: @trip.latitude,
           longitude: @trip.longitude,
@@ -103,10 +103,10 @@ class TripsController < ApplicationController
         @target_list_taxa.each do |tlt|
           if o = obs.select{|o| o["taxon"]["ancestor_ids"].include? tlt.id}
             unless o.select{|i| i["obscured"]}.count > 0
-              @target_list_set << {taxon: tlt, observations: o}
+              @target_list_set << { taxon: tlt, observations: o }
             end
           else
-            @target_list_set << {taxon: tlt, observations: []}
+            @target_list_set << { taxon: tlt, observations: [] }
           end
         end
         
@@ -275,11 +275,11 @@ class TripsController < ApplicationController
     per_page = per_page.to_i
     
     scope = Trip.all
-    scope = scope.taxon(@taxon) if @taxon
-    scope = scope.year(@year) if @year
-    scope = scope.month(@month) if @month
-    scope = scope.place(@place) if @place
-    @trips = scope.published.page(params[:page]).per_page(per_page).order("posts.id DESC")
+    scope = scope.taxon( @taxon ) if @taxon
+    scope = scope.year( @year ) if @year
+    scope = scope.month( @month ) if @month
+    scope = scope.place( @place ) if @place
+    @trips = scope.published.page( params[:page] ).per_page( per_page ).order( "posts.id DESC" )
 
     respond_to do |format|
       format.html

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -4,6 +4,7 @@ class TripsController < ApplicationController
   before_filter :load_record, :only => [:show, :edit, :update, :destroy, :add_taxa_from_observations, :remove_taxa]
   before_filter :require_owner, :only => [:edit, :update, :destroy, :add_taxa_from_observations, :remove_taxa]
   before_filter :load_form_data, :only => [:new, :edit]
+  before_filter :set_feature_test, :only => [:index, :show, :tabulate]
   before_filter :load_user_by_login, :only => [:by_login]
 
   layout "bootstrap"
@@ -93,11 +94,11 @@ class TripsController < ApplicationController
           latitude: @trip.latitude,
           longitude: @trip.longitude,
           radius: @trip.radius,
-          d1: @trip.start_time.xmlschema,
-          d2: @trip.stop_time.xmlschema,
-          user_id: @trip.user_id
+          d1: @trip.start_time.iso8601,
+          d2: @trip.stop_time.iso8601,
+          user_id: @trip.user_id,
+          per_page: 200
         } ).results
-        
         @target_list_set = []
         @target_list_taxa.each do |tlt|
           if o = obs.select{|o| o["taxon"]["ancestor_ids"].include? tlt.id}

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -87,8 +87,8 @@ class TripsController < ApplicationController
           FakeView.image_url(@trip.user.icon.url(:original))
         end
         @shareable_description = FakeView.shareable_description( @trip.body ) if @trip.body
-        trip_purpose_taxon_ids = @trip.trip_purposes.map(&:resource_id).flatten.uniq
-        @check_list_taxa = Taxon.find(trip_purpose_taxon_ids).select{|t| (t.ancestor_ids & trip_purpose_taxon_ids).count == 0 }
+        trip_purpose_taxon_ids = @trip.trip_purposes.where(complete: true).map(&:resource_id).flatten.uniq
+        @target_list_taxa = Taxon.find(trip_purpose_taxon_ids).select{|t| (t.ancestor_ids & trip_purpose_taxon_ids).count == 0 }
         obs = INatAPIService.observations( {
           latitude: @trip.latitude,
           longitude: @trip.longitude,
@@ -98,14 +98,14 @@ class TripsController < ApplicationController
           user_id: @trip.user_id
         } ).results
         
-        @check_list_set = []
-        @check_list_taxa.each do |clt|
-          if o = obs.select{|o| o["taxon"]["ancestor_ids"].include? clt.id}
+        @target_list_set = []
+        @target_list_taxa.each do |tlt|
+          if o = obs.select{|o| o["taxon"]["ancestor_ids"].include? tlt.id}
             unless o.select{|i| i["obscured"]}.count > 0
-              @check_list_set << {taxon: clt, observations: o}
+              @target_list_set << {taxon: tlt, observations: o}
             end
           else
-            @check_list_set << {taxon: clt, observations: []}
+            @target_list_set << {taxon: tlt, observations: []}
           end
         end
         

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -17,7 +17,7 @@ class Trip < Post
   scope :place, lambda{ |place| where("latitude > ? AND latitude <= ? AND longitude > ? AND longitude <= ?", place.swlat, place.nelat, place.swlng, place.nelng) }
   scope :taxon, lambda{ |taxon|
     joins( TRIP_PURPOSE_JOINS ).
-    where( "tp.resource_id IN (?)", [taxon.ancestor_ids, taxon.id].flatten )
+    where( "tp.complete = true AND tp.resource_id IN (?)", [taxon.ancestor_ids, taxon.id].flatten )
   }  
   
   def set_parent

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -7,7 +7,19 @@ class Trip < Post
   accepts_nested_attributes_for :trip_taxa, :allow_destroy => true
 
   before_validation :set_parent
-
+  
+  TRIP_PURPOSE_JOINS = [
+    "JOIN trip_purposes tp ON tp.trip_id = posts.id"
+  ]
+  
+  scope :year, lambda { |year| where( "EXTRACT(YEAR FROM start_time) = ?", year ) }
+  scope :month, lambda { |month| where( "EXTRACT(MONTH FROM start_time) = ?", month ) }  
+  scope :place, lambda{ |place| where("latitude > ? AND latitude <= ? AND longitude > ? AND longitude <= ?", place.swlat, place.nelat, place.swlng, place.nelng) }
+  scope :taxon, lambda{ |taxon|
+    joins( TRIP_PURPOSE_JOINS ).
+    where( "tp.resource_id IN (?)", [taxon.ancestor_ids, taxon.id].flatten )
+  }  
+  
   def set_parent
     self.parent ||= self.user
   end

--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -25,6 +25,9 @@
           = t :allowed_html
           \:
         = Post::ALLOWED_TAGS.to_a.sort.join(', ')
+      .row
+        .col-md-6= f.text_field :distance, :label => t(:distance_traveled_in_meters)
+        .col-md-6= f.text_field :number, :label => t(:number_of_observers)
       %h3=t :when_did_you_go?
       .row
         .col-md-6= f.text_field :start_time, :value => (@trip.start_time || Chronic.parse("today at 9am")).strftime("%Y-%m-%d %H:%m %z"), :label => t(:start_time), :placeholder => t(:start_time, :default => "Start time")
@@ -40,7 +43,7 @@
       .coordinates.row
         .col-md-4= f.text_field :latitude, :label => t(:lat), :class => "form-control"
         .col-md-4= f.text_field :longitude, :label => t(:lon), :class => "form-control"
-        .col-md-4= f.text_field :radius, :label => t(:radius), :class => "form-control"
+        .col-md-4= f.text_field :radius, :label => t(:radius_in_meters), :class => "form-control"
   #trip_purposes_row.row
     .col-md-12
       %h3=t :what_were_you_looking_for?
@@ -61,50 +64,6 @@
           .hide
             = link_to_add_association t(:add_trip_purpose), f, :trip_purposes, "data-association-insertion-method" => "append", "data-association-insertion-node" => "#trip_purposes", :class => "btn btn-sm btn-success"
           = text_field_tag :new_goal_taxon, '', :class => 'col-md-4', :placeholder => t(:start_typing_taxon_name)
-  #trip_taxa_row.stacked
-    .row
-      .col-md-12
-        %h3=t :check_list
-        - if @trip && @trip.persisted?
-          = link_to t(:add_from_observations), add_taxa_from_observations_trip_path(@trip), :id => "addfromobsbutton", :class => 'btn btn-default btn-sm', :method => :post, :remote => true, :data => {:type => 'json', :loading_click => t(:adding)}
-          :ruby
-            opts = {
-              :id => "removetaxabutton", 
-              :class => 'btn btn-default btn-sm', 
-              :method => :delete, 
-              :remote => true, 
-              :data => {
-                :type => 'json', 
-                :loading_click => t(:removing),
-                confirm: t(:are_you_sure?)
-              }
-            }
-          = link_to t(:remove_all), remove_taxa_trip_path(@trip), opts
-    .row
-      .col-md-8
-        %table.taxon_links.stacked.table
-          %thead
-            %tr
-              %th.observed Observed?
-              %th.name Name
-              %th
-          %tbody#trip_taxa
-            = f.fields_for :trip_taxa do |tt|
-              = render "trip_taxon_fields", :f => tt
-        .hide
-          = link_to_add_association t(:add_trip_taxon), f, :trip_taxa, "data-association-insertion-method" => "append", "data-association-insertion-node" => "#trip_taxa"
-        %label=t :add_a_species
-        = text_field_tag :new_species, '', :class => 'col-md-5', :placeholder => t(:start_typing_taxon_name)
-      .col-md-4
-        %p Check the groups for which this represents a complete list of all the species you observed in that group
-        %ul#complete_taxa.plain.taxon_links
-          - for tp in @trip.trip_purposes.select{|tp| tp.resource_type == 'Taxon' && tp.resource.rank_level > Taxon::SPECIES_LEVEL}
-            - elt_id = "#{tp.resource.name.underscore}_complete"
-            %li{:data => {:taxon_id => tp.resource_id}}
-              .checkbox
-                %label{:for => elt_id}
-                  = check_box_tag elt_id, elt_id, tp.complete?, :data => {:taxon => tp.resource.as_json}
-                  = render "shared/taxon", :taxon => tp.resource
   / #trip_users_row.row.stacked
   /   .col-md-12
   /     %h3=t :who_were_you_with?

--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -26,8 +26,8 @@
           \:
         = Post::ALLOWED_TAGS.to_a.sort.join(', ')
       .row
-        .col-md-6= f.text_field :distance, :label => t( :distance_traveled_label )
-        .col-md-6= f.text_field :number, :label => t( :number_of_observers_label )
+        .col-md-6= f.text_field :distance, :label => t( :distance_traveled )
+        .col-md-6= f.text_field :number, :label => t( :number_of_observers )
       %h3=t :when_did_you_go?
       .row
         .col-md-6= f.text_field :start_time, :value => (@trip.start_time || Chronic.parse("today at 9am")).strftime("%Y-%m-%d %H:%m %z"), :label => t(:start_time), :placeholder => t(:start_time, :default => "Start time")

--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -26,8 +26,8 @@
           \:
         = Post::ALLOWED_TAGS.to_a.sort.join(', ')
       .row
-        .col-md-6= f.text_field :distance, :label => t(:distance_traveled_in_meters)
-        .col-md-6= f.text_field :number, :label => t(:number_of_observers)
+        .col-md-6= f.text_field :distance, :label => t(:distance_traveled_label)
+        .col-md-6= f.text_field :number, :label => t(:number_of_observers_label)
       %h3=t :when_did_you_go?
       .row
         .col-md-6= f.text_field :start_time, :value => (@trip.start_time || Chronic.parse("today at 9am")).strftime("%Y-%m-%d %H:%m %z"), :label => t(:start_time), :placeholder => t(:start_time, :default => "Start time")
@@ -43,7 +43,7 @@
       .coordinates.row
         .col-md-4= f.text_field :latitude, :label => t(:lat), :class => "form-control"
         .col-md-4= f.text_field :longitude, :label => t(:lon), :class => "form-control"
-        .col-md-4= f.text_field :radius, :label => t(:radius_in_meters), :class => "form-control"
+        .col-md-4= f.text_field :radius, :label => t(:radius), :class => "form-control"
   #trip_purposes_row.row
     .col-md-12
       %h3=t :what_were_you_looking_for?

--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -26,8 +26,8 @@
           \:
         = Post::ALLOWED_TAGS.to_a.sort.join(', ')
       .row
-        .col-md-6= f.text_field :distance, :label => t(:distance_traveled_label)
-        .col-md-6= f.text_field :number, :label => t(:number_of_observers_label)
+        .col-md-6= f.text_field :distance, :label => t( :distance_traveled_label )
+        .col-md-6= f.text_field :number, :label => t( :number_of_observers_label )
       %h3=t :when_did_you_go?
       .row
         .col-md-6= f.text_field :start_time, :value => (@trip.start_time || Chronic.parse("today at 9am")).strftime("%Y-%m-%d %H:%m %z"), :label => t(:start_time), :placeholder => t(:start_time, :default => "Start time")

--- a/app/views/trips/_trip_purpose_fields.html.haml
+++ b/app/views/trips/_trip_purpose_fields.html.haml
@@ -12,6 +12,5 @@
     = f.hidden_field :trip_id
     = f.hidden_field :resource_type
     = f.hidden_field :resource_id
-    = f.text_field :complete
   .col-xs-2
     = link_to_remove_association t(:remove), f, :class => "btn btn-default btn-xs"

--- a/app/views/trips/_trip_purpose_fields.html.haml
+++ b/app/views/trips/_trip_purpose_fields.html.haml
@@ -12,5 +12,6 @@
     = f.hidden_field :trip_id
     = f.hidden_field :resource_type
     = f.hidden_field :resource_id
+    = f.hidden_field :complete, value: true
   .col-xs-2
     = link_to_remove_association t(:remove), f, :class => "btn btn-default btn-xs"

--- a/app/views/trips/index.html.haml
+++ b/app/views/trips/index.html.haml
@@ -1,5 +1,5 @@
 - content_for( :title ) do
-  - @title = t(:trips)
+  - @title = t( :trips )
   = strip_tags( @title )
 .container
   .row
@@ -17,42 +17,42 @@
             = link_to "Read more", "/pages/trips"
   .row
     .col-xs-12
-      = link_to t(:new_trip), new_trip_path, :class => "default button right"
-      = link_to t(:tabulate_presence_absence_data_from_trips), tabulate_trips_path, :class => "white button left"
+      = link_to t( :new_trip ), new_trip_path, :class => "default button right"
+      = link_to t( :tabulate_presence_absence_data_from_trips ), tabulate_trips_path, :class => "white button left"
   .row
     .col-md-12
       - if @trips.empty?
         %p.description= t :no_trips
       - else
-        %table{class: "table table-striped"}
+        %table{ class: "table table-striped" }
           %thead
             %tr
-              %th{scope: "col"} Trip
-              %th{scope: "col"} Title
-              %th{scope: "col"} User
-              %th{scope: "col"} Latitude
-              %th{scope: "col"} Longitude
-              %th{scope: "col"} Date
-              %th{scope: "col"} Duration (minutes)
-              %th{scope: "col"} Distance (meters)
-              %th{scope: "col"} # Observers
+              %th{ scope: "col" } Trip
+              %th{ scope: "col" } Title
+              %th{ scope: "col" } User
+              %th{ scope: "col" } Latitude
+              %th{ scope: "col" } Longitude
+              %th{ scope: "col" } Date
+              %th{ scope: "col" } Duration (minutes)
+              %th{ scope: "col" } Distance (meters)
+              %th{ scope: "col" } # Observers
           %tbody
             - for trip in @trips
               %tr
-                %th{scope: "row"}
-                  =link_to trip.id, trip_path(trip)
+                %th{ scope: "row" }
+                  =link_to trip.id, trip_path( trip )
                 %td
-                  =trip.title.truncate(50)
+                  =trip.title.truncate( 50 )
                 %td
-                  =link_to trip.user.login, user_path(trip.user_id) if trip.user_id
+                  =link_to trip.user.login, user_path( trip.user_id ) if trip.user_id
                 %td
-                  =trip.latitude.round(3) if trip.latitude
+                  =trip.latitude.round( 3 ) if trip.latitude
                 %td
-                  =trip.longitude.round(3) if trip.longitude
+                  =trip.longitude.round( 3 ) if trip.longitude
                 %td
-                  =trip.start_time.strftime("%m/%d/%Y")
+                  =trip.start_time.strftime( "%m/%d/%Y" )
                 %td
-                  =(( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
+                  =( ( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
                 %td
                   =trip.distance.to_i if trip.distance
                 %td

--- a/app/views/trips/index.html.haml
+++ b/app/views/trips/index.html.haml
@@ -1,3 +1,15 @@
 .container
-  - for trip in @trips
-    %p= link_to trip.title, trip
+  .row
+    = link_to t(:new_trip), new_trip_path, :class => "default button right"
+  .row
+    .col-md-8
+      - for trip in @trips
+        %p
+          =link_to trip.title, trip
+          \|
+          = t( :distance_traveled, distance: trip.distance.to_i )  if trip.distance
+          \|
+          = t( :duration, duration: ( ( trip.stop_time - trip.start_time ) / 1.minutes ).to_i ) if ( trip.start_time && trip.stop_time )
+          \|
+          = t( :number_of_observers, number: trip.number ) if trip.number
+      = will_paginate @trips

--- a/app/views/trips/index.html.haml
+++ b/app/views/trips/index.html.haml
@@ -15,10 +15,12 @@
             = "The existence of observations in the context of trips can be used to tabulate presence absence data."
             = "Presence absence data can be useful for understanding samplibg bias in species distribution modeling."
             = link_to "Read more", "/pages/trips"
-    = link_to t(:new_trip), new_trip_path, :class => "default button right"
-    = link_to t(:tabulate_presence_absence_data_from_trips), tabulate_trips_path, :class => "white button left"
   .row
-    .col-md-8
+    .col-xs-12
+      = link_to t(:new_trip), new_trip_path, :class => "default button right"
+      = link_to t(:tabulate_presence_absence_data_from_trips), tabulate_trips_path, :class => "white button left"
+  .row
+    .col-md-12
       - if @trips.empty?
         %p.description= t :no_trips
       - else
@@ -26,6 +28,7 @@
           %thead
             %tr
               %th{scope: "col"} Trip
+              %th{scope: "col"} Title
               %th{scope: "col"} User
               %th{scope: "col"} Latitude
               %th{scope: "col"} Longitude
@@ -38,6 +41,8 @@
               %tr
                 %th{scope: "row"}
                   =link_to trip.id, trip_path(trip)
+                %td
+                  =trip.title.truncate(50)
                 %td
                   =link_to trip.user.login, user_path(trip.user_id) if trip.user_id
                 %td

--- a/app/views/trips/index.html.haml
+++ b/app/views/trips/index.html.haml
@@ -54,7 +54,7 @@
                 %td
                   =(( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
                 %td
-                  =trip.distance.to_i
+                  =trip.distance.to_i if trip.distance
                 %td
                   =trip.number
         = will_paginate @trips

--- a/app/views/trips/index.html.haml
+++ b/app/views/trips/index.html.haml
@@ -1,15 +1,55 @@
+- content_for( :title ) do
+  - @title = t(:trips)
+  = strip_tags( @title )
 .container
   .row
+    .col-xs-12
+      %h2= @title
+      .panel.panel-info
+        .panel-heading
+          %h3.panel-title
+            = "About Trips"
+        .panel-body
+          %p
+            = "Trips describe survey effort by recording where and when an area was surveyed and what was targeted."
+            = "The existence of observations in the context of trips can be used to tabulate presence absence data."
+            = "Presence absence data can be useful for understanding samplibg bias in species distribution modeling."
+            = link_to "Read more", "/pages/trips"
     = link_to t(:new_trip), new_trip_path, :class => "default button right"
+    = link_to t(:tabulate_presence_absence_data_from_trips), tabulate_trips_path, :class => "white button left"
   .row
     .col-md-8
-      - for trip in @trips
-        %p
-          =link_to trip.title, trip
-          \|
-          = t( :distance_traveled, distance: trip.distance.to_i )  if trip.distance
-          \|
-          = t( :duration, duration: ( ( trip.stop_time - trip.start_time ) / 1.minutes ).to_i ) if ( trip.start_time && trip.stop_time )
-          \|
-          = t( :number_of_observers, number: trip.number ) if trip.number
-      = will_paginate @trips
+      - if @trips.empty?
+        %p.description= t :no_trips
+      - else
+        %table{class: "table table-striped"}
+          %thead
+            %tr
+              %th{scope: "col"} Trip
+              %th{scope: "col"} User
+              %th{scope: "col"} Latitude
+              %th{scope: "col"} Longitude
+              %th{scope: "col"} Date
+              %th{scope: "col"} Duration (minutes)
+              %th{scope: "col"} Distance (meters)
+              %th{scope: "col"} # Observers
+          %tbody
+            - for trip in @trips
+              %tr
+                %th{scope: "row"}
+                  =link_to trip.id, trip_path(trip)
+                %td
+                  =link_to trip.user.login, user_path(trip.user_id) if trip.user_id
+                %td
+                  =trip.latitude.round(3) if trip.latitude
+                %td
+                  =trip.longitude.round(3) if trip.longitude
+                %td
+                  =trip.start_time.strftime("%m/%d/%Y")
+                %td
+                  =(( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
+                %td
+                  =trip.distance.to_i
+                %td
+                  =trip.number
+        = will_paginate @trips

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -13,6 +13,8 @@
   %meta{:name => "twitter:card", :content => "summary"}
   %meta{:name => "og:title", :content => html_attributize(@title)}
 .container
+  - if @trip.published_at.nil?
+    .alert.alert-warning.upstacked= t(:preview)
   %ul.breadcrumb.clearfix
     %li
       - if @trip.parent.is_a?(Project)
@@ -88,10 +90,12 @@
             - for element in @check_list_set
               %li
                 = render "shared/taxon", :taxon => element[:taxon], :link_url => element[:taxon]
-                - if element[:observation]
-                  = link_to observation_path(:id => element[:observation]["id"])  do
-                    %svg{ :height => "10", :width => "10" }
-                      %circle{:cx => "5", :cy => "5", :r => "5", :stroke => "black", :stroke-width => "3", :fill => "#337ab7"}
+                - if element[:observations].count > 0
+                  - element[:observations].each do |o|
+                    = link_to observation_path(:id => o["id"])  do
+                      %svg{ :height => "10", :width => "10" }
+                        %title= o["taxon"]["name"]
+                        %circle{:cx => "5", :cy => "5", :r => "5", :stroke => "black", :stroke-width => "3", :fill => "#337ab7"}
       %section{:id => "comments"}
         - if @trip.published_at
           = render :partial => 'comments/comments', :locals => { :parent => @trip, :header_tag => :h2 }

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -6,6 +6,9 @@
   :javascript
     $('.observationcontrols').observationControls()
     $("#comment_body").textcompleteUsers( );
+    $( document ).ready( function() {
+      $( '[data-toggle="popover"]' ).popover({html:true});
+    } );
 - content_for :extrahead do
   %meta{:property => "og:image", :content => html_attributize(@shareable_image_url)}
   %meta{:property => "twitter:image", :content => html_attributize(@shareable_image_url)}
@@ -47,10 +50,10 @@
         %li= link_to t(:summary), "#summary"
         - unless @trip.body.blank?
           %li= link_to t(:description), "#description"
-        - unless @trip.observations.blank? || @trip.is_a?(Trip)
-          %li= link_to t(:observations), "#observations"
         - if @trip.is_a?(Trip)
-          %li= link_to t(:check_list), "#check_list"
+          %li= link_to t(:target_list), "#target_list"
+        - unless @trip.observations.blank?
+          %li= link_to t(:observations), "#observations"
         %li= link_to t(:comments), "#comments"
     .col-xs-9
       %section{:id => "summary"}
@@ -81,13 +84,15 @@
               = link_to_user @trip.user
             =l @trip.published_at, :format => :long if @trip.published?
       - if @trip.is_a?(Trip)
-        %section{:id => "check_list"}
-          %h2=t :check_list
-          - if @check_list_set.blank?
+        %section{:id => "target_list"}
+          %h2
+            =t :target_list
+            %span.glyphicon.glyphicon-info-sign.info-link{ "style" => "margin-left:5px;font-size:15px;color:gray", "data-content" => t(:trip_target_list_info), "data-placement" => "top", "data-toggle" => "popover" }
+          - if @target_list_set.blank?
             .text-muted.nocontent=t :no_taxa_listed
           - else
             %ul.taxon_links.plain
-            - for element in @check_list_set
+            - for element in @target_list_set
               %li
                 = render "shared/taxon", :taxon => element[:taxon], :link_url => element[:taxon]
                 - if element[:observations].count > 0
@@ -96,6 +101,27 @@
                       %svg{ :height => "10", :width => "10" }
                         %title= o["taxon"]["name"]
                         %circle{:cx => "5", :cy => "5", :r => "5", :stroke => "black", :stroke-width => "3", :fill => "#337ab7"}
+      - unless @trip.observations.blank?
+        %section{:id => "observations"}
+          .observationcontrols.pull-right
+          %h2=t :observations
+          .observations.medium.grid
+            - compact do
+              = render :partial => "observations/cached_component", :collection => @trip.observations
+          - if @trip.is_a?(Trip)
+            .text-muted
+              :ruby
+                obs_params = {
+                  :d1 => @trip.start_time.iso8601,
+                  :d2 => @trip.stop_time.iso8601,
+                  :user_id => @trip.user_id
+                }
+                obs_params[:place_id] = @trip.place_id unless @trip.place_id.blank?
+              = link_to observations_url(obs_params), :class => "readmore" do
+                View observations made between 
+                =l @trip.start_time, :format => :short
+                =t :and
+                =l @trip.stop_time, :format => :short
       %section{:id => "comments"}
         - if @trip.published_at
           = render :partial => 'comments/comments', :locals => { :parent => @trip, :header_tag => :h2 }

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -50,8 +50,8 @@
         %li= link_to t(:summary), "#summary"
         - unless @trip.body.blank?
           %li= link_to t(:description), "#description"
-        - if @trip.is_a?(Trip) && !@target_list_set.blank?
-          %li= link_to t(:target_list), "#target_list"
+        - if @trip.is_a?( Trip ) && !@target_list_set.blank?
+          %li= link_to t( :target_list ), "#target_list"
         - unless @trip.observations.blank?
           %li= link_to t(:observations), "#observations"
         %li= link_to t(:comments), "#comments"
@@ -95,10 +95,10 @@
                 = render "shared/taxon", :taxon => element[:taxon], :link_url => element[:taxon]
                 - if element[:observations].count > 0
                   - element[:observations].each do |o|
-                    = link_to observation_path(:id => o["id"])  do
+                    = link_to observation_path( :id => o["id"] )  do
                       %svg{ :height => "10", :width => "10" }
                         %title= o["taxon"]["name"]
-                        %circle{:cx => "5", :cy => "5", :r => "5", :stroke => "black", :stroke-width => "3", :fill => "#337ab7"}
+                        %circle{ :cx => "5", :cy => "5", :r => "5", :stroke => "black", :stroke-width => "3", :fill => "#337ab7" }
       - unless @trip.observations.blank?
         %section{:id => "observations"}
           .observationcontrols.pull-right

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -50,7 +50,7 @@
         %li= link_to t(:summary), "#summary"
         - unless @trip.body.blank?
           %li= link_to t(:description), "#description"
-        - if @trip.is_a?(Trip)
+        - if @trip.is_a?(Trip) && !@target_list_set.blank?
           %li= link_to t(:target_list), "#target_list"
         - unless @trip.observations.blank?
           %li= link_to t(:observations), "#observations"
@@ -84,13 +84,11 @@
               = link_to_user @trip.user
             =l @trip.published_at, :format => :long if @trip.published?
       - if @trip.is_a?(Trip)
-        %section{:id => "target_list"}
-          %h2
-            =t :target_list
-            %span.glyphicon.glyphicon-info-sign.info-link{ "style" => "margin-left:5px;font-size:15px;color:gray", "data-content" => t(:trip_target_list_info), "data-placement" => "top", "data-toggle" => "popover" }
-          - if @target_list_set.blank?
-            .text-muted.nocontent=t :no_taxa_listed
-          - else
+        - unless @target_list_set.blank?
+          %section{:id => "target_list"}
+            %h2
+              =t :target_list
+              %span.glyphicon.glyphicon-info-sign.info-link{ "style" => "margin-left:5px;font-size:15px;color:gray", "data-content" => t(:trip_target_list_info), "data-placement" => "top", "data-toggle" => "popover" }
             %ul.taxon_links.plain
             - for element in @target_list_set
               %li
@@ -118,9 +116,11 @@
                 }
                 obs_params[:place_id] = @trip.place_id unless @trip.place_id.blank?
               = link_to observations_url(obs_params), :class => "readmore" do
-                View observations made between 
+                View all observations made by 
+                =@trip.user.login
+                between
                 =l @trip.start_time, :format => :short
-                =t :and
+                and
                 =l @trip.stop_time, :format => :short
       %section{:id => "comments"}
         - if @trip.published_at

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -69,11 +69,17 @@
             \-
             = l(@trip.stop_time, :format => :long) if @trip.start_time
           .small.text-muted.stacked
-            = t( :distance_traveled, distance: @trip.distance.to_i )  if @trip.distance
+            = t( :latitude_value, latitude: @trip.latitude.round( 3 ) )  if @trip.latitude
             \|
-            = t( :duration, duration: ( ( @trip.stop_time - @trip.start_time ) / 1.minutes ).to_i ) if ( @trip.start_time && @trip.stop_time )
+            = t( :longitude_value, longitude: @trip.longitude.round( 3 ) )  if @trip.longitude
             \|
-            = t( :number_of_observers, number: @trip.number ) if @trip.number
+            = t( :radius_value, radius: @trip.radius )  if @trip.radius
+            \|
+            = t( :distance_traveled_value, distance: @trip.distance.to_i )  if @trip.distance
+            \|
+            = t( :duration_value, duration: ( ( @trip.stop_time - @trip.start_time ) / 1.minutes ).to_i ) if ( @trip.start_time && @trip.stop_time )
+            \|
+            = t( :number_of_observers_value, number: @trip.number ) if @trip.number
       - unless @trip.body.blank?
         %section.stacked.post{:id => "description"}
           = formatted_user_text(@trip.body, scrubber: PostScrubber.new(tags: Post::ALLOWED_TAGS, attributes: Post::ALLOWED_ATTRIBUTES), skip_simple_format: (@trip.preferred_formatting == Post::FORMATTING_NONE))

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -45,7 +45,7 @@
         %li= link_to t(:summary), "#summary"
         - unless @trip.body.blank?
           %li= link_to t(:description), "#description"
-        - unless @trip.observations.blank?
+        - unless @trip.observations.blank? || @trip.is_a?(Trip)
           %li= link_to t(:observations), "#observations"
         - if @trip.is_a?(Trip)
           %li= link_to t(:check_list), "#check_list"
@@ -59,11 +59,16 @@
               = t(:edit)
         %h1= @title
         - if @trip.is_a?(Trip)
-          .subtitle.text-muted.lead
+          .subtitle.text-muted
             = l(@trip.start_time, :format => :long) if @trip.start_time
             \-
             = l(@trip.stop_time, :format => :long) if @trip.start_time
-
+          .small.text-muted.stacked
+            = t( :distance_traveled, distance: @trip.distance.to_i )  if @trip.distance
+            \|
+            = t( :duration, duration: ( ( @trip.stop_time - @trip.start_time ) / 1.minutes ).to_i ) if ( @trip.start_time && @trip.stop_time )
+            \|
+            = t( :number_of_observers, number: @trip.number ) if @trip.number
       - unless @trip.body.blank?
         %section.stacked.post{:id => "description"}
           = formatted_user_text(@trip.body, scrubber: PostScrubber.new(tags: Post::ALLOWED_TAGS, attributes: Post::ALLOWED_ATTRIBUTES), skip_simple_format: (@trip.preferred_formatting == Post::FORMATTING_NONE))
@@ -73,64 +78,20 @@
               = user_image @trip.user, :size => "mini", :class => "img-rounded"
               = link_to_user @trip.user
             =l @trip.published_at, :format => :long if @trip.published?
-      - unless @trip.observations.blank?
-        %section{:id => "observations"}
-          .observationcontrols.pull-right
-          %h2=t :observations
-          .observations.medium.grid
-            - compact do
-              = render :partial => "observations/cached_component", :collection => @trip.observations
-          - if @trip.is_a?(Trip)
-            .text-muted
-              :ruby
-                obs_params = {
-                  :d1 => @trip.start_time.iso8601,
-                  :d2 => @trip.stop_time.iso8601,
-                  :user_id => @trip.user_id
-                }
-                obs_params[:place_id] = @trip.place_id unless @trip.place_id.blank?
-              = link_to observations_url(obs_params), :class => "readmore" do
-                View observations made between 
-                =l @trip.start_time, :format => :short
-                =t :and
-                =l @trip.stop_time, :format => :short
       - if @trip.is_a?(Trip)
         %section{:id => "check_list"}
           %h2=t :check_list
-          - if @trip_taxa.blank?
+          - if @check_list_set.blank?
             .text-muted.nocontent=t :no_taxa_listed
           - else
-            .row
-              .col-xs-6
-                %h4 Observed
-                - if @trip.trip_purposes.blank?
-                  %ul.taxon_links.plain
-                    - for trip_taxon in @trip_taxa_observed
-                      %li
-                        = render "shared/taxon", :taxon => trip_taxon.taxon, :link_url => trip_taxon.taxon
-                - else
-                  - for trip_purpose in @trip.trip_purposes
-                    %h5
-                      = trip_purpose.resource.default_name.name
-                      - if trip_purpose.complete?
-                        .label.label-success{data: {tip: "Complete list of taxa observed. Taxa not on this list were not observed."}}=t :complete
-                    %ul.taxon_links.plain
-                      - for trip_taxon in @trip_taxa_observed
-                        - if trip_taxon.ancestor_ids.include?(trip_purpose.resource_id)
-                          %li
-                            = render "shared/taxon", :taxon => trip_taxon.taxon, :link_url => trip_taxon.taxon
-                  - unless @trip_taxa_untargeted.blank?
-                    %h5 Everything else
-                    %ul.taxon_links.plain
-                      - for trip_taxon in @trip_taxa_untargeted
-                        %li
-                          = render "shared/taxon", :taxon => trip_taxon.taxon, :link_url => trip_taxon.taxon
-              .col-xs-6
-                %h4 Sought but not found
-                %ul.taxon_links.plain
-                  - for trip_taxon in @trip_taxa_unobserved
-                    %li
-                      = render "shared/taxon", :taxon => trip_taxon.taxon, :link_url => trip_taxon.taxon
+            %ul.taxon_links.plain
+            - for element in @check_list_set
+              %li
+                = render "shared/taxon", :taxon => element[:taxon], :link_url => element[:taxon]
+                - if element[:observation]
+                  = link_to observation_path(:id => element[:observation]["id"])  do
+                    %svg{ :height => "10", :width => "10" }
+                      %circle{:cx => "5", :cy => "5", :r => "5", :stroke => "black", :stroke-width => "3", :fill => "#337ab7"}
       %section{:id => "comments"}
         - if @trip.published_at
           = render :partial => 'comments/comments', :locals => { :parent => @trip, :header_tag => :h2 }

--- a/app/views/trips/tabulate.html.haml
+++ b/app/views/trips/tabulate.html.haml
@@ -71,21 +71,24 @@
             %thead
               %tr
                 %th{scope: "col"} Trip
-                %th{scope: "col"} Taxon
+                %th{scope: "col"} Title
+                %th{scope: "col"} User
                 %th{scope: "col"} Latitude
                 %th{scope: "col"} Longitude
                 %th{scope: "col"} Date
-                %th{scope: "col"} Duration (minutes)
-                %th{scope: "col"} Distance (meters)
-                %th{scope: "col"} # Observers
-                %th{scope: "col"} Presence/Absence
+                %th{scope: "col"} Duration(min)
+                %th{scope: "col"} Distance(m)
+                %th{scope: "col"} #Observers
+                %th{scope: "col"}=@taxon.name
             %tbody
               - for trip in @trips
                 %tr
                   %th{scope: "row"}
                     =link_to trip.id, trip_path(trip)
                   %td
-                    =@taxon.name
+                    =trip.title.truncate(15)
+                  %td
+                    =link_to trip.user.login.truncate(15), user_path(trip.user_id) if trip.user_id
                   %td
                     =trip.latitude.round(3) if trip.latitude
                   %td
@@ -95,11 +98,11 @@
                   %td
                     =(( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
                   %td
-                    =trip.distance.to_i
+                    =trip.distance.to_i if trip.distance
                   %td
                     =trip.number
                   %td
-                    N/A
+                    null
           = will_paginate @trips
       - else
         %p.description= t :please_enter_a_species

--- a/app/views/trips/tabulate.html.haml
+++ b/app/views/trips/tabulate.html.haml
@@ -1,0 +1,105 @@
+:ruby
+  if @taxon
+    @taxon.html = render( partial: "taxa/chooser.html.erb", object: @taxon )
+  end
+  @default_taxa = Taxon::ICONIC_TAXA.map do |taxon|
+    taxon.html = render( partial: "taxa/chooser.html.erb", object: taxon )
+    taxon
+  end
+- content_for( :title ) do
+  - @title = t(:tabulate_presence_absence_data_from_trips)
+  = strip_tags( @title )
+- content_for( :extracss ) do
+  = stylesheet_link_tag "autocomplete"
+  :css
+    .ui-chooser-choice { max-width: 190px; }
+    form .text { width: 200px; }
+    .taxon_framework_relationship { border-bottom: 1px solid #eee; margin-top: 10px; padding-bottom: 10px; }
+    .name { font-size: 110%; font-style: italic; }
+    .admin-box {
+        border-width: 2px;
+        border-style: dotted;
+        position: relative;
+        padding: 5px;
+    }
+- content_for( :extrajs ) do
+  :javascript
+    window.taxon = #{ json_escape @taxon.to_json( methods: [:html] ).html_safe }
+    window.place = #{ json_escape @place.to_json( methods: [:html] ).html_safe }
+    window.defaultTaxa = #{ json_escape @default_taxa.to_json( methods: [:html] ).html_safe }
+    $( document ).ready( function() {      
+      $( "#filters_place_id" ).chooser( {
+        queryParam: "q",
+        collectionUrl: "/places/search.json",
+        resourceUrl: "/places/{{id}}.json",
+        chosen: place
+      } )
+      $( "#filters_taxon_name" ).taxonAutocomplete( {
+        idEl: $( "#filters_taxon_id" ),
+        initialSelection: #{ raw @taxon.to_json },
+        thumbnail: false,
+        bootstrapClear: true
+      } );
+      
+    } )
+.container
+  .row
+    .col-xs-12
+      %ul.list-unstyled
+        %li
+          = link_to t(:back_to_x, :noun => "trips"), trips_path, :class => "back crumb"
+      %h2= @title
+      .panel.panel-info
+        .panel-heading
+          = "Notice - trips aren't yet properly calculating presence absence data"
+  .row
+    .col-xs-3
+      = form_for :filters, builder: DefaultFormBuilder, html: { method: :get } do |f|
+        = f.text_field :taxon_name, placeholder: t(:type_taxon_name), label: t(:taxon)
+        = f.hidden_field :taxon_id, value: @taxon ? @taxon.id : nil
+        = f.text_field :place_id, value: @place ? @place.id : nil, placeholder: t( :start_typing_place_name ), label: t( :place )
+        = f.select :month, [1,2,3,4,5,6,7,8,9,10,11,12], include_blank: t( :any ), selected: @month, label: t( :month )
+        = f.select :year, [2019], include_blank: t( :any ), selected: @year, label: t( :year )
+        = f.submit t( :filter ), class: "default button", "data-loading-click": t( :filtering )
+        = link_to t( :clear_filters ), tabulate_trips_url, class: "minor button"
+    .col-xs-9
+      - if @taxon
+        - if @trips.empty?
+          %p.description= t :no_trips
+        - else
+          %table{class: "table table-striped"}
+            %thead
+              %tr
+                %th{scope: "col"} Trip
+                %th{scope: "col"} Taxon
+                %th{scope: "col"} Latitude
+                %th{scope: "col"} Longitude
+                %th{scope: "col"} Date
+                %th{scope: "col"} Duration (minutes)
+                %th{scope: "col"} Distance (meters)
+                %th{scope: "col"} # Observers
+                %th{scope: "col"} Presence/Absence
+            %tbody
+              - for trip in @trips
+                %tr
+                  %th{scope: "row"}
+                    =link_to trip.id, trip_path(trip)
+                  %td
+                    =@taxon.name
+                  %td
+                    =trip.latitude.round(3) if trip.latitude
+                  %td
+                    =trip.longitude.round(3) if trip.longitude
+                  %td
+                    =trip.start_time.strftime("%m/%d/%Y")
+                  %td
+                    =(( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
+                  %td
+                    =trip.distance.to_i
+                  %td
+                    =trip.number
+                  %td
+                    N/A
+          = will_paginate @trips
+      - else
+        %p.description= t :please_enter_a_species

--- a/app/views/trips/tabulate.html.haml
+++ b/app/views/trips/tabulate.html.haml
@@ -47,7 +47,7 @@
     .col-xs-12
       %ul.list-unstyled
         %li
-          = link_to t(:back_to_x, :noun => "trips"), trips_path, :class => "back crumb"
+          = link_to t( :back_to_x, :noun => "trips" ), trips_path, :class => "back crumb"
       %h2= @title
       .panel.panel-info
         .panel-heading
@@ -55,7 +55,7 @@
   .row
     .col-xs-3
       = form_for :filters, builder: DefaultFormBuilder, html: { method: :get } do |f|
-        = f.text_field :taxon_name, placeholder: t(:type_taxon_name), label: t(:taxon)
+        = f.text_field :taxon_name, placeholder: t(:type_taxon_name), label: t( :taxon )
         = f.hidden_field :taxon_id, value: @taxon ? @taxon.id : nil
         = f.text_field :place_id, value: @place ? @place.id : nil, placeholder: t( :start_typing_place_name ), label: t( :place )
         = f.select :month, [1,2,3,4,5,6,7,8,9,10,11,12], include_blank: t( :any ), selected: @month, label: t( :month )
@@ -67,34 +67,34 @@
         - if @trips.empty?
           %p.description= t :no_trips
         - else
-          %table{class: "table table-striped"}
+          %table{ class: "table table-striped" }
             %thead
               %tr
-                %th{scope: "col"} Trip
-                %th{scope: "col"} Title
-                %th{scope: "col"} User
-                %th{scope: "col"} Latitude
-                %th{scope: "col"} Longitude
-                %th{scope: "col"} Date
-                %th{scope: "col"} Duration(min)
-                %th{scope: "col"} Distance(m)
-                %th{scope: "col"} #Observers
-                %th{scope: "col"}=@taxon.name
+                %th{ scope: "col" } Trip
+                %th{ scope: "col" } Title
+                %th{ scope: "col" } User
+                %th{ scope: "col" } Latitude
+                %th{ scope: "col" } Longitude
+                %th{ scope: "col" } Date
+                %th{ scope: "col" } Duration(min)
+                %th{ scope: "col" } Distance(m)
+                %th{ scope: "col" } #Observers
+                %th{ scope: "col" }=@taxon.name
             %tbody
               - for trip in @trips
                 %tr
-                  %th{scope: "row"}
-                    =link_to trip.id, trip_path(trip)
+                  %th{ scope: "row" }
+                    =link_to trip.id, trip_path( trip )
                   %td
-                    =trip.title.truncate(15)
+                    =trip.title.truncate( 15 )
                   %td
-                    =link_to trip.user.login.truncate(15), user_path(trip.user_id) if trip.user_id
+                    =link_to trip.user.login.truncate( 15 ), user_path( trip.user_id ) if trip.user_id
                   %td
-                    =trip.latitude.round(3) if trip.latitude
+                    =trip.latitude.round( 3 ) if trip.latitude
                   %td
-                    =trip.longitude.round(3) if trip.longitude
+                    =trip.longitude.round( 3 ) if trip.longitude
                   %td
-                    =trip.start_time.strftime("%m/%d/%Y")
+                    =trip.start_time.strftime( "%m/%d/%Y" )
                   %td
                     =(( trip.stop_time - trip.start_time ) / 1.minutes ).to_i
                   %td

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1108,6 +1108,7 @@ en:
   display_listings_added_by_curators: Display listings added by curators
   display_listings_from_place: Display listings from place
   distance_traveled: "Distance traveled: %{distance}m"
+  distance_traveled_label: "Distance traveled (m)"
   dna_: DNA
   documentation_for_developers_html: Documentation for <a href="/pages/developers">developers</a>
   do_not_show_this_message_again: Do not show this message again
@@ -2407,6 +2408,7 @@ en:
     of taxa that don't match the taxon in your own identification exactly.
   number_of_observations: Number of observations
   number_of_observers: "Number of observers: %{number}"
+  number_of_observers_label: "Number of observers"
   number_selected: "# selected"
   numeric_: numeric
   noun_by_you: "%{noun} by you"
@@ -3270,6 +3272,7 @@ en:
   quality_grade_colon: "Quality grade:"
   queued: Queued
   query: Query
+  radius: Radius (m)
   random: Random
   range: Range
   range_from: 'Range from '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1107,8 +1107,8 @@ en:
   display_link_to_checklist: Display link to project list from project page
   display_listings_added_by_curators: Display listings added by curators
   display_listings_from_place: Display listings from place
-  distance_traveled: "Distance traveled: %{distance}m"
-  distance_traveled_label: "Distance traveled (m)"
+  distance_traveled_value: "Distance traveled: %{distance}m"
+  distance_traveled: "Distance traveled (m)"
   dna_: DNA
   documentation_for_developers_html: Documentation for <a href="/pages/developers">developers</a>
   do_not_show_this_message_again: Do not show this message again
@@ -1151,7 +1151,7 @@ en:
   drag_and_drop_some_photos_or_sounds: Drag & drop some photos or sounds
   drawings: Drawings
   duplicate_verb: Duplicate
-  duration: "Duration: %{duration} minutes"
+  duration_value: "Duration: %{duration} minutes"
   each_place_displays_all_species_inat_knows: "Each place page displays all the species %{site_name} knows about from that place, including information about their abundance, conservation status, and who was first to observe that species from that place on %{site_name}. You can filter the species by taxonomic group, color, conservation status, or plain old search."
   edit: Edit
   edit_a_batch_of_observations: Edit a Batch of Observations
@@ -1802,6 +1802,7 @@ en:
   latitude: Latitude
   latitude_in_decimals: 'Latitude in decimal degrees, e.g. 38.123'
   latitude_slash_y_coord_slash_northing: Latitude / y coord / northing
+  latitude_value: "Latitude: %{latitude}"
   layers: Layers
   layout: Layout
   leaderboard: Leaderboard
@@ -2020,6 +2021,7 @@ en:
   longitude: Longitude
   longitude_in_decimal: 'Longitude in decimal degrees, e.g. -122.123'
   longitude_slash_x_coord_slash_easting: Longitude / x coord / easting
+  longitude_value: "Longitude: %{longitude}"
   look_up_name: "Look up name"
   looks_like_neither_have!: Looks like neither have any taxa!
   looks_like_no_species_in_guide: Looks like you don't have an species in your guide yet.
@@ -2407,8 +2409,8 @@ en:
     opt out of this you will only receive notifications about identifications
     of taxa that don't match the taxon in your own identification exactly.
   number_of_observations: Number of observations
-  number_of_observers: "Number of observers: %{number}"
-  number_of_observers_label: "Number of observers"
+  number_of_observers_value: "Number of observers: %{number}"
+  number_of_observers: "Number of observers"
   number_selected: "# selected"
   numeric_: numeric
   noun_by_you: "%{noun} by you"
@@ -3273,6 +3275,7 @@ en:
   queued: Queued
   query: Query
   radius: Radius (m)
+  radius_value: "Radius (m): %{radius}"
   random: Random
   range: Range
   range_from: 'Range from '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4227,6 +4227,7 @@ en:
   'true': 'True'
   trending: Trending
   trends: Trends
+  trip_target_list_info: 'This is a non-overlaping set of the coarsest taxa in your target list. Any taxa represented by obscured observations excluded. <a href="/pages/trips">Read more</a>.'
   trusted: Trusted
   trusted_project?: Trusted project?
   trust_this_person_with_your_private_coordinates: Trust this person with your hidden coordinates
@@ -4555,6 +4556,7 @@ en:
   what_do_you_want_to_list: What do you want to list?
   what_to_keep: What to keep
   what_want_to_list?: What do you want to list? 
+  what_were_you_looking_for?: "What were you looking for? (target list)"
   whats_this?: What's this?
   when: When
   when_did_you_see_it?: When did you see it?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1107,6 +1107,7 @@ en:
   display_link_to_checklist: Display link to project list from project page
   display_listings_added_by_curators: Display listings added by curators
   display_listings_from_place: Display listings from place
+  distance_traveled: "Distance traveled: %{distance}m"
   dna_: DNA
   documentation_for_developers_html: Documentation for <a href="/pages/developers">developers</a>
   do_not_show_this_message_again: Do not show this message again
@@ -1149,6 +1150,7 @@ en:
   drag_and_drop_some_photos_or_sounds: Drag & drop some photos or sounds
   drawings: Drawings
   duplicate_verb: Duplicate
+  duration: "Duration: %{duration} minutes"
   each_place_displays_all_species_inat_knows: "Each place page displays all the species %{site_name} knows about from that place, including information about their abundance, conservation status, and who was first to observe that species from that place on %{site_name}. You can filter the species by taxonomic group, color, conservation status, or plain old search."
   edit: Edit
   edit_a_batch_of_observations: Edit a Batch of Observations
@@ -2404,6 +2406,7 @@ en:
     opt out of this you will only receive notifications about identifications
     of taxa that don't match the taxon in your own identification exactly.
   number_of_observations: Number of observations
+  number_of_observers: "Number of observers: %{number}"
   number_selected: "# selected"
   numeric_: numeric
   noun_by_you: "%{noun} by you"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -459,6 +459,9 @@ Rails.application.routes.draw do
       post :add_taxa_from_observations
       delete :remove_taxa
     end
+    collection do
+      get :tabulate
+    end
   end
   get 'trips/:login' => 'trips#by_login', :as => :trips_by_login, :constraints => { :login => simplified_login_regex }
   

--- a/db/migrate/20190404042229_add_distance_and_number_to_posts.rb
+++ b/db/migrate/20190404042229_add_distance_and_number_to_posts.rb
@@ -1,6 +1,6 @@
 class AddDistanceAndNumberToPosts < ActiveRecord::Migration
   def change
-    add_column :posts, :distance, :float
-    add_column :posts, :number, :integer
+    add_column :posts, :distance, :float, null: true
+    add_column :posts, :number, :integer, null: true
   end
 end

--- a/db/migrate/20190404042229_add_distance_and_number_to_posts.rb
+++ b/db/migrate/20190404042229_add_distance_and_number_to_posts.rb
@@ -1,0 +1,6 @@
+class AddDistanceAndNumberToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :distance, :float
+    add_column :posts, :number, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3014,7 +3014,9 @@ CREATE TABLE public.posts (
     place_id integer,
     latitude numeric(15,10),
     longitude numeric(15,10),
-    radius integer
+    radius integer,
+    distance double precision,
+    number integer
 );
 
 
@@ -9748,4 +9750,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190104024910');
 INSERT INTO schema_migrations (version) VALUES ('20190301012813');
 
 INSERT INTO schema_migrations (version) VALUES ('20190308020554');
+
+INSERT INTO schema_migrations (version) VALUES ('20190404042229');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1394,49 +1394,6 @@ ALTER SEQUENCE public.flow_tasks_id_seq OWNED BY public.flow_tasks.id;
 
 
 --
--- Name: frequency_cell_month_taxa; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.frequency_cell_month_taxa (
-    frequency_cell_id integer,
-    month integer,
-    taxon_id integer,
-    count integer
-);
-
-
---
--- Name: frequency_cells; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.frequency_cells (
-    id integer NOT NULL,
-    swlat integer,
-    swlng integer
-);
-
-
---
--- Name: frequency_cells_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.frequency_cells_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: frequency_cells_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.frequency_cells_id_seq OWNED BY public.frequency_cells.id;
-
-
---
 -- Name: friendly_id_slugs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3057,9 +3014,7 @@ CREATE TABLE public.posts (
     place_id integer,
     latitude numeric(15,10),
     longitude numeric(15,10),
-    radius integer,
-    distance double precision,
-    number integer
+    radius integer
 );
 
 
@@ -5230,13 +5185,6 @@ ALTER TABLE ONLY public.flow_tasks ALTER COLUMN id SET DEFAULT nextval('public.f
 
 
 --
--- Name: frequency_cells id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.frequency_cells ALTER COLUMN id SET DEFAULT nextval('public.frequency_cells_id_seq'::regclass);
-
-
---
 -- Name: friendly_id_slugs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6098,14 +6046,6 @@ ALTER TABLE ONLY public.flow_task_resources
 
 ALTER TABLE ONLY public.flow_tasks
     ADD CONSTRAINT flow_tasks_pkey PRIMARY KEY (id);
-
-
---
--- Name: frequency_cells frequency_cells_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.frequency_cells
-    ADD CONSTRAINT frequency_cells_pkey PRIMARY KEY (id);
 
 
 --
@@ -7216,27 +7156,6 @@ CREATE INDEX index_flow_tasks_on_unique_hash ON public.flow_tasks USING btree (u
 --
 
 CREATE INDEX index_flow_tasks_on_user_id ON public.flow_tasks USING btree (user_id);
-
-
---
--- Name: index_frequency_cell_month_taxa_on_frequency_cell_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_frequency_cell_month_taxa_on_frequency_cell_id ON public.frequency_cell_month_taxa USING btree (frequency_cell_id);
-
-
---
--- Name: index_frequency_cell_month_taxa_on_taxon_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_frequency_cell_month_taxa_on_taxon_id ON public.frequency_cell_month_taxa USING btree (taxon_id);
-
-
---
--- Name: index_frequency_cells_on_swlat_and_swlng; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_frequency_cells_on_swlat_and_swlng ON public.frequency_cells USING btree (swlat, swlng);
 
 
 --
@@ -9826,11 +9745,7 @@ INSERT INTO schema_migrations (version) VALUES ('20181120235404');
 
 INSERT INTO schema_migrations (version) VALUES ('20190104024910');
 
-INSERT INTO schema_migrations (version) VALUES ('20190215195613');
-
 INSERT INTO schema_migrations (version) VALUES ('20190301012813');
 
 INSERT INTO schema_migrations (version) VALUES ('20190308020554');
-
-INSERT INTO schema_migrations (version) VALUES ('20190404042229');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1394,6 +1394,49 @@ ALTER SEQUENCE public.flow_tasks_id_seq OWNED BY public.flow_tasks.id;
 
 
 --
+-- Name: frequency_cell_month_taxa; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.frequency_cell_month_taxa (
+    frequency_cell_id integer,
+    month integer,
+    taxon_id integer,
+    count integer
+);
+
+
+--
+-- Name: frequency_cells; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.frequency_cells (
+    id integer NOT NULL,
+    swlat integer,
+    swlng integer
+);
+
+
+--
+-- Name: frequency_cells_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.frequency_cells_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: frequency_cells_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.frequency_cells_id_seq OWNED BY public.frequency_cells.id;
+
+
+--
 -- Name: friendly_id_slugs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3014,7 +3057,9 @@ CREATE TABLE public.posts (
     place_id integer,
     latitude numeric(15,10),
     longitude numeric(15,10),
-    radius integer
+    radius integer,
+    distance double precision,
+    number integer
 );
 
 
@@ -5185,6 +5230,13 @@ ALTER TABLE ONLY public.flow_tasks ALTER COLUMN id SET DEFAULT nextval('public.f
 
 
 --
+-- Name: frequency_cells id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.frequency_cells ALTER COLUMN id SET DEFAULT nextval('public.frequency_cells_id_seq'::regclass);
+
+
+--
 -- Name: friendly_id_slugs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6046,6 +6098,14 @@ ALTER TABLE ONLY public.flow_task_resources
 
 ALTER TABLE ONLY public.flow_tasks
     ADD CONSTRAINT flow_tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: frequency_cells frequency_cells_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.frequency_cells
+    ADD CONSTRAINT frequency_cells_pkey PRIMARY KEY (id);
 
 
 --
@@ -7156,6 +7216,27 @@ CREATE INDEX index_flow_tasks_on_unique_hash ON public.flow_tasks USING btree (u
 --
 
 CREATE INDEX index_flow_tasks_on_user_id ON public.flow_tasks USING btree (user_id);
+
+
+--
+-- Name: index_frequency_cell_month_taxa_on_frequency_cell_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_frequency_cell_month_taxa_on_frequency_cell_id ON public.frequency_cell_month_taxa USING btree (frequency_cell_id);
+
+
+--
+-- Name: index_frequency_cell_month_taxa_on_taxon_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_frequency_cell_month_taxa_on_taxon_id ON public.frequency_cell_month_taxa USING btree (taxon_id);
+
+
+--
+-- Name: index_frequency_cells_on_swlat_and_swlng; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_frequency_cells_on_swlat_and_swlng ON public.frequency_cells USING btree (swlat, swlng);
 
 
 --
@@ -9745,7 +9826,11 @@ INSERT INTO schema_migrations (version) VALUES ('20181120235404');
 
 INSERT INTO schema_migrations (version) VALUES ('20190104024910');
 
+INSERT INTO schema_migrations (version) VALUES ('20190215195613');
+
 INSERT INTO schema_migrations (version) VALUES ('20190301012813');
 
 INSERT INTO schema_migrations (version) VALUES ('20190308020554');
+
+INSERT INTO schema_migrations (version) VALUES ('20190404042229');
 


### PR DESCRIPTION
Trips have been giving 500 errors on show for the last few years. This PR, fixes those bugs, and makes some modifications to how trip data is stored/displayed to accomodate the UBIF collaboration and validating distribution models. TripTaxa are no longer used but haven't been fully removed in the interest of time/going back. Trips now use the existence of observations in the context of Trip parameters and trip_purposes to calculate presence/absence. Trips#tabulate isn't populating the presence/absence column yet - ticket for the ES changes involved in this coming soon