### PR TITLE
Monthly Supporters

### DIFF
--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -64,4 +64,9 @@ h1 {
   .date {
     margin-right: 20px;
   }
+  .monthly-supporter,
+  .monthly-supporter i {
+    color: $inat-green;
+  }
+
 }

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -64,9 +64,15 @@ h1 {
   .date {
     margin-right: 20px;
   }
-  .monthly-supporter,
-  .monthly-supporter i {
+  .monthly-supporter {
     color: $inat-green;
+    white-space: nowrap;
+    i {
+      color: $inat-green;
+      position: relative;
+      top: -1px;
+      font-size: 20px;
+    }
   }
 
 }

--- a/app/controllers/donate_controller.rb
+++ b/app/controllers/donate_controller.rb
@@ -4,12 +4,16 @@ class DonateController < ApplicationController
     @responsive = true
     @footless = true
     @no_footer_gap = true
-  end
-
-  def index
     @shareable_image_url = FakeView.image_url( "donate-banner.png" )
     if Site.default && @site && @site.id != Site.default.id
       return redirect_to donate_url( host: Site.default.domain )
     end
   end
+
+  def index
+  end
+
+  def monthly_supporters
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -341,6 +341,9 @@ class UsersController < ApplicationController
             ).first.try(&:created_at)
           ].compact.sort.map{|t| t.in_time_zone( Time.zone ).to_date }.last
         end
+        @donor_since = @selected_user.donorbox_plan_status == "active" &&
+          @selected_user.donorbox_plan_type == "monthly" &&
+          @selected_user.donorbox_plan_started_at
         render layout: "bootstrap"
       end
       opts = User.default_json_options

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -565,7 +565,10 @@ class UsersController < ApplicationController
   
   def edit
     respond_to do |format|
