### PR TITLE
Parental consent email endpoint

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -871,7 +871,7 @@ class UsersController < ApplicationController
     end
     if error_msg
       respond_to do |format|
-        format.json { render status: :unprocessable_entity, json: { error: t( "views.parental_consent.#{error_msg}" ) } }
+        format.json { render status: :unprocessable_entity, json: { error: t( "parental_consent.#{error_msg}" ) } }
       end
       return
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,8 @@ class UsersController < ApplicationController
     if: lambda { authenticate_with_oauth? }
   before_filter :authenticate_user!,
     :unless => lambda { authenticated_with_oauth? },
-    :except => [ :index, :show, :new, :create, :activate, :relationships, :search, :update_session ]
+    :except => [ :index, :show, :new, :create, :activate, :relationships,
+      :search, :update_session, :parental_consent ]
   load_only = [ :suspend, :unsuspend, :destroy, :purge,
     :show, :update, :followers, :following, :relationships, :add_role,
     :remove_role, :set_spammer, :merge, :trust, :untrust ]
@@ -858,6 +859,31 @@ class UsersController < ApplicationController
     end
     respond_to do |format|
       format.json { render json: { friendship: friendship } }
+    end
+  end
+
+  def parental_consent
+    error_msg = nil
+    if !params[:email]
+      error_msg = :must_specify_email
+    elsif params[:email] !~ Devise.email_regexp
+      error_msg = :invalid_email
+    end
+    if error_msg
+      respond_to do |format|
+        format.json { render status: :unprocessable_entity, json: { error: t( "views.parental_consent.#{error_msg}" ) } }
+      end
+      return
+    end
+    unless current_user && current_user.id == Devise::Strategies::ApplicationJsonWebToken::ANONYMOUS_USER_ID
+      respond_to do |format|
+        format.json { render status: :forbidden, json: { error: "forbidden" } }
+      end
+      return
+    end
+    Emailer.parental_consent( params[:email] ).deliver_now
+    respond_to do |format|
+      format.json { render head: :no_content, :layout => false, :text => nil }
     end
   end
 

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -212,6 +212,14 @@ class Emailer < ActionMailer::Base
     ) )
   end
 
+  def parental_consent( email )
+    @site = Site.default
+    mail( set_site_specific_opts.merge(
+      to: email,
+      subject: t( "views.emailer.parental_consent.subject" )
+    ) )
+  end
+
   private
   def default_url_options
     opts = (Rails.application.config.action_mailer.default_url_options || {}).dup

--- a/app/views/emailer/_footer.html.erb
+++ b/app/views/emailer/_footer.html.erb
@@ -1,5 +1,5 @@
 <%-
-  @site = @user.site || Site.default
+  @site = ( @user && @user.site ) || Site.default
   blog_url = @site.blog_url
   twitter_url = @site.twitter_url
   facebook_url = @site.facebook_url

--- a/app/views/emailer/_header.html.erb
+++ b/app/views/emailer/_header.html.erb
@@ -1,5 +1,5 @@
 <%-
-  site = @user.site || @site || Site.default
+  site = ( @user && @user.site ) || @site || Site.default
   site_logo_email_banner = site.logo_email_banner.url
   site_url = site.url
   img_url = if site_logo_email_banner =~ /http/

--- a/app/views/emailer/parental_consent.html.haml
+++ b/app/views/emailer/parental_consent.html.haml
@@ -1,0 +1,3 @@
+= render "header"
+=t "views.emailer.parental_consent.content_html", registration_url: new_user_registration_url, privacy_policy_url: privacy_policy_url
+= render "footer"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,6 @@
 require "devise_json_web_token"
+require "devise_application_json_web_token"
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -227,6 +229,8 @@ Devise.setup do |config|
   # end
 
   config.warden do |manager|
+    manager.strategies.add(:ajwt, Devise::Strategies::ApplicationJsonWebToken)
+    manager.default_strategies(scope: :user).unshift :ajwt
     manager.strategies.add(:jwt, Devise::Strategies::JsonWebToken)
     manager.default_strategies(scope: :user).unshift :jwt
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2699,6 +2699,9 @@ en:
   owner: Owner
   parent: Parent
   parent_name: Parent name
+  parental_consent:
+    must_specify_email: You must specify an email address
+    invalid_email: Invalid email format
   password: Password
   password_confirmation: 'Password confirmation'
   paste: Paste
@@ -5634,8 +5637,6 @@ en:
           <a href="%{url}">observations export page</a> for a list of your exports.
       parental_consent:
         subject: Your child would like to use iNaturalist
