### PR TITLE
Support implicit flow for OAuth

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -73,7 +73,7 @@ Doorkeeper.configure do
   #   client.superapp? or resource_owner.admin?
   # end
 
-  grant_flows %w(authorization_code client_credentials password)
+  grant_flows %w(authorization_code client_credentials password implicit)
 
   # Don't force devs to use SSL redirects
   force_ssl_in_redirect_uri false


### PR DESCRIPTION
I'm building a client-side (in browser) only webapp as a client to iNat and want to use OAuth for users to connect to their iNat account.

As the [doco](https://www.inaturalist.org/pages/api+reference#auth) states, iNat currently supports Authorization Code, Resource Owner and some third party flows.

I don't want to deal with passwords so Resource Owner isn't suitable. Authorization Code flow isn't really suited but it could work. The secret wouldn't be secret and there's an extra HTTP call to get the token but it would work. The problem here is iNat doesn't have an OPTIONS method on the `/oauth/token` endpoint so the CORS preflight check fails and we can't POST to get the token.

Implicit Flow is the right flow for this situation. I have been able to enable it with the change in this PR and things work as expected. That is, on the client if we use `...&response_type=token` in our URL that we bounce the user to, we get a token back after redirect.

There should probably be an update to the dev doco to talk about this new flow and something on the OAuth client app page, perhaps a second link, that shows how to use this flow. I'm happy to make those changes, I wanted to make sure I'm on the right path first.

I'm unsure if there are any security implications for this change. DoorKeeper is doing the heavy lifting so I'm thinking it should all be ok.