### PR TITLE
No tracking preference

### DIFF
--- a/app/assets/javascripts/i18n/pluralizations.js
+++ b/app/assets/javascripts/i18n/pluralizations.js
@@ -58,6 +58,15 @@
     return ["other"];
   }
 
+  // Override default to deal with English-style delimiters
+  I18n.pluralization.default = function ( count ) {
+    switch ( normalizeCount( count, "en" ) ) {
+      case 0: return ["zero", "other"];
+      case 1: return ["one"];
+      default: return ["other"];
+    }
+  };
+
   // Add pluralization rules for locales
   I18n.pluralization.ar = function ( count ) {
     var n = normalizeCount( count, "ar" ) || 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,6 +84,7 @@ class ApplicationController < ActionController::Base
 
   def set_ga_trackers
     return true unless request.format.blank? || request.format.html?
+    return true if current_user && current_user.prefers_no_tracking?
     trackers = [ ]
     if Site.default && !Site.default.google_analytics_tracker_id.blank?
       trackers << [ "default", Site.default.google_analytics_tracker_id ]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,6 +84,7 @@ class ApplicationController < ActionController::Base
 
   def set_ga_trackers
     return true unless request.format.blank? || request.format.html?
+    return true if request.env["HTTP_DNT"] == "1"
     return true if current_user && current_user.prefers_no_tracking?
     trackers = [ ]
     if Site.default && !Site.default.google_analytics_tracker_id.blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -576,10 +576,12 @@ class UsersController < ApplicationController
             :crypted_password, :salt, :old_preferences, :activation_code,
             :remember_token, :last_ip, :suspended_at, :suspension_reason,
             :icon_content_type, :icon_file_name, :icon_file_size,
-            :icon_updated_at, :deleted_at, :remember_token_expires_at, :icon_url, :latitude, :longitude, :lat_lon_acc_admin_level
+            :icon_updated_at, :deleted_at, :remember_token_expires_at,
+            :icon_url, :latitude, :longitude, :lat_lon_acc_admin_level
           ],
           :methods => [
-            :user_icon_url, :medium_user_icon_url, :original_user_icon_url
+            :user_icon_url, :medium_user_icon_url, :original_user_icon_url,
+            :prefers_no_tracking
           ]
         )
       end
@@ -1120,6 +1122,7 @@ protected
       :prefers_scientific_name_first,
       :prefers_no_place,
       :prefers_no_site,
+      :prefers_no_tracking,
       :prefers_coordinate_interpolation_protection,
       :prefers_coordinate_interpolation_protection_test,
       :prefers_monthly_supporter_badge,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,7 @@ class User < ActiveRecord::Base
   preference :monthly_supporter_badge, :boolean, default: false
   preference :map_tile_test, :boolean, default: false
   preference :no_site, :boolean, default: false
+  preference :no_tracking, :boolean, default: false
   
   NOTIFICATION_PREFERENCES = %w(
     comment_email_notification

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -169,8 +169,45 @@
           [t(:only_you), User::PREFERRED_OBSERVATION_FIELDS_BY_OBSERVER]
         ], :description => t(:observation_fields_by_preferences_description) %>
 
-      <% if current_user.prefers_coordinate_interpolation_protection_test? %>
+      <%= feature_test "no-tracking" do %>
         <h3><%=t :privacy %></h3>
+        <%- no_tracking_desc = capture do %>
+          <%= link_to_dialog "<i class='fa fa-info-circle'></i> #{t( "views.users.edit.about_third_party_tracking" )}".html_safe, title: t( "views.users.edit.about_third_party_tracking" ), width: "80%" do %>
+            <p><%=t "views.users.edit.prefers_no_tracking_label_desc_we_use" %></p>
+            <ul>
+              <li class="readable">
+                <%=t "views.users.edit.prefers_no_tracking_label_desc_we_use_google_html" %>
+              </li>
+              <li class="readable">
+                <a href="https://newrelic.com">New Relic</a>
+              </li>
+            </ul>
+            <p><%=t "views.users.edit.prefers_no_tracking_label_desc_info_we_share" %></p>
+            <ul>
+              <li class="readable">
+                <%=t "views.users.edit.prefers_no_tracking_label_desc_info_we_share_ip_addresses_html" %>
+              </li>
+              <li class="readable">
+                <%=t "views.users.edit.prefers_no_tracking_label_desc_info_we_share_browser_details" %>
+              </li>
+              <li class="readable">
+                <%=t "views.users.edit.prefers_no_tracking_label_desc_info_we_share_crash_details" %>
+              </li>
+              <li class="readable">
+                <%=t "views.users.edit.prefers_no_tracking_label_desc_info_we_share_device_details" %>
+              </li>
+            </ul>
+            <p><%=t "views.users.edit.prefers_no_tracking_label_desc_value_html" %></p>
+            <p><%=t "views.users.edit.prefers_no_tracking_label_desc_limits" %></p>
+          <% end %>
+        <% end %>
+        <%= f.check_box "prefers_no_tracking",
+          label: t( "views.users.edit.prefers_no_tracking_label" ),
+          label_after: true,
+          description: no_tracking_desc
+        %>
+      <% end %>
+      <% if current_user.prefers_coordinate_interpolation_protection_test? %>
         <%= f.check_box "prefers_coordinate_interpolation_protection", 
           label: t( "views.users.edit.same_day_geoprivacy_protection" ),
           label_after: true,
