### PR TITLE
Several ideas for reducing the amount of UpdateActions

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -3235,8 +3235,12 @@ class Observation < ActiveRecord::Base
   end
 
   def user_viewed_updates(user_id)
-    obs_updates = UpdateAction.where(resource: self)
-    UpdateAction.user_viewed_updates(obs_updates, user_id)
+    obs_updates_as_resource = UpdateAction.where(resource: self)
+    obs_updates_as_notifier = UpdateAction.where(notifier: self)
+    UpdateAction.user_viewed_updates(
+      [obs_updates_as_resource.to_a, obs_updates_as_notifier.to_a].flatten,
+      user_id
+    )
   end
 
   def self.dedupe_for_user(user, options = {})

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -68,7 +68,7 @@ class Subscription < ActiveRecord::Base
   # stop getting any updates about anything from CA
   def suspended?
     return false unless %w{Place Taxon}.include?( resource_type )
-    return true if suspended_at < 1.day.ago
+    return true if suspended_at && suspended_at < 1.day.ago
     unviewed_count_for_resource = UpdateAction.elastic_search(
       size: 0,
       filters: [
@@ -93,9 +93,10 @@ class Subscription < ActiveRecord::Base
     ).results.total_entries
     if unviewed_count_for_resource > 1000
       update_attribute( :suspended_at, Time.now )
-    else
-      update_attribute( :suspended_at, nil )
+      return true
     end
+    update_attribute( :suspended_at, nil )
+    false
   end
 
 end

--- a/db/migrate/20191113020752_add_suspended_at_to_subscriptions.rb
+++ b/db/migrate/20191113020752_add_suspended_at_to_subscriptions.rb
@@ -1,6 +1,6 @@
-class AddSuspendedAtToUpdateActions < ActiveRecord::Migration
+class AddSuspendedAtToSubscriptions < ActiveRecord::Migration
   def up
-    add_column :update_actions, :suspended_at, :timestamp
+    add_column :subscriptions, :suspended_at, :timestamp
 
     # Consider all UpdateActions for places and taxa to be viewed since we're
     # about to start suspending subscriptions if they have a lot of unviewed
@@ -24,6 +24,6 @@ class AddSuspendedAtToUpdateActions < ActiveRecord::Migration
   end
 
   def down
-    remove_column :update_actions, :suspended_at
+    remove_column :subscriptions, :suspended_at
   end
 end

--- a/db/migrate/20191113020752_add_suspended_at_to_update_actions.rb
+++ b/db/migrate/20191113020752_add_suspended_at_to_update_actions.rb
@@ -1,0 +1,29 @@
+class AddSuspendedAtToUpdateActions < ActiveRecord::Migration
+  def up
+    add_column :update_actions, :suspended_at, :timestamp
+
+    # Consider all UpdateActions for places and taxa to be viewed since we're
+    # about to start suspending subscriptions if they have a lot of unviewed
+    # updates (and considering a place or taxon update to be "viewed" if the
+    # subscriber views the obs)
+    UpdateAction.__elasticsearch__.client.update_by_query(
+      index: UpdateAction.index_name,
+      body: {
+        query: {
+          bool: {
+            must: [
+              { terms: { resource_type: ["Place", "Taxon"] } }
+            ]
+          }
+        },
+        script: {
+          source: "ctx._source.viewed_subscriber_ids = ctx._source.subscriber_ids"
+        }
+      }
+    )
+  end
+
+  def down
+    remove_column :update_actions, :suspended_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4678,7 +4678,8 @@ CREATE TABLE public.update_actions (
     notifier_id integer,
     notification character varying,
     resource_owner_id integer,
-    created_at timestamp without time zone
+    created_at timestamp without time zone,
+    suspended_at timestamp without time zone
 );
 
 
@@ -10016,4 +10017,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190820224224');
 INSERT INTO schema_migrations (version) VALUES ('20190918161513');
 
 INSERT INTO schema_migrations (version) VALUES ('20191104233418');
+
+INSERT INTO schema_migrations (version) VALUES ('20191113020752');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3956,7 +3956,8 @@ CREATE TABLE public.subscriptions (
     resource_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    taxon_id integer
+    taxon_id integer,
+    suspended_at timestamp without time zone
 );
 
 
@@ -4678,8 +4679,7 @@ CREATE TABLE public.update_actions (
     notifier_id integer,
     notification character varying,
     resource_owner_id integer,
-    created_at timestamp without time zone,
-    suspended_at timestamp without time zone
+    created_at timestamp without time zone
 );
 
 

--- a/lib/has_subscribers.rb
+++ b/lib/has_subscribers.rb
@@ -228,12 +228,13 @@ module HasSubscribers
           # Don't notify people who have already been notified by this
           next if users_with_unviewed_from_notifier.include?(subscription.user_id)
 
-          # Don't notify people about updates within a resource if they already have X unviewed updates about that resource
-          next if subscription.suspended?
-
           if options[:if]
             next unless options[:if].call(notifier, subscribable, subscription)
           end
+
+          # Don't notify people about updates within a resource if they already have X unviewed updates about that resource
+          next if subscription.suspended?
+
           users_to_notify[subscribable] ||= [ ]
           users_to_notify[subscribable] << subscription.user_id
         end


### PR DESCRIPTION
Not entirely convinced any of these are *good* ideas, but I submit them for review, at least. IMO, these are all stopgap ways to address this problem. Hopefully deal with subscriptions to places, taxa, and users without having to rely on a notifications system in the future. To wit:

1. `Observation#user_viewed_updates` now marks UpdateActions as viewed where the observation is the *notifier*, not just the resource. This should mark UpdateActions for subscriptions to places, taxa, and users as "viewed" and trigger their deletion when we clean out updates older than 3 months
1. `rake inaturalist:delete_expired_updates` now deletes UpdateActions where the resource is a place or a taxon that are over 1 month old (as opposed to 3 months old for everything else)
1. Suspend subscriptions to resources when the subscriber has more than 1000 unviewed updates for that resource. E.g. if you subscribe to everything from California and there are 1000 updates about observations you've never clicked through to, we stop updating you about new observations in California. As noted in the comments, the current implementation ignores taxonomic conditions on place subscriptions b/c we don't have that info in the UpdateActions index... which might be a problem. We could just not suspend subscriptions that have a taxonomic condition, I guess, but that would mean you could still subscribe to "animals of North America" or something equally absurd.
    1. Another problem might be performance. The cost of running this ES search to check how many unviewed updates each subscriber has might be more than the cost of having all those extra updates
1. Brutal migration that adds a column to `update_actions` and marks all update actions in the ES index as viewed by all subscribers. Might be too brutal to actually do.

TODO: write some tests