### PR TITLE
Specify Gemfile references as refs, not branches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem "objectify-xml", git: "https://github.com/inaturalist/objectify_xml.git"
 gem "omniauth"
 gem "omniauth-oauth2", "1.5.0"
 gem "omniauth-facebook", "~> 5.0.0"
-gem "omniauth-flickr", git: "https://github.com/IDolgirev/omniauth-flickr.git", branch: "bcd202b0825659cbd984e611f6151f67c4aae591"
+gem "omniauth-flickr", git: "https://github.com/IDolgirev/omniauth-flickr.git", ref: "bcd202b0825659cbd984e611f6151f67c4aae591"
 gem "omniauth-openid"
 gem "omniauth-orcid"
 gem "omniauth-google-oauth2", "~> 0.5.2"
@@ -97,8 +97,8 @@ gem "yui-compressor"
 gem "xmp", git: "https://github.com/inaturalist/xmp.git"
 gem "rubyzip"
 # these need to be loaded after will_paginate
-gem "elasticsearch-model", git: "https://github.com/elasticsearch/elasticsearch-rails.git", branch: "64f31b41c073f05eac7d089aeea07c4366b7adca"
-gem "elasticsearch-rails", git: "https://github.com/elasticsearch/elasticsearch-rails.git", branch: "64f31b41c073f05eac7d089aeea07c4366b7adca"
+gem "elasticsearch-model", git: "https://github.com/elasticsearch/elasticsearch-rails.git", ref: "64f31b41c073f05eac7d089aeea07c4366b7adca"
+gem "elasticsearch-rails", git: "https://github.com/elasticsearch/elasticsearch-rails.git", ref: "64f31b41c073f05eac7d089aeea07c4366b7adca"
 gem "elasticsearch", "5.0.4"
 gem "elasticsearch-api", "5.0.4"
 
@@ -117,7 +117,7 @@ group :test, :development, :prod_dev do
 
   # this fork fixes the `warning: constant ::Fixnum is deprecated` warnings
   # See https://github.com/notahat/machinist/pull/133
-  gem "machinist", git: "https://github.com/narze/machinist", branch: "eaf5a447ff0d59a1fb2c49b91c6e1b2d95d8e4ee"
+  gem "machinist", git: "https://github.com/narze/machinist", ref: "eaf5a447ff0d59a1fb2c49b91c6e1b2d95d8e4ee"
 
   gem "better_errors"
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/IDolgirev/omniauth-flickr.git
   revision: bcd202b0825659cbd984e611f6151f67c4aae591
-  branch: bcd202b0825659cbd984e611f6151f67c4aae591
+  ref: bcd202b0825659cbd984e611f6151f67c4aae591
   specs:
     omniauth-flickr (0.0.19)
       multi_json (~> 1.13.0)
@@ -28,7 +28,7 @@ GIT
 GIT
   remote: https://github.com/elasticsearch/elasticsearch-rails.git
   revision: 64f31b41c073f05eac7d089aeea07c4366b7adca
-  branch: 64f31b41c073f05eac7d089aeea07c4366b7adca
+  ref: 64f31b41c073f05eac7d089aeea07c4366b7adca
   specs:
     elasticsearch-model (6.0.0.alpha1)
       activesupport (> 3)
@@ -122,7 +122,7 @@ GIT
 GIT
   remote: https://github.com/narze/machinist
   revision: eaf5a447ff0d59a1fb2c49b91c6e1b2d95d8e4ee
-  branch: eaf5a447ff0d59a1fb2c49b91c6e1b2d95d8e4ee
+  ref: eaf5a447ff0d59a1fb2c49b91c6e1b2d95d8e4ee
   specs:
     machinist (2.0)
 


### PR DESCRIPTION
This is what is currently confusing Dependabot.