-      format.html
+      format.html do
+        @monthly_supporter = @user.donorbox_plan_status == "active" &&
+          @user.donorbox_plan_type == "monthly"
+      end
       format.json do
         render :json => @user.to_json(
           :except => [
@@ -1109,6 +1112,7 @@ protected
       :prefers_no_place,
       :prefers_coordinate_interpolation_protection,
       :prefers_coordinate_interpolation_protection_test,
+      :prefers_monthly_supporter_badge,
       :search_place_id,
       :site_id,
       :test_groups,

--- a/app/models/local_photo.rb
+++ b/app/models/local_photo.rb
@@ -243,8 +243,13 @@ class LocalPhoto < Photo
         o.longitude = o.longitude * -1
       end
     end
-    if !metadata[:gps_h_positioning_error].blank? && !metadata[:gps_h_positioning_error].to_f.nan?
-      o.positional_accuracy = metadata[:gps_h_positioning_error].to_i
+    begin
+      if !metadata[:gps_h_positioning_error].blank? && !metadata[:gps_h_positioning_error].to_f.nan?
+        o.positional_accuracy = metadata[:gps_h_positioning_error].to_i
+      end
+    rescue FloatDomainError
+      # Apparently GPS Horizontal Positioning Error can be infinity.
+      # Let's just ignore photos of the entire Universe
     end
     if (o.latitude && o.latitude.abs > 90) || (o.longitude && o.longitude.abs > 180)
       o.latitude = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,6 +87,7 @@ class User < ActiveRecord::Base
   preference :coordinate_interpolation_protection, default: false
   preference :coordinate_interpolation_protection_test, default: false
   preference :forum_topics_on_dashboard, :boolean, default: true
+  preference :monthly_supporter_badge, :boolean, default: false
   
   NOTIFICATION_PREFERENCES = %w(
     comment_email_notification

--- a/app/views/donate/monthly_supporters.html.haml
+++ b/app/views/donate/monthly_supporters.html.haml
@@ -1,0 +1,40 @@
+:ruby
+  donorbox_params = params.slice( :utm_source, :utm_campaign, :utm_content, :utm_medium )
+  donorbox_params[:utm_source] = @site.name if donorbox_params[:utm_source].blank?
+  donorbox_params[:utm_medium] = "web" if donorbox_params[:utm_medium].blank?
+- content_for :title do
+  =t "views.donate.monthly_supporters.become_a_monthly_supporter_of_inaturalist"
+- content_for :extrajs do
+  = javascript_include_tag "https://donorbox.org/widget.js", paypalExpress: false
+  :javascript
+    $( ".sharing .btn" ).click( function( ) {
+      return !window.open( this.href, $(this).text( ), "width=640,height=400" );
+    } );
+- content_for :extracss do
+  = stylesheet_link_tag :donate, media: "all", cache: true
+- content_for :extrahead do
+  %meta{ property: "og:title", content: t( :help_support_inaturalist ) }
+  %meta{ property: "og:description", content: t( "views.donate.donate_short_desc" ) }
+  %meta{ property: "og:image", content: @shareable_image_url }
+  %meta{ property: "twitter:image", content: @shareable_image_url }
+  %meta{ name: "twitter:card", content: "summary_large_image" }
+.container
+  .row
+    .col-md-10.col-md-offset-1.col-xs-12
+      %h1=t "views.donate.monthly_supporters.become_a_monthly_supporter_of_inaturalist"
+  .row
+    .col-md-5.col-md-offset-1.col-xs-12
+      %iframe#donorbox-iframe{ src: "https://donorbox.org/embed/inaturalist-monthly-supporters?#{donorbox_params.to_query}", seamless: "seamless", name: "donorbox", frameborder: "0", scrolling: "no", allowpaymentrequest: true }
+    .col-md-5.col-xs-12
+      =t "views.donate.monthly_supporters.desc_html", donate_url: donate_url
+      .sharing
+        %p.lead.text-center=t :share_colon, default: t(:share)
+        = link_to "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape( donate_url( utm_source: "facebook", utm_campaign: "2018-launch", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-facebook", target: "_blank" do
+          %i.fa.fa-facebook
+          = t(:facebook)
+        = link_to "https://twitter.com/intent/tweet/?url=#{CGI.escape( donate_url( utm_source: "twitter", utm_campaign: "2018-launch", utm_medium: "social" ) )}&text=#{t( "views.donate.post_donate_social_media_text" )}", class: "btn btn-inat btn-sm btn-twitter", target: "_blank" do
+          %i.fa.fa-twitter
+          = t(:twitter)
+        = link_to "https://www.linkedin.com/shareArticle?mini=true&url=#{CGI.escape( donate_url( utm_source: "linkedin", utm_campaign: "2018-launch", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-linkedin", target: "_blank" do
+          %i.fa.fa-linkedin
+          = t(:linkedin)

--- a/app/views/users/_show.html.haml
+++ b/app/views/users/_show.html.haml
@@ -71,7 +71,7 @@
         - else
           =t :last_active_with_date, date: t(:unknown)
       = feature_test :monthly_supporters do
-        - if @donor_since
+        - if @donor_since && @user.prefers_monthly_supporter_badge?
           %span.date.monthly-supporter
             %i.fa.fa-check-circle
             =t :monthly_supporter_since_date, date: l( @donor_since, format: :short_with_year )

--- a/app/views/users/_show.html.haml
+++ b/app/views/users/_show.html.haml
@@ -70,6 +70,12 @@
           =t :last_active_with_date, date: l( @user.last_active, format: :short_with_year )
         - else
           =t :last_active_with_date, date: t(:unknown)
+      = feature_test :monthly_supporters do
+        - if @donor_since
+          %span.date.monthly-supporter
+            %i.fa.fa-check-circle
+            =t :monthly_supporter_since_date, date: l( @donor_since, format: :short_with_year )
+
     #description
       - if @user.description.blank?
         - if is_me?(@selected_user)

--- a/app/views/users/_show.html.haml
+++ b/app/views/users/_show.html.haml
@@ -73,8 +73,8 @@
       = feature_test :monthly_supporters do
         - if @donor_since && @user.prefers_monthly_supporter_badge?
           %span.date.monthly-supporter
-            %i.fa.fa-check-circle
-            =t :monthly_supporter_since_date, date: l( @donor_since, format: :short_with_year )
+            %i.icon-iconic-aves
+            =t :monthly_supporter_since_date, date: l( @donor_since, format: :month_year )
 
     #description
       - if @user.description.blank?

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -121,6 +121,21 @@
           <%= raw t('views.users.edit.this_only_applies_to_traditional_projects') %>
         </div>
       </div>
+
+      <%= feature_test :monthly_supporters do %>
+        <a name="donors"></a>
+        <h3><%=t :monthly_supporter %></h3>
+        <div class="stacked">
+          <%= f.check_box :prefers_monthly_supporter_badge,
+            label: t( "views.users.edit.display_monthly_supporter_status_on_my_profile" ),
+            description: @monthly_supporter ?
+              t( "views.users.edit.thanks_for_supporting_us!" ) :
+              t( "views.users.edit.monthly_supporter_desc_html", url: monthly_supporters_url ),
+            label_after: true,
+            disabled: !@monthly_supporter
+          %>
+        </div>
+      <% end %>
     </div>
 
     <div class="last column span-9 stacked">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,10 +19,10 @@ Inaturalist::Application.configure do
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.delivery_method = :test
 
-  # Uncomment to test mail delivery
-  smtp_config_path = File.open("#{Rails.root}/config/smtp.yml")
-  ActionMailer::Base.smtp_settings = YAML.load(smtp_config_path).symbolize_keys
-  config.action_mailer.delivery_method = :smtp
+  # # Uncomment to test mail delivery
+  # smtp_config_path = File.open("#{Rails.root}/config/smtp.yml")
+  # ActionMailer::Base.smtp_settings = YAML.load(smtp_config_path).symbolize_keys
+  # config.action_mailer.delivery_method = :smtp
 
   # Uncomment these to test caching
   # config.action_controller.perform_caching             = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6790,9 +6790,11 @@ en:
           which are received by the California Academy of Sciences (United
           States IRS FIN 94-1156258) to support the not-for-profit operation of
           iNaturalist and iNaturalist Network sites.
-          <a href="%{url}">Click here to become a monthly supporter</a>.
+          <a href="%{url}">Click here to become a Monthly Supporter</a>.
           When we have confirmed your support you will be able to check this
-          box to display this status on your profile.
+          box to display this status on your profile. Note: you will need to use
+          exactly the same email address on Donorbox as you do on iNaturalist
+          for us to confirm that you've become a Monthly Supporter.
         muting_desc_html: |
           <p>
             Muting someone prevents you from receiving notifications about things

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4999,6 +4999,33 @@ en:
           organization based in the United States of America.
         </p>
       post_donate_social_media_text: I support iNaturalist because...
+      monthly_supporters:
+        become_a_monthly_supporter_of_inaturalist: Become a Monthly Supporter of iNaturalist
+        desc_html: |
+          <p class="lead">
+            <strong>iNaturalist is one of the world's largest communities dedicated to
+            exploring biodiversity. Thank you for being part of it!</strong>
+          </p>
+          <p class="lead">
+            We want to keep iNaturalist free to use, but it’s not free to
+            operate. If you love iNaturalist, please consider becoming a monthly
+            supporter. Recurring gifts help ensure that iNaturalist can continue
+            to scale its infrastructure and staff by providing predictable
+            revenue. You can also opt to show your monthly supporter status on
+            your user profile.
+          </p>
+          <p class="lead">
+            Your charitable donations help support iNaturalist as the community
+            grows, from advancing computer vision and implementing new features
+            to supporting our servers and staff. If you prefer to give a
+            one-time donation, please <a href="%{donate_url}">click here</a>.
+          </p>
+          <p class="text-muted">
+            iNaturalist is a joint initiative of the California Academy of Sciences
+            and the National Geographic Society. All donations will be received by
+            the California Academy of Sciences, a 501(c)(3) tax-exempt not-for-profit
+            organization based in the United States of America.
+          </p>
     flags:
       show:
         flags_that_should_not_be_resolved_desc_html: |
@@ -6719,6 +6746,8 @@ en:
           Show common names. Disable if you only want to view scientific names.
           Note that you can control which common names you see by changing your
           locale and place settings.
+        display_monthly_supporter_status_on_my_profile: |
+          Display Monthly Supporter status on my profile
         if_you_change_your_mind_you_can_always_edit_your_settings_html: |
           If you change your mind you can always
           <a href='/users/edit'>edit your settings</a>.
@@ -6756,6 +6785,14 @@ en:
           Facility</a> (GBIF), an international, inter-governmental organization
           that compiles and distributes biodiversity information from around the
           world.
+        monthly_supporter_desc_html: |
+          iNaturalist Monthly Supporters make automatic monthly contributions
+          which are received by the California Academy of Sciences (United
+          States IRS FIN 94-1156258) to support the not-for-profit operation of
+          iNaturalist and iNaturalist Network sites.
+          <a href="%{url}">Click here to become a monthly supporter</a>.
+          When we have confirmed your support you will be able to check this
+          box to display this status on your profile.
         muting_desc_html: |
           <p>
             Muting someone prevents you from receiving notifications about things
@@ -6777,23 +6814,6 @@ en:
           any: Any
           joined: Projects you've joined
           none: "None, only you can add your observations to projects"
-        this_only_applies_to_traditional_projects: |
-          This only applies to traditional projects. You can't exclude observations
-          from collection or umbrella projects, which are essentially saved searches.
-          You can read more
-          <a href="/blog/15450-announcing-changes-to-projects-on-inaturalist">here</a>.
-        project_settings_desc: |
-          Remember, this does not give projects permission to access your
-          hidden coordinates or send you updates. You must join projects in
-          order to grant these permissions, or grant them on a case-by-case
-          basis.
-        taxon_change_desc: |
-          When taxa are merged or renamed on %{site_name}, your observations, listed
-          taxa, identifications, etc. will be automatically updated to the new
-          taxa if the change is unambiguous. If you opt out or the change is
-          ambiguous (e.g. a split), you will receive an update about the
-          change linking to a tool you can use to manually update your content
-          if you choose.
         prefers_community_taxa_desc: |
           %{site_name} tracks what you think your observations are and what
           the community thinks they are. The identification we share with data
@@ -6803,18 +6823,36 @@ en:
           community opinion won't be favored over yours. This means your
           observations will not be eligible for research grade unless you
           agree with the community.
-        search_place_help_html: |
-          Default place for observation searches.
-        scientific_name_first_desc: |
-          Show scientific names before common names.
-        youve_used_all_of_your_blocks: You've used all of your blocks. Remove a block to add another.
-        same_day_geoprivacy_protection: Same-day geoprivacy protection
         prefers_coordinate_interpolation_protection_desc: |
           When you set the geoprivacy of an observation to "obscured" or
           "private" this will apply the same geoprivacy to all your other
           observations from the same day to make it harder for other people to
           guess the true coordinates based on observations made around the same
           time.
+        project_settings_desc: |
+          Remember, this does not give projects permission to access your
+          hidden coordinates or send you updates. You must join projects in
+          order to grant these permissions, or grant them on a case-by-case
+          basis.
+        same_day_geoprivacy_protection: Same-day geoprivacy protection
+        search_place_help_html: |
+          Default place for observation searches.
+        scientific_name_first_desc: |
+          Show scientific names before common names.
+        taxon_change_desc: |
+          When taxa are merged or renamed on %{site_name}, your observations, listed
+          taxa, identifications, etc. will be automatically updated to the new
+          taxa if the change is unambiguous. If you opt out or the change is
+          ambiguous (e.g. a split), you will receive an update about the
+          change linking to a tool you can use to manually update your content
+          if you choose.
+        thanks_for_supporting_us!: Thanks for supporting us!
+        this_only_applies_to_traditional_projects: |
+          This only applies to traditional projects. You can't exclude observations
+          from collection or umbrella projects, which are essentially saved searches.
+          You can read more
+          <a href="/blog/15450-announcing-changes-to-projects-on-inaturalist">here</a>.
+        youve_used_all_of_your_blocks: You've used all of your blocks. Remove a block to add another.
       recent:
         about_recent_users: About
         definitions_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2185,6 +2185,7 @@ en:
     datetime_with_zone: "MMM D, YYYY · LT z"
   mon: Mon
   month: Month
+  monthly_supporter_since_date: Monthly Supporter since %{date}
   months: Months
   months_ago: "%{text} ago"
   more: More

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get "/privacy", to: redirect( "/pages/privacy" ), as: :privacy_policy
   get "/users/new.mobile", to: redirect( "/signup" )
   get "/donate", to: "donate#index"
+  get "/monthly-supporters", to: "donate#monthly_supporters", as: :monthly_supporters
 
   resources :controlled_terms
   resources :controlled_term_labels, only: [:create, :update, :destroy]

--- a/db/migrate/20190820224224_add_donorbox_plan_columns_to_users.rb
+++ b/db/migrate/20190820224224_add_donorbox_plan_columns_to_users.rb
@@ -1,0 +1,7 @@
+class AddDonorboxPlanColumnsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :donorbox_plan_type, :string
+    add_column :users, :donorbox_plan_status, :string
+    add_column :users, :donorbox_plan_started_at, :date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4887,7 +4887,10 @@ CREATE TABLE public.users (
     suspended_by_user_id integer,
     birthday date,
     pi_consent_at timestamp without time zone,
-    donorbox_donor_id integer
+    donorbox_donor_id integer,
+    donorbox_plan_type character varying,
+    donorbox_plan_status character varying,
+    donorbox_plan_started_at date
 );
 
 
@@ -9991,4 +9994,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190528222836');
 INSERT INTO schema_migrations (version) VALUES ('20190604231553');
 
 INSERT INTO schema_migrations (version) VALUES ('20190702063435');
+
+INSERT INTO schema_migrations (version) VALUES ('20190820224224');
 

--- a/tools/donorbox-plans.rb
+++ b/tools/donorbox-plans.rb
@@ -32,6 +32,9 @@ while true
     user.donorbox_plan_status = plan["status"],
     user.donorbox_plan_started_at = Date.parse( plan["started_at"] ) rescue nil
     if user.changed?
+      if user.donorbox_plan_status_changed? && user.donorbox_plan_status != "active"
+        user.prefers_monthly_supporter_badge = false
+      end
       if user.save
         puts "\tUpdated #{user}"
         num_updated_users += 1

--- a/tools/donorbox-plans.rb
+++ b/tools/donorbox-plans.rb
@@ -1,0 +1,48 @@
+start = Time.now
+if !CONFIG.donorbox || !CONFIG.donorbox.email || !CONFIG.donorbox.key
+  raise "Donorbox email an API key haven't been added to config"
+end
+donorbox_email = CONFIG.donorbox.email
+donorbox_key = CONFIG.donorbox.key
+page = 1
+per_page = 100
+debug = true
+num_plans = 0
+num_updated_users = 0
+num_invalid_users = 0
+while true
+  url = "https://donorbox.org/api/v1/plans?page=#{page}&per_page=#{per_page}"
+  puts url if debug
+  response = RestClient.get( url, {
+    "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
+    "User-Agent" => "iNaturalist/Donorbox"
+  } )
+  json = JSON.parse( response )
+  break if json.size == 0
+  json.each do |plan|
+    num_plans += 1
+    next unless donor = plan["donor"]
+    puts "Donor #{donor["id"]} (#{donor['email']})"
+    unless user = User.find_by_email( donor["email"] )
+      puts "\tNo user"
+      next
+    end
+    user.donorbox_donor_id = donor["id"],
+    user.donorbox_plan_type = plan["type"],
+    user.donorbox_plan_status = plan["status"],
+    user.donorbox_plan_started_at = Date.parse( plan["started_at"] ) rescue nil
+    if user.changed?
+      if user.save
+        puts "\tUpdated #{user}"
+        num_updated_users += 1
+      else
+        puts "\tFailed to update user: #{user.errors.full_messages.to_sentence}" 
+        num_invalid_users += 1
+      end
+    end
+  end
+  page += 1
+end
+puts
+puts "#{num_plans} donors, #{num_updated_users} users udpated, #{num_invalid_users} invalid users in #{Time.now - start}s"
+puts


### PR DESCRIPTION
Adds a Monthly Supporters page and the ability for Monthly Supporters to display a badge on the profile page. At present requires `test=monthly_supporters` param to view. Closes #2369, #2367,  and #2368.