-        must_specify_email: You must specify an email address
-        invalid_email: Invalid email format
         content_html: |
           <p>
             Your child is using the Seek by iNaturalist educational app and

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5612,13 +5612,6 @@ en:
           obseration field being merged and move all observations using it
           over to the keeper. <strong>This process cannot be undone</strong>, so be careful.
     emailer:
-      observations_export_notification:
-        your_observations_export_is_ready_html: |
-          Your observations export is ready. There's a copy attached to this email, or you can
-          <a href="%{url}">download your export</a>.
-        your_observations_export_failed_html: |
-          Your observations export failed. Visit the
-          <a href="%{url}">observations export page</a> for a list of your exports.
       bulk_import_success:
         success_message: |
           Your bulk import of %{filename} was successful. Your observations
@@ -5632,11 +5625,66 @@ en:
           the search page to import new names. If the name is present but
           applies to multiple valid taxa, try to use a more or less specific
           name that only matches a single taxon. 
-      users_updates_suspended:
-        message: |
-          You have been inactive on %{site_name} for a while, so we have suspended
-          your subscriptions. To resume getting updates on site activity, please
-          <a href="%{login_url}">log in to your account</a> again.
+      observations_export_notification:
+        your_observations_export_is_ready_html: |
+          Your observations export is ready. There's a copy attached to this email, or you can
+          <a href="%{url}">download your export</a>.
+        your_observations_export_failed_html: |
+          Your observations export failed. Visit the
+          <a href="%{url}">observations export page</a> for a list of your exports.
+      parental_consent:
+        subject: Your child would like to use iNaturalist
+        must_specify_email: You must specify an email address
+        invalid_email: Invalid email format
+        content_html: |
+          <p>
+            Your child is using the Seek by iNaturalist educational app and
+            would like to share data with the iNaturalist citizen-science
+            platform. Because this data includes Personal Identifying
+            Information, it cannot be used by person’s under the age of 13
+            without the consent of a parent.
+          </p>
+          <p>
+            Seek by iNaturalist may be used without creating an account, and no
+            data will be shared, but your child will not be able to contribute
+            observations to iNaturalist. [EXPLANATION OF INAT]
+          </p>
+          <p>
+            If you’d like to give consent for your child to use iNaturalist,
+            we’ll need you to do the following:
+          </p>
+          <ol>
+            <li>
+              <p>
+                Create an iNaturalist account that your child will use
+                indicating that the account will be used by a person under the
+                age of 13 by following this link:
+                <a href="%{registration_url}">%{registration_url}</a>
+              </p>
+            </li>
+            <li>
+              <p>
+                Make a nominal donation of $1 with a credit card to iNaturalist
+                to verify that you are an adult. Please make sure to use include
+                the same email that you used to create the account alongside
+                your donation here: https://www.inaturalist.org/donate
+              </p>
+            </li>
+            <li>
+              <p>
+                Once we process the donation, we will send a notification to the
+                account email that the account has been activated and you can
+                use the iNaturalist username and password you created to log in
+                to your child’s Seek app.
+              </p>
+            </li>
+          </ol>
+          <p>
+            Learn more about what Personal Identifying Information iNaturalist shares: …
+          </p>
+          <p>
+            Learn more about iNaturalist’s Privacy Policy <a href="%{privacy_policy_url}">here</a>.
+          </p>
       photos_missing:
         subject: Some photos need repairing
         we_have_been_housekeeping: |
@@ -5660,6 +5708,11 @@ en:
           some research grade observations will become casual if they no longer have any photos.
         we_included_links: |
           We've included links to the affected photos below.
+      users_updates_suspended:
+        message: |
+          You have been inactive on %{site_name} for a while, so we have suspended
+          your subscriptions. To resume getting updates on site activity, please
+          <a href="%{login_url}">log in to your account</a> again.
     photos:
       forbidden_notice_html: |
         We don't have permission to access those photos right now. You might

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "/ping", to: "application#ping"
   get "/seek", to: redirect( "/pages/seek_app", status: 302 )
   get "/terms", to: redirect( "/pages/terms" )
-  get "/privacy", to: redirect( "/pages/privacy" )
+  get "/privacy", to: redirect( "/pages/privacy" ), as: :privacy_policy
   get "/users/new.mobile", to: redirect( "/signup" )
   get "/donate", to: "donate#index"
 
@@ -159,6 +159,7 @@ Rails.application.routes.draw do
     collection do
       get :recent
       get :delete
+      post :parental_consent
     end
     member do
       put :join_test