@@ -225,7 +262,7 @@
         </div>
         
         <div class="last column span-18">
-          <%= link_to_function "<span class='helptip'></span> #{t(:about_these_licenses)}".html_safe,
+          <%= link_to_function "<i class='fa fa-info-circle'></i> #{t(:about_these_licenses)}".html_safe,
             "$('#aboutlicenses').dialog({width:'auto', modal:true, title: '#{t(:about_the_cc_licenses)}'})" %>
           <div id="aboutlicenses" class="dialog" style="display:none">
             <div class="column span-18 verticalmiddle">

--- a/app/webpack/stats/year/components/growth.jsx
+++ b/app/webpack/stats/year/components/growth.jsx
@@ -12,7 +12,10 @@ const Growth = ( {
   data,
   year
 } ) => {
-  const label = d => `<strong>${moment( d.date ).add( 2, "days" ).format( "MMMM YYYY" )}</strong>: ${I18n.toNumber( d.value, { precision: 0 } )}`;
+  const label = d => I18n.t( "bold_label_colon_value_html", {
+    label: moment( d.date ).add( 2, "days" ).format( "MMMM YYYY" ),
+    value: I18n.t( "x_observations", { count: I18n.toNumber( d.value, { precision: 0 } ) } )
+  } );
   const grayColor = "rgba( 40%, 40%, 40%, 0.5 )";
   const emptyJan = {
     date: `${year + 1}-01-01`,

--- a/app/webpack/stats/year/components/identifications.jsx
+++ b/app/webpack/stats/year/components/identifications.jsx
@@ -19,7 +19,10 @@ const Identifications = ( { data, user, currentUser, year } ) => {
       data: _.map( data.month_histogram, ( value, date ) => ( { date, value } ) ),
       style: "bar",
       color: grayColor,
-      label: d => `<strong>${moment( d.date ).add( 2, "days" ).format( "MMMM" )}</strong>: ${I18n.toNumber( d.value, { precision: 0 } )}`
+      label: d => I18n.t( "bold_label_colon_value_html", {
+        label: moment( d.date ).add( 2, "days" ).format( "MMMM" ),
+        value: I18n.t( "x_identifications", { count: I18n.toNumber( d.value, { precision: 0 } ) } )
+      } )
     };
   }
   if ( data.week_histogram ) {
@@ -28,14 +31,21 @@ const Identifications = ( { data, user, currentUser, year } ) => {
       data: _.map( data.week_histogram, ( value, date ) => ( { date, value } ) ),
       color: "rgba( 168, 204, 9, 0.2 )",
       style: "bar",
-      label: d => `<strong>${I18n.t( "week_of_date", { date: moment( d.date ).format( "LL" ) } )}</strong>: ${I18n.toNumber( d.value, { precision: 0 } )}`
+      label: d => I18n.t( "bold_label_colon_value_html", {
+        label: I18n.t( "week_of_date", { date: moment( d.date ).format( "LL" ) } ),
+        value: I18n.t( "x_identifications", { count: I18n.toNumber( d.value, { precision: 0 } ) } )
+      } )
     };
   }
   if ( data.day_histogram ) {
     series.day = {
       title: I18n.t( "per_day" ),
       data: _.map( data.day_histogram, ( value, date ) => ( { date, value } ) ),
-      color: "#74ac00"
+      color: "#74ac00",
+      label: d => I18n.t( "bold_label_colon_value_html", {
+        label: moment( d.date ).format( "ll" ),
+        value: I18n.t( "x_identifications", { count: I18n.toNumber( d.value, { precision: 0 } ) } )
+      } )
     };
   }
   return (

--- a/app/webpack/stats/year/components/observations_grid.jsx
+++ b/app/webpack/stats/year/components/observations_grid.jsx
@@ -10,7 +10,7 @@ class ObservationsGrid extends React.Component {
   constructor( props ) {
     super( props );
     this.state = {
-      obsToShow: props.perPage || props.max
+      initialObsToShow: props.perPage || props.max
     };
   }
 
@@ -21,13 +21,17 @@ class ObservationsGrid extends React.Component {
       columns,
       identifier,
       dateField,
-      max,
-      perPage
+      perPage,
+      max
     } = this.props;
-    const { obsToShow } = this.state;
+    const { initialObsToShow } = this.state;
+    let obsToshow = initialObsToShow;
+    if ( !perPage && initialObsToShow < max ) {
+      obsToshow = max;
+    }
     return (
       <div className={`${identifier} ${user ? "for-user" : ""}`}>
-        { _.map( _.chunk( observations.slice( 0, obsToShow ), columns ), ( chunk, i ) => (
+        { _.map( _.chunk( observations.slice( 0, obsToshow ), columns ), ( chunk, i ) => (
           <Row key={`${identifier}-obs-chunk-${i}`}>
             { chunk.map( o => {
               const colSize = Math.floor( 12.0 / columns );
@@ -76,13 +80,13 @@ class ObservationsGrid extends React.Component {
             } ) }
           </Row>
         ) ) }
-        { observations.length > obsToShow && perPage && (
+        { observations.length > initialObsToShow && perPage && (
           <button
             type="button"
             className="btn btn-default btn-bordered center-block"
             onClick={() => {
               this.setState( {
-                obsToShow: Math.min( observations.length, obsToShow + perPage )
+                initialObsToShow: Math.min( observations.length, initialObsToShow + perPage )
               } );
             }}
           >

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,9 +67,11 @@ Inaturalist::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
   
-  config.middleware.use Rack::GoogleAnalytics, :trackers => lambda { |env|
-    return env['inat_ga_trackers'] if env['inat_ga_trackers']
-  }
+  config.middleware.use Rack::GoogleAnalytics,
+    anonymize_ip: true,
+    trackers: lambda { |env|
+      return env['inat_ga_trackers'] if env['inat_ga_trackers']
+    }
 
   config.log_formatter = CustomLogFormatter.new
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6326,6 +6326,7 @@ en:
         you_must_enter_confirmation_code_in_the_form: |
           You must enter "%{confirmation_code}" in the form to delete your account
       edit:
+        about_third_party_tracking: About third party tracking
         blocking_desc_html: |
           <p>
             Blocking someone prevents them from messaging you, commenting on your
@@ -6483,6 +6484,52 @@ en:
           observations from the same day to make it harder for other people to
           guess the true coordinates based on observations made around the same
           time.
+        prefers_no_tracking_label: Do not collect stability and usage data using third party services
+        prefers_no_tracking_label_desc_we_use: |
+          We use a variety of third party services to monitor stability and
+          diagnose bugs and problems in our software. These third parties
+          include
+        prefers_no_tracking_label_desc_we_use_google_html:
+          Google (<a href="https://analytics.google.com">Google Analytics</a>,
+          <a href="https://firebase.google.com/products/crashlytics/">Firebase Crashlytics</a>)
+        prefers_no_tracking_label_desc_info_we_share: |
+          Information we might share with these third parties include
+        prefers_no_tracking_label_desc_info_we_share_ip_addresses_html: |
+          IP addresses (which can be used to derive location at city-level
+          resolution, and to track you across different websites and services;
+          note that we have enabled
+          <a href="https://support.google.com/analytics/answer/2763052">IP anonymization</a>
+          in Google Analytics and <a
+          href="https://firebase.google.com/support/privacy">Firebase
+          Crashlytics</a> does not record IP address to our knowledge)
+        prefers_no_tracking_label_desc_info_we_share_browser_details: |
+          Browser details, like make, model, and version
+        prefers_no_tracking_label_desc_info_we_share_crash_details: |
+          Crash details, like exactly what line of code caused a crash
+        prefers_no_tracking_label_desc_info_we_share_device_details: |
+          Device details, like make and model of a mobile phone
+        prefers_no_tracking_label_desc_value_html: |
+          <strong>These third party services provide enormous value to
+          us</strong> in maintaining the stability and usability of iNaturalist
+          with our relatively small staff. On mobile devices, there is almost no
+          other way we can gain insight into problems that are occurring, since
+          the software is running on devices we do not control. Sometimes we
+          aren’t even aware such problems are occurring until we see them in the
+          data these services provide. <strong>By sharing this information, you
+          are helping us serve you and the entire iNaturalist
+          community.</strong>
+        prefers_no_tracking_label_desc_limits: |
+          Note that this option only applies to analytics and crash data that we
+          are explicitly sending to these companies. All iNaturalist servers are
+          provided and hosted by Microsoft, all iNaturalist images are hosted by
+          Amazon, and almost all iNaturalist maps are served by Google, which
+          means every time you look at an observation on iNaturalist, you are
+          connecting to services provided by these companies and exposing your
+          IP address to them, at the very least (in the iPhone app we use
+          Apple’s maps). iNaturalist probably would not exist without the
+          services these companies provide, and while we can limit the amount
+          and kinds of data you share with them while using iNat, we cannot stop
+          the flow of data entirely.
         project_settings_desc: |
           Remember, this does not give projects permission to access your
           hidden coordinates or send you updates. You must join projects in


### PR DESCRIPTION
Addresses #2490. The setting is currently only available at /users/edit?test=no-tracking until translators have a shot at the large amount of text.