--- a/lib/devise_application_json_web_token.rb
+++ b/lib/devise_application_json_web_token.rb
@@ -1,0 +1,31 @@
+require "json_web_token"
+
+module Devise
+  module Strategies
+    class ApplicationJsonWebToken < Base
+      ANONYMOUS_USER_ID = -1
+      def valid?
+        claims
+      end
+
+      def authenticate!
+        if claims
+          anon_user = User.new( id: ANONYMOUS_USER_ID, login: "anonymous" )
+          success! anon_user
+        else
+          fail!
+        end
+      end
+
+      private
+
+      def claims
+        auth_header = request.headers["Authorization"] and
+          token = auth_header.split(" ").last and
+          ::JsonWebToken.decodeApplication( token )
+      rescue
+        nil
+      end
+    end
+  end
+end

--- a/lib/devise_json_web_token.rb
+++ b/lib/devise_json_web_token.rb
@@ -8,7 +8,12 @@ module Devise
       end
 
       def authenticate!
-        if claims && user = User.find_by_id(claims.fetch("user_id"))
+        user_id = begin
+          claims.fetch("user_id")
+        rescue KeyError
+          nil
+        end
+        if claims && user_id && user = User.find_by_id( user_id )
           success! user
         else
           fail!

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -14,6 +14,10 @@ class JsonWebToken
   def self.applicationToken(expiration = 5.minutes.from_now)
     payload = { application: "rails" }
     payload[:exp] = expiration.to_i
-    JWT.encode(payload, CONFIG.jwt_application_secret || "secret", "HS512")
+    JWT.encode(payload, CONFIG.jwt_application_secret || "application_secret", "HS512")
+  end
+
+  def self.decodeApplication( token )
+    JWT.decode( token, CONFIG.jwt_application_secret || "application_secret", true, { algorithm: "HS512" } ).first
   end
 end

--- a/spec/controllers/users_controller_api_spec.rb
+++ b/spec/controllers/users_controller_api_spec.rb
@@ -270,6 +270,37 @@ describe UsersController, "without authentication" do
     end
   end
 
+  describe "parental_consent" do
+    it "should deliver an email with the application JWT" do
+      deliveries = ActionMailer::Base.deliveries.size
+      token = JsonWebToken.applicationToken
+      request.env["HTTP_AUTHORIZATION"] = token
+      post :parental_consent, format: :json, email: Faker::Internet.email
+      expect( ActionMailer::Base.deliveries.size ).to eq deliveries + 1
+    end
+    it "should not deliver an email without the application JWT" do
+      deliveries = ActionMailer::Base.deliveries.size
+      token = JsonWebToken.applicationToken + "bad"
+      request.env["HTTP_AUTHORIZATION"] = token
+      post :parental_consent, format: :json, email: Faker::Internet.email
+      expect( ActionMailer::Base.deliveries.size ).to eq deliveries
+    end
+    describe "should return a 422 with" do
+      it "no email" do
+        token = JsonWebToken.applicationToken
+        request.env["HTTP_AUTHORIZATION"] = token
+        post :parental_consent, format: :json
+        expect( response.status ).to eq 422
+      end
+      it "a bad email" do
+        token = JsonWebToken.applicationToken
+        request.env["HTTP_AUTHORIZATION"] = token
+        post :parental_consent, format: :json, email: "lkdshglsdhfg"
+        expect( response.status ).to eq 422
+      end
+    end
+  end
+
 end
 
 describe UsersController, "oauth authentication with login scope" do

--- a/test/mailers/previews/emailer_preview.rb
+++ b/test/mailers/previews/emailer_preview.rb
@@ -72,6 +72,11 @@ class EmailerPreview < ActionMailer::Preview
     Emailer.bulk_observation_error(@user, "some_file_name", errors)
   end
 
+  def parental_consent
+    set_locale
+    Emailer.parental_consent( "test@inaturalist.org" )
+  end
+
   private
   def set_user
     # @user = if login = @rack_env["QUERY_STRING"].to_s[/login=([^&]+)/, 1]


### PR DESCRIPTION
Adds an endpoint our own apps can use to send an email to a potential parent asking them to create an account for their child. Email content and any further restrictions may need some more work, but this is probably ready for developer testing, at least.

This has the kind of weird consequence that when you make a request to the Rails app with our application JWT, it will create a `current_user` but with an ID of `-1`. Devise / Warden seem to want some kind of user object, and this allows us to see that auth was successful but that the "user" is anonymous. If this seems like too much of a risk, I think we could redo this so the auth part just skips Devise no `current_user` gets populated.