### PR TITLE
Observation Streaks for Year In Review

### DIFF
--- a/app/assets/javascripts/i18n/pluralizations.js
+++ b/app/assets/javascripts/i18n/pluralizations.js
@@ -14,6 +14,8 @@
     var parsableString = pieces.join( "." );
     if ( pieces.length === 2 ) {
       parsableString = pieces[0].replace( delimiter, "" ) + "." + pieces[1];
+    } else {
+      parsableString = pieces[0].replace( delimiter, "" );
     }
     return parseFloat( parsableString );
   }

--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -14564,10 +14564,11 @@ I18n.translations["en"] = {
         "include_usa": "Include US",
         "new_species_desc_html": "Species that were added for the first time this year.\nClick on a month to view some of the new species added in that month.\nYou can also view the total species accumulation, or move the slider\nback in time to see other newly-observed species. This chart shows\nspecies from verifiable observations by the month they were uploaded\nto %{site_name} (not the month they were observed). It does not\ninclude higher or lower level taxa, so an observation identified as\nMammalia doesn't count, and an observation of <i>Canis lupus</i> ssp.\n<i>arctos</i> will just count as <i>Canis lupus</i>.\n",
         "obs_in_year": "Obs in %{year}",
+        "observation_streaks": "Observation Streaks",
+        "observation_streaks_desc": "An observation streak is a period where someone has made observations\nfor at least 5 days running.\n",
         "percent_growth_in_year": "% Growth in %{year}",
         "percent_of_total_growth": "% of Total Growth",
         "publications_desc_html": "Click the flower charts for more information about what the numbers\nand colors mean. Impact data and charts courtesy of\n<a href=\"https://www.altmetric.com\">Altmetric</a>. Information\nabout data usage courtesy of our friends at the\n<a href=\"https://www.gbif.org/\">Global Biodiversity Information Faciltity</a>.\n<br/>\n<a href=\"%{url}\">View all %{numStudies} studies</a>\n",
-        "streaks": "Streaks",
         "sunburst_desc_html": "Observed taxa arranged as a hierarchical \"sunburst\" diagram. The base\nof the hierarchy is at the center, starting with \"Life\" and ending\nwith species at the outer edges. The size of each arc is proportional\nto the number of observations of that taxon, and colors rougly\ncorrespond to our usual \"iconic\" taxon colors (green for plants,\norange for insects, blue for most other animals, etc.), so if you're\nseeing a lot of green, that means you observed a lot of plants.\n<strong>Click an arc to place that taxon at the center</strong> and\nits children around it, or <strong>click the center to move back up\nthe hierarchy</strong>.\n"
       }
     },

--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -356,6 +356,16 @@ I18n.translations["ar"] = {
   "date_time": "تاريخ/وقت",
   "date_updated": "تاريخ التحديث",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "zero": "صفر أيام",
+        "one": "يوم واحد",
+        "two": "يومان",
+        "few": "%{count} أيام",
+        "many": "%{count} يوم",
+        "other": "%{count} يوم"
+      }
+    }
   },
   "decrease_brightness": "تقليل السطوع",
   "default": "الافتراضي",
@@ -2099,6 +2109,12 @@ I18n.translations["bg"] = {
     "countdown_x_seconds": {
       "one": "сек",
       "other": "сек"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 ден",
+        "other": "%{count} дни"
+      }
     }
   },
   "default": "по подразбиране",
@@ -3265,6 +3281,8 @@ I18n.translations["br"] = {
   },
   "date_time": "Deiz/Eur",
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "default": "dre ziouer",
   "delete": "Dilemel",
@@ -4032,6 +4050,12 @@ I18n.translations["ca"] = {
     "countdown_x_seconds": {
       "one": "seg.",
       "other": "segs."
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 dia",
+        "other": "%{count} dies"
+      }
     }
   },
   "decrease_brightness": "Reduïu brillantor",
@@ -5794,6 +5818,13 @@ I18n.translations["cs"] = {
   "date_time": "Datum/Čas",
   "date_updated": "Datum aktualizováno",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "24 hodinami",
+        "few": "%{count} dny",
+        "other": "%{count} dny"
+      }
+    }
   },
   "default": "výchozí",
   "delete": "Smazat",
@@ -7538,6 +7569,12 @@ I18n.translations["da"] = {
     "countdown_x_seconds": {
       "one": "sek",
       "other": "sek"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 dag ",
+        "other": "%{count} dage"
+      }
     }
   },
   "decrease_brightness": "Mindsk lysstyrke",
@@ -9634,6 +9671,12 @@ I18n.translations["de"] = {
     "countdown_x_days": {
       "one": "Tag",
       "other": "Tage"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 Tag",
+        "other": "%{count} Tage"
+      }
     }
   },
   "decrease_brightness": "Helligkeit reduzieren",
@@ -11430,6 +11473,12 @@ I18n.translations["el"] = {
     "countdown_x_seconds": {
       "one": "δευτερόλεπτο",
       "other": "δευτερόλεπτα"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 ημέρα",
+        "other": "%{count} ημέρες"
+      }
     }
   },
   "default": "προεπιλογή",
@@ -13019,6 +13068,12 @@ I18n.translations["en"] = {
     "countdown_x_seconds": {
       "one": "sec",
       "other": "sec"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "%{count} day",
+        "other": "%{count} days"
+      }
     }
   },
   "decrease_brightness": "Decrease Brightness",
@@ -14512,6 +14567,7 @@ I18n.translations["en"] = {
         "percent_growth_in_year": "% Growth in %{year}",
         "percent_of_total_growth": "% of Total Growth",
         "publications_desc_html": "Click the flower charts for more information about what the numbers\nand colors mean. Impact data and charts courtesy of\n<a href=\"https://www.altmetric.com\">Altmetric</a>. Information\nabout data usage courtesy of our friends at the\n<a href=\"https://www.gbif.org/\">Global Biodiversity Information Faciltity</a>.\n<br/>\n<a href=\"%{url}\">View all %{numStudies} studies</a>\n",
+        "streaks": "Streaks",
         "sunburst_desc_html": "Observed taxa arranged as a hierarchical \"sunburst\" diagram. The base\nof the hierarchy is at the center, starting with \"Life\" and ending\nwith species at the outer edges. The size of each arc is proportional\nto the number of observations of that taxon, and colors rougly\ncorrespond to our usual \"iconic\" taxon colors (green for plants,\norange for insects, blue for most other animals, etc.), so if you're\nseeing a lot of green, that means you observed a lot of plants.\n<strong>Click an arc to place that taxon at the center</strong> and\nits children around it, or <strong>click the center to move back up\nthe hierarchy</strong>.\n"
       }
     },
@@ -14763,6 +14819,8 @@ I18n.translations["en-UK"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "establishment": {
   },
@@ -14915,6 +14973,12 @@ I18n.translations["en-US"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 day",
+        "other": "%{count} days"
+      }
+    }
   },
   "establishment": {
   },
@@ -15326,6 +15390,12 @@ I18n.translations["eo"] = {
     "countdown_x_seconds": {
       "one": "sekundo",
       "other": "sekundoj"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 tago",
+        "other": "%{count} tagoj"
+      }
     }
   },
   "default": "implicita",
@@ -16617,6 +16687,12 @@ I18n.translations["es"] = {
     "countdown_x_seconds": {
       "one": "s",
       "other": "s"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 día",
+        "other": "%{count} días"
+      }
     }
   },
   "decrease_brightness": "Reducir brillo",
@@ -18706,6 +18782,12 @@ I18n.translations["es-AR"] = {
     "countdown_x_seconds": {
       "one": "s",
       "other": "s"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 día",
+        "other": "%{count} días"
+      }
     }
   },
   "decrease_brightness": "Reducir brillo",
@@ -20433,6 +20515,12 @@ I18n.translations["es-ES"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 día",
+        "other": "%{count} días"
+      }
+    }
   },
   "establishment": {
   },
@@ -20918,6 +21006,12 @@ I18n.translations["es-MX"] = {
     "countdown_x_seconds": {
       "one": "s",
       "other": "s"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "un día",
+        "other": "%{count} días"
+      }
     }
   },
   "default": "Predeterminada",
@@ -22710,6 +22804,12 @@ I18n.translations["et"] = {
     "countdown_x_seconds": {
       "one": "sek",
       "other": "sek"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 päev",
+        "other": "%{count} päeva"
+      }
     }
   },
   "default": "vaikimisi",
@@ -24421,6 +24521,12 @@ I18n.translations["eu"] = {
   },
   "date_time": "Data/Ordua",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 egun",
+        "other": "%{count} egun"
+      }
+    }
   },
   "default": "Lehenetsia",
   "delete": "Ezabatu",
@@ -25482,6 +25588,12 @@ I18n.translations["fi"] = {
     "countdown_x_seconds": {
       "one": "sekunti",
       "other": "sekuntia"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 päivä",
+        "other": "%{count} päivää"
+      }
     }
   },
   "decrease_brightness": "Vähennä kirkkautta",
@@ -27034,6 +27146,8 @@ I18n.translations["fil"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "establishment": {
   },
@@ -27545,6 +27659,12 @@ I18n.translations["fr"] = {
     "countdown_x_seconds": {
       "one": "seconde",
       "other": "seconde"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 jour",
+        "other": "%{count} jours"
+      }
     }
   },
   "decrease_brightness": "Diminuer la luminosité",
@@ -29113,6 +29233,12 @@ I18n.translations["fr-CA"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 jour",
+        "other": "%{count} jours"
+      }
+    }
   },
   "establishment": {
   },
@@ -29261,6 +29387,8 @@ I18n.translations["gd"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "establishment": {
   },
@@ -29598,6 +29726,12 @@ I18n.translations["gl"] = {
   },
   "date_time": "Data/Hora",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 día",
+        "other": "%{count} días"
+      }
+    }
   },
   "default": "Predeterminada",
   "delete": "Eliminar",
@@ -30465,6 +30599,14 @@ I18n.translations["he"] = {
       "two": "שתי שניות",
       "many": "שניות",
       "other": "שניות"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "יום אחד",
+        "other": "%{count} ימים",
+        "two": "%{count} ימים",
+        "many": "%{count} ימים"
+      }
     }
   },
   "default": "ברירת המחדל",
@@ -31846,6 +31988,12 @@ I18n.translations["id"] = {
   "date_time": "Tanggal/Waktu",
   "date_updated": "Tanggal pemutakhiran",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "sehari",
+        "other": "%{count} hari"
+      }
+    }
   },
   "default": "baku",
   "delete": "Hapus",
@@ -32945,6 +33093,12 @@ I18n.translations["it"] = {
     "countdown_x_seconds": {
       "one": "sec",
       "other": "sec"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 giorno",
+        "other": "%{count} giorni"
+      }
     }
   },
   "decrease_brightness": "Riduci luminosità",
@@ -34647,6 +34801,8 @@ I18n.translations["iw"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "establishment": {
   },
@@ -35066,6 +35222,12 @@ I18n.translations["ja"] = {
     },
     "countdown_x_seconds": {
       "other": "秒"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1日",
+        "other": "%{count}日"
+      }
     }
   },
   "default": "既定",
@@ -35958,6 +36120,8 @@ I18n.translations["ka"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "establishment": {
   },
@@ -36376,6 +36540,12 @@ I18n.translations["ko"] = {
     },
     "countdown_x_seconds": {
       "other": "초"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "하루",
+        "other": "%{count}일"
+      }
     }
   },
   "decrease_brightness": "밝기 줄이기",
@@ -37599,6 +37769,12 @@ I18n.translations["lb"] = {
     "countdown_x_seconds": {
       "one": "Sek",
       "other": "Sek"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 Dag",
+        "other": "%{count} Deeg"
+      }
     }
   },
   "default": "Standard",
@@ -38557,6 +38733,13 @@ I18n.translations["lt"] = {
   "date_time": "Data/Laikas",
   "date_updated": "Data atnaujinta",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "%{count} diena",
+        "few": "%{count} dienos",
+        "other": "%{count} dienų"
+      }
+    }
   },
   "decrease_brightness": "Sumažinti ryškumą",
   "default": "bumatytasis",
@@ -39476,6 +39659,12 @@ I18n.translations["mk"] = {
   },
   "date_time": "Датум/време",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 ден",
+        "other": "%{count} дена"
+      }
+    }
   },
   "default": "по основно",
   "delete": "Избриши",
@@ -40428,6 +40617,12 @@ I18n.translations["nb"] = {
     "countdown_x_seconds": {
       "one": "sek",
       "other": "sek"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "%{count} dag",
+        "other": "%{count} dager"
+      }
     }
   },
   "decrease_brightness": "Senk lysstyrken",
@@ -42550,6 +42745,12 @@ I18n.translations["nl"] = {
     "countdown_x_seconds": {
       "one": "sec",
       "other": "sec"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "%{count} dag",
+        "other": "%{count} dagen"
+      }
     }
   },
   "decrease_brightness": "Helderheid verminderen",
@@ -44306,6 +44507,12 @@ I18n.translations["nn"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 dag",
+        "other": "%{count} dagar"
+      }
+    }
   },
   "establishment": {
   },
@@ -44627,6 +44834,8 @@ I18n.translations["oc"] = {
   },
   "date_time": "Data/Ora",
   "datetime": {
+    "distance_in_words": {
+    }
   },
   "default": "per defaut",
   "delete": "Suprimir",
@@ -45566,6 +45775,14 @@ I18n.translations["pl"] = {
       "few": "sekundy",
       "many": "sekund",
       "other": "sekundy"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "few": "%{count} dni",
+        "many": "%{count} dni",
+        "one": "1 dzień",
+        "other": "%{count} dni"
+      }
     }
   },
   "decrease_brightness": "Zmniejsz jasność",
@@ -47211,6 +47428,12 @@ I18n.translations["pt"] = {
     "countdown_x_seconds": {
       "one": "s",
       "other": "s"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 dia",
+        "other": "%{count} dias"
+      }
     }
   },
   "decrease_brightness": "Reduzir a Luminosidade",
@@ -48614,6 +48837,12 @@ I18n.translations["pt-BR"] = {
     "countdown_x_seconds": {
       "one": "s",
       "other": "s"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 dia",
+        "other": "%{count} dias"
+      }
     }
   },
   "decrease_brightness": "Diminuir o brilho",
@@ -50528,6 +50757,14 @@ I18n.translations["ru"] = {
       "few": "сек",
       "many": "сек",
       "other": "сек"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "few": "%{count} дня",
+        "many": "%{count} дней",
+        "one": "%{count} день",
+        "other": "%{count} дней"
+      }
     }
   },
   "decrease_brightness": "Уменьшить яркость",
@@ -52615,6 +52852,13 @@ I18n.translations["sk"] = {
   "date_time": "Dátum/čas",
   "date_updated": "Dátum aktualizovaný",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "dňom",
+        "few": "%{count} dňami",
+        "other": "%{count} dňami"
+      }
+    }
   },
   "decrease_brightness": "Znížiť jas",
   "default": "štandardne",
@@ -54105,6 +54349,12 @@ I18n.translations["sq"] = {
   "date_specified": "Data e specifikuar",
   "date_time": "Data/Ora",
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 ditë",
+        "other": "%{count} ditë"
+      }
+    }
   },
   "default": "e paracaktuar",
   "delete": "Fshi",
@@ -55299,6 +55549,12 @@ I18n.translations["sv"] = {
     "countdown_x_seconds": {
       "one": "sek",
       "other": "sek"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "1 dag",
+        "other": "%{count} dagar"
+      }
     }
   },
   "default": "standard",
@@ -56441,6 +56697,12 @@ I18n.translations["tr"] = {
     "countdown_x_seconds": {
       "one": "sn",
       "other": "sn"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "%{count} gün",
+        "other": "%{count} gün"
+      }
     }
   },
   "decrease_brightness": "Parlaklığı azalt",
@@ -58200,6 +58462,14 @@ I18n.translations["uk"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "few": "%{count} дні",
+        "many": "%{count} днів",
+        "one": "%{count} день",
+        "other": "%{count} дня"
+      }
+    }
   },
   "establishment": {
   },
@@ -58681,6 +58951,12 @@ I18n.translations["zh-CN"] = {
     },
     "countdown_x_seconds": {
       "other": "秒"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "一天",
+        "other": "%{count} 日"
+      }
     }
   },
   "default": "默认",
@@ -59979,6 +60255,12 @@ I18n.translations["zh-HK"] = {
   "date_picker": {
   },
   "datetime": {
+    "distance_in_words": {
+      "x_days": {
+        "one": "一天",
+        "other": "%{count}天"
+      }
+    }
   },
   "establishment": {
   },
@@ -60484,6 +60766,12 @@ I18n.translations["zh-TW"] = {
     },
     "countdown_x_seconds": {
       "other": "秒"
+    },
+    "distance_in_words": {
+      "x_days": {
+        "one": "一天",
+        "other": "%{count} 日"
+      }
     }
   },
   "decrease_brightness": "減少亮度",

--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -307,6 +307,7 @@ I18n.translations["ar"] = {
       "7": "سب"
     },
     "formats": {
+      "long": "%ش %ي، %س",
       "month_day_year": "%ش %ي، %س"
     },
     "month_names": [
@@ -1446,6 +1447,13 @@ I18n.translations["ar"] = {
   "this_taxon_has_no_default_photo": "هذه الأصنوفة ليست لديها صورة افتراضية!",
   "this_year": "هذا العام",
   "threatened": "مهددة",
+  "time": {
+    "am": "صباحا",
+    "formats": {
+      "long": "%B %d, %Y %H:%M"
+    },
+    "pm": "مساء"
+  },
   "to_add_comments": "لإضافة تعليقات",
   "to_suggest_an_identification": "لاقتراح هوية",
   "today": "اليوم",
@@ -2046,6 +2054,7 @@ I18n.translations["bg"] = {
       "7": "Сб"
     },
     "formats": {
+      "long": "%d %B %Y",
       "month_day_year": "%d %B %Y"
     },
     "month_names": [
@@ -2891,6 +2900,13 @@ I18n.translations["bg"] = {
   "this_observation_was_created_using": "Това наблюдение е създадено със:",
   "this_taxon_has_no_default_photo": "Този таксон няма примерна снимка!",
   "threatened": "застрашен",
+  "time": {
+    "am": "преди обяд",
+    "formats": {
+      "long": "%d %B %Y, %H:%M"
+    },
+    "pm": "следобед"
+  },
   "today": "Днес",
   "top_identifier": "Най-добър разпознавач",
   "top_identifiers": "Най-добри разпознавачи",
@@ -3583,6 +3599,10 @@ I18n.translations["br"] = {
   "taxon_map": {
   },
   "this_year": "Bloaz-mañ",
+  "time": {
+    "formats": {
+    }
+  },
   "uploader": {
     "errors": {
     },
@@ -3986,6 +4006,7 @@ I18n.translations["ca"] = {
       "7": "ds"
     },
     "formats": {
+      "long": "%d de %B de %Y",
       "month_day_year": "%d de %B de %Y"
     },
     "month_names": [
@@ -5059,6 +5080,14 @@ I18n.translations["ca"] = {
   "this_taxon_has_no_default_photo": "Aquest tàxon no té foto per defecte!",
   "this_year": "Aquest any",
   "threatened": "Amenaçat",
+  "time": {
+    "am": "del matí",
+    "formats": {
+      "hours": "%I:%M %p %Z",
+      "long": "%d de %B de %Y"
+    },
+    "pm": "de la tarda"
+  },
   "to_add_comments": "per afegir comentaris.",
   "to_suggest_an_identification": "per suggerir una identificació",
   "today": "Avui",
@@ -5769,6 +5798,7 @@ I18n.translations["cs"] = {
       "7": "so"
     },
     "formats": {
+      "long": "%M %d, %R",
       "month_day_year": "%M %d, %R"
     },
     "month_names": [
@@ -6811,6 +6841,13 @@ I18n.translations["cs"] = {
   "this_taxon_has_no_default_photo": "Tento taxon nemá žádnou základní fotku!",
   "this_year": "Tento rok",
   "threatened": "ohrožený",
+  "time": {
+    "am": "dopoledne",
+    "formats": {
+      "long": "%A %d. %B %Y %H:%M"
+    },
+    "pm": "odpoledne"
+  },
   "to_add_comments": "přidat komentáře",
   "to_suggest_an_identification": "k navržení identifikace",
   "today": "Dnes",
@@ -7504,6 +7541,8 @@ I18n.translations["da"] = {
       "7": "Lø"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%d. %B, %Y",
       "month_day_year": "%d. %B %Y"
     },
     "month_names": [
@@ -8780,6 +8819,14 @@ I18n.translations["da"] = {
   "this_taxon_has_no_default_photo": "Denne taxon har intet standardbillede!",
   "this_year": "Dette år",
   "threatened": "truet",
+  "time": {
+    "am": "er",
+    "formats": {
+      "hours": "%H:%M %p",
+      "long": "%d. %B, %Y %I:%M %p"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "for at tilføje kommentarer",
   "to_suggest_an_identification": "at foreslå en identifikation",
   "today": "I dag",
@@ -9620,6 +9667,8 @@ I18n.translations["de"] = {
       "7": "Sa"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%B %d, %Y"
     },
     "month_names": [
       null,
@@ -10740,6 +10789,14 @@ I18n.translations["de"] = {
   "this_taxon_has_no_default_photo": "Dieses Taxon hat kein Standardbild!",
   "this_year": "Dieses Jahr",
   "threatened": "bedroht",
+  "time": {
+    "am": "vormittags",
+    "formats": {
+      "hours": "%l:%M %p",
+      "long": "%B %d, %Y %I:%M %p"
+    },
+    "pm": "nachmittags"
+  },
   "to_add_comments": "um Kommentare hinzuzufügen",
   "to_suggest_an_identification": "eine Identifikation vorschlagen",
   "today": "Heute",
@@ -11410,6 +11467,7 @@ I18n.translations["el"] = {
       "7": "Σα"
     },
     "formats": {
+      "long": "%e %B %Y"
     },
     "month_names": [
       null,
@@ -12406,6 +12464,13 @@ I18n.translations["el"] = {
   "this_observation_is_research_grade": "Αυτή η παρατήρηση είναι Ερευνητικού Επιπέδου!",
   "this_year": "Αυτό το έτος",
   "threatened": "απειλούμενο",
+  "time": {
+    "am": "πμ",
+    "formats": {
+      "long": "%A %d %B %Y %H:%M:%S %Z"
+    },
+    "pm": "μμ"
+  },
   "today": "Σήμερα",
   "top_identifier": "Κορυφαίος Ταυτοποιητής",
   "top_identifiers_of_taxon": "Κορυφαίοι Ταυτοποιητές για %{taxon}",
@@ -13003,6 +13068,8 @@ I18n.translations["en"] = {
       "7": "Sa"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%B %d, %Y",
       "month_day_year": "%B %d, %Y"
     },
     "month_names": [
@@ -14282,6 +14349,14 @@ I18n.translations["en"] = {
   "this_taxon_has_no_default_photo": "This taxon has no default photo!",
   "this_year": "This Year",
   "threatened": "Threatened",
+  "time": {
+    "am": "am",
+    "formats": {
+      "hours": "%l:%M %p",
+      "long": "%B %d, %Y %I:%M %p"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "to add comments",
   "to_suggest_an_identification": "to suggest an identification",
   "today": "Today",
@@ -14565,7 +14640,7 @@ I18n.translations["en"] = {
         "new_species_desc_html": "Species that were added for the first time this year.\nClick on a month to view some of the new species added in that month.\nYou can also view the total species accumulation, or move the slider\nback in time to see other newly-observed species. This chart shows\nspecies from verifiable observations by the month they were uploaded\nto %{site_name} (not the month they were observed). It does not\ninclude higher or lower level taxa, so an observation identified as\nMammalia doesn't count, and an observation of <i>Canis lupus</i> ssp.\n<i>arctos</i> will just count as <i>Canis lupus</i>.\n",
         "obs_in_year": "Obs in %{year}",
         "observation_streaks": "Observation Streaks",
-        "observation_streaks_desc": "An observation streak is a period where someone has made observations\nfor at least 5 days running.\n",
+        "observation_streaks_desc": "An observation streak is a period of time when someone got outside and\nrecorded new observations every single day. Here we're showing the\nlongest streaks that began this year or were ongoing when these stats\nwere generated.\n",
         "percent_growth_in_year": "% Growth in %{year}",
         "percent_of_total_growth": "% of Total Growth",
         "publications_desc_html": "Click the flower charts for more information about what the numbers\nand colors mean. Impact data and charts courtesy of\n<a href=\"https://www.altmetric.com\">Altmetric</a>. Information\nabout data usage courtesy of our friends at the\n<a href=\"https://www.gbif.org/\">Global Biodiversity Information Faciltity</a>.\n<br/>\n<a href=\"%{url}\">View all %{numStudies} studies</a>\n",
@@ -14849,6 +14924,10 @@ I18n.translations["en-UK"] = {
   },
   "taxon_map": {
   },
+  "time": {
+    "formats": {
+    }
+  },
   "uploader": {
     "errors": {
     },
@@ -14950,6 +15029,7 @@ I18n.translations["en-US"] = {
       "Saturday"
     ],
     "formats": {
+      "long": "%B %d, %Y"
     },
     "month_names": [
       null,
@@ -15008,6 +15088,13 @@ I18n.translations["en-US"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%B %d, %Y %H:%M"
+    },
+    "pm": "pm"
   },
   "uploader": {
     "errors": {
@@ -15331,6 +15418,7 @@ I18n.translations["eo"] = {
       "7": "sa"
     },
     "formats": {
+      "long": "%e-a de %B %Y",
       "month_day_year": "%e-a de %B %Y"
     },
     "month_names": [
@@ -16072,6 +16160,13 @@ I18n.translations["eo"] = {
   "this_bioblitz_beings_in": "Ĉi tiu biofulmado komencas en",
   "this_observation": "Tiu observo",
   "this_year": "Nuna Jaro",
+  "time": {
+    "am": "atm",
+    "formats": {
+      "long": "%A %d %B %Y %H:%M"
+    },
+    "pm": "ptm"
+  },
   "today": "Hodiaŭ",
   "total": "Sumo",
   "two_thirds": "du trionoj",
@@ -16623,6 +16718,8 @@ I18n.translations["es"] = {
       "7": "sá"
     },
     "formats": {
+      "compact": "%e %b",
+      "long": "%d de %B de %Y",
       "month_day_year": "%d %B %Y"
     },
     "month_names": [
@@ -17896,6 +17993,14 @@ I18n.translations["es"] = {
   "this_taxon_has_no_default_photo": "Este taxón no tiene ninguna foto predeterminada.",
   "this_year": "Este año",
   "threatened": "Amenazada",
+  "time": {
+    "am": "mañana",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%d de %B de %Y"
+    },
+    "pm": "tarde"
+  },
   "to_add_comments": "para agregar comentarios.",
   "to_suggest_an_identification": "para sugerir una identificación",
   "today": "Hoy",
@@ -18723,6 +18828,7 @@ I18n.translations["es-AR"] = {
       "7": "sá"
     },
     "formats": {
+      "long": "%d de %B de %Y"
     },
     "month_names": [
       null,
@@ -19987,6 +20093,14 @@ I18n.translations["es-AR"] = {
   "this_taxon_has_no_default_photo": "Este taxón no tiene ninguna foto predeterminada.",
   "this_year": "Este año",
   "threatened": "Amenazada",
+  "time": {
+    "am": "mañana",
+    "formats": {
+      "hours": "%l:%M %p",
+      "long": "%d de %B de %Y"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "para agregar comentarios.",
   "to_suggest_an_identification": "para sugerir una identificación",
   "today": "Hoy",
@@ -20492,6 +20606,7 @@ I18n.translations["es-ES"] = {
       "sábado"
     ],
     "formats": {
+      "long": "%-d de %B de %Y"
     },
     "month_names": [
       null,
@@ -20550,6 +20665,13 @@ I18n.translations["es-ES"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%-d de %B de %Y %H:%M"
+    },
+    "pm": "pm"
   },
   "uploader": {
     "errors": {
@@ -20948,6 +21070,7 @@ I18n.translations["es-MX"] = {
       "7": "Sá"
     },
     "formats": {
+      "long": "%d de %B de %Y"
     },
     "month_names": [
       null,
@@ -22003,6 +22126,13 @@ I18n.translations["es-MX"] = {
   "this_taxon_has_no_default_photo": "¡Esta especie o grupo no tiene foto predeterminada!",
   "this_year": "Este año",
   "threatened": "en riesgo",
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%B %d, %A %H:%M"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "para añadir comentarios",
   "to_suggest_an_identification": "sugerir una identificación",
   "today": "Hoy",
@@ -22749,6 +22879,7 @@ I18n.translations["et"] = {
       "7": "L"
     },
     "formats": {
+      "long": "%d. %B %Y",
       "month_day_year": "%d. %B %Y"
     },
     "month_names": [
@@ -23806,6 +23937,14 @@ I18n.translations["et"] = {
   "this_taxon_has_no_default_photo": "Sellel taksonil puudub vaikimisi foto!",
   "this_year": "Sel aastal",
   "threatened": "Ohustatud",
+  "time": {
+    "am": "ennelõunat",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%d. %B %Y %H:%M"
+    },
+    "pm": "pealelõunat"
+  },
   "to_add_comments": "lisada kommentaare",
   "to_suggest_an_identification": "määratluse pakkumiseks",
   "today": "Täna",
@@ -24478,6 +24617,7 @@ I18n.translations["eu"] = {
       "7": "Lr"
     },
     "formats": {
+      "long": "%Y(e)ko %Bk %d"
     },
     "month_names": [
       null,
@@ -25026,6 +25166,13 @@ I18n.translations["eu"] = {
   "this_taxon_concept_is_inactive": "espezie edo talde hau inaktibo dago",
   "this_taxon_has_no_default_photo": "Taxon honek ez du lehenetsitako argazkirik!",
   "threatened": "Mehatxatuta",
+  "time": {
+    "am": "goiza",
+    "formats": {
+      "long": "%Y(e)ko %Bk %d"
+    },
+    "pm": "arratsaldea"
+  },
   "to_add_comments": "aipamenak gehitzeko.",
   "to_suggest_an_identification": "Identifikazio bat gomendatu",
   "today": "Gaur",
@@ -25524,6 +25671,8 @@ I18n.translations["fi"] = {
       "7": "La"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%-d. %Bta %Y",
       "month_day_year": "%-d. %Bta %Y"
     },
     "month_names": [
@@ -26709,6 +26858,14 @@ I18n.translations["fi"] = {
   "this_taxon_has_no_default_photo": "Tällä taksonilla ei ole oletuskuvaa!",
   "this_year": "Tänä vuonna",
   "threatened": "Uhanalainen",
+  "time": {
+    "am": "ap.",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%-d. %Bta %Y %H:%M"
+    },
+    "pm": "ip."
+  },
   "to_add_comments": "lisätäksesi kommentteja",
   "today": "Tänään",
   "too_many_results": "Liian monta tulosta",
@@ -27176,6 +27333,10 @@ I18n.translations["fil"] = {
   },
   "taxon_map": {
   },
+  "time": {
+    "formats": {
+    }
+  },
   "uploader": {
     "errors": {
     },
@@ -27597,6 +27758,8 @@ I18n.translations["fr"] = {
       "7": "Sa"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%e %B %Y",
       "month_day_year": "%B %d, %Y"
     },
     "month_names": [
@@ -28733,6 +28896,13 @@ I18n.translations["fr"] = {
   "this_taxon_has_no_default_photo": "Ce taxon n’a pas de photo par défaut!",
   "this_year": "Cette année",
   "threatened": "Menacé",
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%A %d %B %Y %Hh%M"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "pour ajouter des commentaires",
   "to_suggest_an_identification": "pour suggérer une identification",
   "today": "Aujourd’hui",
@@ -29210,6 +29380,7 @@ I18n.translations["fr-CA"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%d %B %Y"
     },
     "month_names": [
       null,
@@ -29268,6 +29439,13 @@ I18n.translations["fr-CA"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%A %d %B %Y %H h %M"
+    },
+    "pm": "pm"
   },
   "uploader": {
     "errors": {
@@ -29416,6 +29594,10 @@ I18n.translations["gd"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "formats": {
+    }
   },
   "uploader": {
     "errors": {
@@ -29684,6 +29866,7 @@ I18n.translations["gl"] = {
       "7": "Sá"
     },
     "formats": {
+      "long": "%d de %B de %Y"
     },
     "month_names": [
       null,
@@ -30139,6 +30322,13 @@ I18n.translations["gl"] = {
   "this_taxon_concept_is_inactive": "esta especie ou grupo está inactiva",
   "this_taxon_has_no_default_photo": "Este taxón non ten foto por defecto!",
   "threatened": "Ameazado",
+  "time": {
+    "am": "Mañá",
+    "formats": {
+      "long": "%d de %B de %Y"
+    },
+    "pm": "Tarde"
+  },
   "to_add_comments": "para engadir comentarios.",
   "today": "Hoxe",
   "total_observations": "Total de observacións",
@@ -30529,6 +30719,7 @@ I18n.translations["he"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%e ב%B, %Y"
     },
     "month_names": [
       null,
@@ -31533,6 +31724,13 @@ I18n.translations["he"] = {
   "this_observation": "תצפית זו",
   "this_observation_was_created_using": "תצפית זו נוצרה באמצעות:",
   "this_year": "השנה",
+  "time": {
+    "am": "לפנה\"צ",
+    "formats": {
+      "long": "%d ב%B, %Y %H:%M"
+    },
+    "pm": "אחה\"צ"
+  },
   "to_add_comments": "להוספת הערות",
   "to_suggest_an_identification": "להצעת זיהוי",
   "today": "היום",
@@ -31948,6 +32146,7 @@ I18n.translations["id"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%A, %d %B %Y"
     },
     "month_names": [
       null,
@@ -32547,6 +32746,13 @@ I18n.translations["id"] = {
   "this_taxon_concept_is_inactive": "Konsep takson ini tidak aktif",
   "this_taxon_has_no_default_photo": "Takson ini tidak memiliki foto default!",
   "threatened": "terancam",
+  "time": {
+    "am": "pagi",
+    "formats": {
+      "long": "%d %B %Y %H.%M"
+    },
+    "pm": "malam"
+  },
   "to_add_comments": "untuk menambahkan komen",
   "today": "Hari ini",
   "total": "total:",
@@ -33029,6 +33235,8 @@ I18n.translations["it"] = {
       "7": "Sa"
     },
     "formats": {
+      "compact": "%e %b",
+      "long": "%d %B, %Y",
       "month_day_year": "%d %B, %Y"
     },
     "month_names": [
@@ -34305,6 +34513,14 @@ I18n.translations["it"] = {
   "this_taxon_has_no_default_photo": "Questo taxon non ha una foto predefinita!",
   "this_year": "Questo anno",
   "threatened": "Minacciata",
+  "time": {
+    "am": "am",
+    "formats": {
+      "hours": "%l:%M %p",
+      "long": "%d %B, %Y %I:%M %p"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "per aggiungere commenti",
   "to_suggest_an_identification": "per suggerire un'identificazione",
   "today": "Oggi",
@@ -34835,6 +35051,10 @@ I18n.translations["iw"] = {
   },
   "taxon_map": {
   },
+  "time": {
+    "formats": {
+    }
+  },
   "uploader": {
     "errors": {
     },
@@ -35173,6 +35393,7 @@ I18n.translations["ja"] = {
       "7": "土"
     },
     "formats": {
+      "long": "%Y年%B%d日",
       "month_day_year": "%Y年%B%d日"
     },
     "month_names": [
@@ -35859,6 +36080,13 @@ I18n.translations["ja"] = {
   "this_taxon_concept_is_inactive": "この分類群概念は廃止されました",
   "this_taxon_has_no_default_photo": "この分類群のデファルト写真がありません",
   "threatened": "絶滅危惧種",
+  "time": {
+    "am": "午前",
+    "formats": {
+      "long": "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+    },
+    "pm": "午後"
+  },
   "to_add_comments": "すれば、コメントを投稿することができます",
   "to_suggest_an_identification": "同定を提案",
   "today": "今日",
@@ -36149,6 +36377,10 @@ I18n.translations["ka"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "formats": {
+    }
   },
   "uploader": {
     "errors": {
@@ -36483,6 +36715,7 @@ I18n.translations["ko"] = {
       "7": "토"
     },
     "formats": {
+      "long": "%Y년 %m월 %d일 (%a)"
     },
     "month_names": [
       null,
@@ -37286,6 +37519,13 @@ I18n.translations["ko"] = {
   "this_observation_is_research_grade": "본 관찰은 연구 자료 등급 관찰입니다!",
   "this_observation_was_created_using": "이 관찰은 다음을 사용하여 만들어졌습니다:",
   "this_year": "올해",
+  "time": {
+    "am": "오전",
+    "formats": {
+      "long": "%Y년 %m월 %d일, %H시 %M분 %S초 %Z"
+    },
+    "pm": "오후"
+  },
   "too_many_results": "결과가 너무 많음",
   "total": "합계",
   "total_observations": "총 관찰",
@@ -37715,6 +37955,7 @@ I18n.translations["lb"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%e. %B %Y"
     },
     "month_names": [
       null,
@@ -38259,6 +38500,13 @@ I18n.translations["lb"] = {
   "this_is_your_observation_desc": "Dir kënnt ëmmer d'Koordinate vun Ären Observatioune gesinn.",
   "this_observation": "Dës Observatioun",
   "this_year": "Dëst Joer",
+  "time": {
+    "am": "moies",
+    "formats": {
+      "long": "%A, %d. %B %Y, %H:%M Auer"
+    },
+    "pm": "mëttes"
+  },
   "today": "Haut",
   "too_many_results": "Ze vill Resultater",
   "trends": "Tendenzen",
@@ -38687,6 +38935,7 @@ I18n.translations["lt"] = {
       "7": "Še"
     },
     "formats": {
+      "long": "%B %d, %Y"
     },
     "month_names": [
       null,
@@ -39309,6 +39558,13 @@ I18n.translations["lt"] = {
   "taxonomy": "Taksonomija",
   "these_observations_have_not_been_uploaded_yet": "Šie stebėjimai dar nebuvo įkelti\n",
   "this_year": "Šiais Metais",
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%B %d, %Y %H:%M"
+    },
+    "pm": "pm"
+  },
   "total_species_observed": "Iš viso rūšių stebėta",
   "type_species_name": "Įveskite rūšies pavadinimą",
   "umbrella_projects": "Skėtiniai projektai",
@@ -39616,6 +39872,7 @@ I18n.translations["mk"] = {
       "7": "са"
     },
     "formats": {
+      "long": "%j %B %Y",
       "month_day_year": "%j %B %Y"
     },
     "month_names": [
@@ -40045,6 +40302,13 @@ I18n.translations["mk"] = {
   "terms": "Услови",
   "terrain": "теренска",
   "threatened": "Загрозен",
+  "time": {
+    "am": "претпладне",
+    "formats": {
+      "long": "%j %B %Y %I:%M %p"
+    },
+    "pm": "попладне"
+  },
   "today": "Денес",
   "total": "вкупно",
   "total_observations": "Вкупно набљудувања",
@@ -40553,6 +40817,8 @@ I18n.translations["nb"] = {
       "7": "Lø"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%d. %B %Y",
       "month_day_year": "%d. %B %Y"
     },
     "month_names": [
@@ -41829,6 +42095,14 @@ I18n.translations["nb"] = {
   "this_taxon_has_no_default_photo": "Dette taksonet har ingen standardbilde!",
   "this_year": "Dette året",
   "threatened": "Truet",
+  "time": {
+    "am": "am",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%d. %B %Y %H:%M"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "for å legge til kommentarer",
   "to_suggest_an_identification": "for å foreslå en identifikasjon",
   "today": "I dag",
@@ -42681,6 +42955,8 @@ I18n.translations["nl"] = {
       "7": "za"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%d %B %Y",
       "month_day_year": "%d %B %Y"
     },
     "month_names": [
@@ -43957,6 +44233,14 @@ I18n.translations["nl"] = {
   "this_taxon_has_no_default_photo": "Dit taxon heeft geen standaardfoto!",
   "this_year": "Dit jaar",
   "threatened": "Bedreigd",
+  "time": {
+    "am": "am",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%d %B %Y %H:%M"
+    },
+    "pm": "pm"
+  },
   "to_add_comments": "om reacties toe te voegen",
   "to_suggest_an_identification": "om een determinatie voor te stellen",
   "today": "Vandaag",
@@ -44484,6 +44768,7 @@ I18n.translations["nn"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%e. %B %Y"
     },
     "month_names": [
       null,
@@ -44542,6 +44827,13 @@ I18n.translations["nn"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "am": "",
+    "formats": {
+      "long": "%A, %e. %B %Y, %H:%M"
+    },
+    "pm": ""
   },
   "uploader": {
     "errors": {
@@ -45208,6 +45500,10 @@ I18n.translations["oc"] = {
   "taxon_map": {
   },
   "terms": "Condicions",
+  "time": {
+    "formats": {
+    }
+  },
   "today": "Uèi",
   "total": "total",
   "unreview_all": "Marcar tot coma pas relegit",
@@ -45705,6 +46001,7 @@ I18n.translations["pl"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%B %d, %Y"
     },
     "month_names": [
       null,
@@ -46740,6 +47037,13 @@ I18n.translations["pl"] = {
   "this_observation_was_created_using": "Ta obserwacja została wykonana przy użyciu:",
   "this_taxon_has_no_default_photo": "Ten takson nie ma domyślnego zdjęcia!",
   "threatened": "Zagrożony",
+  "time": {
+    "am": "przed południem",
+    "formats": {
+      "long": "%B %d, %Y %H:%M"
+    },
+    "pm": "po południu"
+  },
   "to_add_comments": "aby dodać komentarze",
   "to_suggest_an_identification": "aby zasugerować oznaczenie",
   "today": "Dzisiaj",
@@ -47370,6 +47674,7 @@ I18n.translations["pt"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%d de %B de %Y",
       "month_day_year": "%d de %B de %Y"
     },
     "month_names": [
@@ -48253,6 +48558,13 @@ I18n.translations["pt"] = {
   "this_taxon_has_no_default_photo": "Este táxon não tem foto predefinidaǃ",
   "this_year": "Este Ano",
   "threatened": "ameaçado",
+  "time": {
+    "am": "am",
+    "formats": {
+      "long": "%d de %B de %Y, %I:%M %p"
+    },
+    "pm": "pm"
+  },
   "today": "Hoje",
   "top_identifier": "Principal Identificador",
   "top_identifiers": "Principais Identificadores",
@@ -48779,6 +49091,7 @@ I18n.translations["pt-BR"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%d de %B de %Y"
     },
     "month_names": [
       null,
@@ -49864,6 +50177,13 @@ I18n.translations["pt-BR"] = {
   "this_taxon_has_no_default_photo": "Este táxon não tem foto padrão!",
   "this_year": "Este Ano",
   "threatened": "Ameaçado",
+  "time": {
+    "am": "manhã",
+    "formats": {
+      "long": "%d de %B de %Y, %H:%M"
+    },
+    "pm": "tarde"
+  },
   "to_add_comments": "para adicionar comentários",
   "to_suggest_an_identification": "para sugerir uma identificação",
   "today": "Hoje",
@@ -50685,6 +51005,8 @@ I18n.translations["ru"] = {
       "7": "Сб"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%B %d, %Y",
       "month_day_year": "%B %d, %Y"
     },
     "month_names": [
@@ -51985,6 +52307,14 @@ I18n.translations["ru"] = {
   "this_taxon_has_no_default_photo": "У этого таксона нет фото по умолчанию!",
   "this_year": "В этом году",
   "threatened": "Под угрозой исчезновения",
+  "time": {
+    "am": "утра",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%d %B %Y %I%M%p"
+    },
+    "pm": "вечера"
+  },
   "to_add_comments": "чтобы добавить комментарии",
   "to_suggest_an_identification": "предлагать идентификацию",
   "today": "Сегодня",
@@ -52804,6 +53134,7 @@ I18n.translations["sk"] = {
       "7": "So"
     },
     "formats": {
+      "long": "%M %d, %R",
       "month_day_year": "%M %d, %R"
     },
     "month_names": [
@@ -53843,6 +54174,13 @@ I18n.translations["sk"] = {
   "this_observation_was_created_using": "Toto pozorovanie bolo vytvorené pomocou:",
   "this_taxon_has_no_default_photo": "Tento taxón nemá žiadnu základnú fotku!",
   "threatened": "Ohrozený",
+  "time": {
+    "am": "dopoludnia",
+    "formats": {
+      "long": "%A %d. %B %Y %H:%M"
+    },
+    "pm": "popoludní"
+  },
   "to_add_comments": "pridať komentáre",
   "to_suggest_an_identification": "k navrhnutiu identifikácie",
   "today": "Dnes",
@@ -54303,6 +54641,7 @@ I18n.translations["sq"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%B %d, %Y"
     },
     "month_names": [
       null,
@@ -55106,6 +55445,13 @@ I18n.translations["sq"] = {
   },
   "taxon_split": "ndarje e taxon",
   "the_world": "Bota",
+  "time": {
+    "am": "pd",
+    "formats": {
+      "long": "%B %d, %Y %I:%M %p"
+    },
+    "pm": "md"
+  },
   "top_species": "Specjet Kryesore",
   "total_species_observed": "Numri total i specjeve të vëzhguara",
   "type_species_name": "Shkruaj emrin e specjeve",
@@ -55496,6 +55842,7 @@ I18n.translations["sv"] = {
       "7": "Lö"
     },
     "formats": {
+      "long": "%-d %B %Y",
       "month_day_year": "%-d %B %Y"
     },
     "month_names": [
@@ -56032,6 +56379,14 @@ I18n.translations["sv"] = {
   "these_observations_have_not_been_uploaded_yet": "Dessa observationer har ännu inte laddats upp.\n",
   "this_observation": "Denna observation",
   "this_year": "Detta år",
+  "time": {
+    "am": "",
+    "formats": {
+      "hours": "%H:%M",
+      "long": "%-d %B %Y %H:%M"
+    },
+    "pm": ""
+  },
   "to_suggest_an_identification": "för att föreslå en identifiering",
   "today": "Idag",
   "too_many_results": "För många resultat",
@@ -56633,6 +56988,8 @@ I18n.translations["tr"] = {
       "7": "Cmt"
     },
     "formats": {
+      "compact": "%b %e",
+      "long": "%d %B, %Y",
       "month_day_year": "%d %B, %Y"
     },
     "month_names": [
@@ -57909,6 +58266,14 @@ I18n.translations["tr"] = {
   "this_taxon_has_no_default_photo": "Bu sınıflandırmanın varsayılan fotoğrafı yok!",
   "this_year": "Bu Yıl",
   "threatened": "Tehdit Altında",
+  "time": {
+    "am": "öö",
+    "formats": {
+      "hours": "%l:%M %p",
+      "long": "%d %B, %Y %I:%M %p"
+    },
+    "pm": "ös"
+  },
   "to_add_comments": "yorum eklemek",
   "to_suggest_an_identification": "bir kimlik önerme",
   "today": "Bugün",
@@ -58439,6 +58804,7 @@ I18n.translations["uk"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%d %B %Y"
     },
     "month_names": [
       null,
@@ -58499,6 +58865,13 @@ I18n.translations["uk"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "am": "до полудня",
+    "formats": {
+      "long": "%d %B %Y, %H:%M"
+    },
+    "pm": "по полудні"
   },
   "uploader": {
     "errors": {
@@ -58893,6 +59266,7 @@ I18n.translations["zh-CN"] = {
       "7": "六"
     },
     "formats": {
+      "long": "%Y年%B%d日",
       "month_day_year": "%B%d日%Y年"
     },
     "month_names": [
@@ -59833,6 +60207,14 @@ I18n.translations["zh-CN"] = {
   "this_taxon_has_no_default_photo": "此分类单元没有默认照片！",
   "this_year": "今年",
   "threatened": "受到威胁",
+  "time": {
+    "am": "上午",
+    "formats": {
+      "hours": "%I:%M %p",
+      "long": "%Y年%d%B日 %I:%M %p"
+    },
+    "pm": "下午"
+  },
   "to_add_comments": "要添加评论",
   "to_suggest_an_identification": "要建议一次鉴定",
   "today": "今天",
@@ -60232,6 +60614,7 @@ I18n.translations["zh-HK"] = {
       "7": "Sa"
     },
     "formats": {
+      "long": "%Y年%b%d日"
     },
     "month_names": [
       null,
@@ -60290,6 +60673,13 @@ I18n.translations["zh-HK"] = {
   "sounds": {
   },
   "taxon_map": {
+  },
+  "time": {
+    "am": "上午",
+    "formats": {
+      "long": "%Y年%b%d日 %H:%M"
+    },
+    "pm": "下午"
   },
   "uploader": {
     "errors": {
@@ -60707,6 +61097,7 @@ I18n.translations["zh-TW"] = {
       "7": "六"
     },
     "formats": {
+      "long": "%Y年%b%d日"
     },
     "month_names": [
       null,
@@ -61928,6 +62319,13 @@ I18n.translations["zh-TW"] = {
   "this_taxon_has_no_default_photo": "此物種分類沒有預設照片！",
   "this_year": "今年",
   "threatened": "受威脅",
+  "time": {
+    "am": "上午",
+    "formats": {
+      "long": "%Y年%b%d日 %H:%M"
+    },
+    "pm": "下午"
+  },
   "to_add_comments": "添加評論",
   "to_suggest_an_identification": "提議一個鑑定",
   "today": "今日",

--- a/app/assets/stylesheets/stats/year.scss
+++ b/app/assets/stylesheets/stats/year.scss
@@ -776,12 +776,15 @@ $obs-grid-photo-size: 210px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    margin-right: 5px;
+    margin-right: 15px;
     .UserImage {
       margin-right: 10px;
       border: 0 transparent;
-      width: 30px;
-      height: 30px;
+      width: $streak-height;
+      height: $streak-height;
+    }
+    .userlink {
+      line-height: $streak-height;
     }
   }
   .background {
@@ -802,7 +805,7 @@ $obs-grid-photo-size: 210px;
       text-align: center;
       padding: 10px 0;
     }
-    @media (max-width: 992px) {
+    @media (max-width: 500px) {
       .tick {
         font-size: 8px;
       }
@@ -810,17 +813,30 @@ $obs-grid-photo-size: 210px;
   }
   .datum {
     position: relative;
-    display: block;
     background-color: $inat-green;
     display: flex;
     align-items: center;
     height: 100%;
-    overflow: hidden;
     white-space: nowrap;
-    text-overflow: ellipsis;
-    .days {
-      padding: 0px 10px;
-      font-size: 10px;
+    justify-content: space-between;
+    padding: 0px 10px;
+    font-size: 10px;
+    @media (max-width: 500px) {
+      .start,
+      .stop {
+        display: none;
+      }
+    }
+
+    .triangle {
+      position: absolute;
+      left: -1 * ($streak-height / 2 - 5);
+      top: 0;
+      width: 0;
+      height: 0;
+      border-top: $streak-height / 2 solid transparent;
+      border-bottom: $streak-height / 2 solid transparent;
+      border-right: ($streak-height / 2) - 5 solid blue;
     }
   }
 }

--- a/app/assets/stylesheets/stats/year.scss
+++ b/app/assets/stylesheets/stats/year.scss
@@ -758,3 +758,68 @@ $obs-grid-photo-size: 210px;
     }
   }
 }
+
+.Streaks {
+  $streak-height: 30px;
+  .streak {
+    display: flex;
+    width: "100%";
+    margin-bottom: 5px;
+    min-height: $streak-height;
+  }
+  a,
+  a:hover {
+    color: white;
+  }
+  .user {
+    width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    .UserImage {
+      margin-right: 10px;
+      border: 0 transparent;
+      width: 30px;
+      height: 30px;
+    }
+  }
+  .background {
+    width: 100%;
+    position: relative;
+    display: flex;
+  }
+  .ticks {
+    .background {
+      height: 35px;
+    }
+    .tick {
+      position: absolute;
+      display: block;
+      &.alt {
+        background-color: $dark-gray;
+      }
+      text-align: center;
+      padding: 10px 0;
+    }
+    @media (max-width: 992px) {
+      .tick {
+        font-size: 8px;
+      }
+    }
+  }
+  .datum {
+    position: relative;
+    display: block;
+    background-color: $inat-green;
+    display: flex;
+    align-items: center;
+    height: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    .days {
+      padding: 0px 10px;
+      font-size: 10px;
+    }
+  }
+}

--- a/app/assets/stylesheets/stats/year.scss
+++ b/app/assets/stylesheets/stats/year.scss
@@ -776,6 +776,7 @@ $obs-grid-photo-size: 210px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    margin-right: 5px;
     .UserImage {
       margin-right: 10px;
       border: 0 transparent;

--- a/app/models/year_statistic.rb
+++ b/app/models/year_statistic.rb
@@ -93,8 +93,7 @@ class YearStatistic < ActiveRecord::Base
         week_histogram: observations_histogram( year, user: user, interval: "week" ),
         day_histogram: observations_histogram( year, user: user, interval: "day" ),
         day_last_year_histogram: observations_histogram( year - 1, user: user, interval: "day" ),
-        popular: popular_observations( year, user: user ),
-        streaks: streaks( year, user: user )
+        popular: popular_observations( year, user: user )
       },
       identifications: {
         category_counts: identification_counts_by_category( year, user: user ), 

--- a/app/views/stats/year.html.haml
+++ b/app/views/stats/year.html.haml
@@ -10,7 +10,7 @@
 - content_for :extrajs do
   :javascript
     var ROOT_TAXON_ID = #{ Taxon::LIFE.id };
-    var YEAR_DATA = #{ @year_statistic.try(:data).to_json.html_safe };
+    var YEAR_DATA = #{ File.open( "/Users/kueda/Downloads/yir-2019-total-streaks.json" ).read.html_safe};
     var YEAR = #{ @year };
     var DISPLAY_USER = #{ @display_user ? 
       @display_user.as_indexed_json.merge( icon_url: @display_user.medium_user_icon_url ).to_json.html_safe

--- a/app/views/stats/year.html.haml
+++ b/app/views/stats/year.html.haml
@@ -10,7 +10,7 @@
 - content_for :extrajs do
   :javascript
     var ROOT_TAXON_ID = #{ Taxon::LIFE.id };
-    var YEAR_DATA = #{ File.open( "/Users/kueda/Downloads/yir-2019-total-streaks.json" ).read.html_safe};
+    var YEAR_DATA = #{ @year_statistic.try(:data).to_json.html_safe };
     var YEAR = #{ @year };
     var DISPLAY_USER = #{ @display_user ? 
       @display_user.as_indexed_json.merge( icon_url: @display_user.medium_user_icon_url ).to_json.html_safe

--- a/app/webpack/stats/year/components/app.jsx
+++ b/app/webpack/stats/year/components/app.jsx
@@ -25,7 +25,9 @@ const App = ( {
   if ( !year ) {
     body = (
       <p className="alert alert-warning">
-        Not a valid year. Please choose a year between 1950 and { new Date().getYear() }.
+        Not a valid year. Please choose a year between 1950 and
+        { new Date().getYear() }
+        .
       </p>
     );
   } else if ( !data || !currentUser ) {

--- a/app/webpack/stats/year/components/observations.jsx
+++ b/app/webpack/stats/year/components/observations.jsx
@@ -165,11 +165,10 @@ const Observations = ( {
       }
       <h3><span>{ I18n.t( "most_comments_and_faves" ) }</span></h3>
       { popular }
-      { data.streaks && (
+      { data.streaks && data.streaks.length > 0 && (
         <Streaks
           year={year}
           data={data.streaks.slice( 0, 20 )}
-          hideUsers={!!user}
         />
       ) }
     </div>

--- a/app/webpack/stats/year/components/observations.jsx
+++ b/app/webpack/stats/year/components/observations.jsx
@@ -6,6 +6,7 @@ import DateHistogram from "./date_histogram";
 import TorqueMap from "../../../shared/components/torque_map";
 import GlobalMap from "./global_map";
 import ObservationsGrid from "./observations_grid";
+import Streaks from "./streaks";
 
 const Observations = ( {
   data,
@@ -164,6 +165,13 @@ const Observations = ( {
       }
       <h3><span>{ I18n.t( "most_comments_and_faves" ) }</span></h3>
       { popular }
+      { data.streaks && (
+        <Streaks
+          year={year}
+          data={data.streaks.slice( 0, 20 )}
+          hideUsers={!!user}
+        />
+      ) }
     </div>
   );
 };

--- a/app/webpack/stats/year/components/streaks.jsx
+++ b/app/webpack/stats/year/components/streaks.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { scaleTime } from "d3";
+import moment from "moment";
+import UserImage from "../../../shared/components/user_image";
+import UserLink from "../../../shared/components/user_link";
+
+const Streaks = ( {
+  data,
+  year,
+  hideUsers
+} ) => {
+  const scale = scaleTime( )
+    .domain( [new Date( `${year}-01-01` ), new Date( `${year}-12-31` )] )
+    .range( [0, 1.0] );
+  const ticks = scale.ticks();
+  const tickWidth = scale( ticks[1] ) - scale( ticks[0] );
+  return (
+    <div className="Streaks">
+      <h3><span>{ I18n.t( "views.stats.year.streaks" ) }</span></h3>
+      <div className="rows">
+        <div
+          className="ticks streak"
+          key="streaks-ticks"
+        >
+          { !hideUsers && <div className="user" /> }
+          <div className="background">
+            { scale.ticks( ).map( ( tick, i ) => (
+              <div
+                className={`tick ${i % 2 === 0 ? "alt" : ""}`}
+                key={`streaks-ticks-${tick}`}
+                style={{
+                  left: `${scale( new Date( tick ) ) * 100}%`,
+                  height: 35 * data.length + 35,
+                  width: `${tickWidth * 100}%`
+                }}
+              >
+                { moment( tick ).format( "MMM" ) }
+              </div>
+            ) ) }
+          </div>
+        </div>
+        { data.map( streak => {
+          const x1 = scale( new Date( streak.start ) );
+          const x2 = scale( new Date( streak.stop ) );
+          const width = x2 - x1;
+          const user = {
+            login: streak.login,
+            id: streak.user_id,
+            icon_url: streak.icon_url
+          };
+          const xDays = I18n.t( "datetime.distance_in_words.x_days", { count: I18n.toNumber( streak.days, { precision: 0 } ) } );
+          const d1 = moment( streak.start ).format( "ll" );
+          const d2 = moment( streak.stop ).format( "ll" );
+          return (
+            <div
+              key={`streaks-${streak.login}-${streak.start}`}
+              className="streak"
+            >
+              { !hideUsers && (
+                <div className="user">
+                  <UserImage user={user} />
+                  <UserLink user={user} />
+                </div>
+              ) }
+              <div className="background">
+                <a
+                  className="datum"
+                  href={`/observations?user_id=${streak.login}&d1=${streak.start}&d2=${streak.stop}`}
+                  style={{
+                    left: `${x1 * 100}%`,
+                    width: `${width * 100}%`
+                  }}
+                  title={`${I18n.t( "date_to_date", { d1, d2 } )} • ${xDays}`}
+                >
+                  <span className="days">
+                    { xDays }
+                  </span>
+                </a>
+              </div>
+            </div>
+          );
+        } ) }
+      </div>
+    </div>
+  );
+};
+
+Streaks.propTypes = {
+  // site: PropTypes.object,
+  // user: PropTypes.object,
+  year: PropTypes.number.isRequired,
+  data: PropTypes.array.isRequired,
+  hideUsers: PropTypes.boolean
+};
+
+export default Streaks;

--- a/app/webpack/stats/year/components/streaks.jsx
+++ b/app/webpack/stats/year/components/streaks.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import * as d3 from "d3";
 import moment from "moment";
+import _ from "lodash";
 import UserImage from "../../../shared/components/user_image";
 import UserLink from "../../../shared/components/user_link";
 
@@ -14,14 +15,28 @@ const Streaks = ( {
     .domain( [new Date( `${year}-01-01` ), new Date( `${year}-12-31` )] )
     .range( [0, 1.0] );
   const ticks = scale.ticks();
-  const tickWidth = Math.min( 1, scale( ticks[1] ) - scale( ticks[0] ) );
   const days = data.map( d => d.days );
-  const dayScale = d3.scaleLinear( )
+  const dayScale = d3.scaleLog( )
     .domain( [d3.min( days ), d3.max( days )] )
     .range( [0, 0.8] );
+  const d3Locale = d3.timeFormatLocale( {
+    datetime: I18n.t( "time.formats.long" ),
+    date: I18n.t( "date.formats.long" ),
+    time: I18n.t( "time.formats.hours" ),
+    periods: [I18n.t( "time.am" ), I18n.t( "time.pm" )],
+    days: I18n.t( "date.day_names" ),
+    shortDays: I18n.t( "date.abbr_day_names" ),
+    months: _.compact( I18n.t( "date.month_names" ) ),
+    shortMonths: _.compact( I18n.t( "date.abbr_month_names" ) )
+  } );
+  const shortDate = d3Locale.format( I18n.t( "date.formats.compact" ) );
   return (
     <div className="Streaks">
-      <h3><span>{ I18n.t( "views.stats.year.observation_streaks" ) }</span></h3>
+      <h3>
+        <a name="streaks" href="#streaks">
+          <span>{ I18n.t( "views.stats.year.observation_streaks" ) }</span>
+        </a>
+      </h3>
       <p className="text-muted">
         { I18n.t( "views.stats.year.observation_streaks_desc" ) }
       </p>
@@ -32,23 +47,32 @@ const Streaks = ( {
         >
           { !hideUsers && <div className="user" /> }
           <div className="background">
-            { scale.ticks( ).map( ( tick, i ) => (
-              <div
-                className={`tick ${i % 2 === 0 ? "alt" : ""}`}
-                key={`streaks-ticks-${tick}`}
-                style={{
-                  left: `${Math.round( Math.max( 0, scale( new Date( tick ) ) * 100 ) )}%`,
-                  height: 35 * data.length + 35,
-                  width: `${tickWidth * 100}%`
-                }}
-              >
-                { moment( tick ).format( "MMM" ) }
-              </div>
-            ) ) }
+            { ticks.map( ( tick, i ) => {
+              const tickDate = new Date( tick );
+              const left = i === 0
+                ? 0
+                : Math.max( 0, scale( tickDate ) );
+              const tickWidth = i === ticks.length - 1
+                ? 1 - scale( tickDate )
+                : scale( ticks[i + 1] ) - scale( tickDate );
+              return (
+                <div
+                  className={`tick ${i % 2 === 0 ? "alt" : ""}`}
+                  key={`streaks-ticks-${tick}`}
+                  style={{
+                    left: `${left * 100}%`,
+                    height: 35.6 * data.length + 35.6,
+                    width: `${tickWidth * 100}%`
+                  }}
+                >
+                  { moment( tick ).format( "MMM" ) }
+                </div>
+              );
+            } ) }
           </div>
         </div>
         { data.map( streak => {
-          const x1 = scale( new Date( streak.start ) );
+          const x1 = Math.max( 0, scale( new Date( streak.start ) ) );
           const x2 = scale( new Date( streak.stop ) );
           const width = Math.min( 1, x2 - x1 );
           const user = {
@@ -57,8 +81,11 @@ const Streaks = ( {
             icon_url: streak.icon_url
           };
           const xDays = I18n.t( "datetime.distance_in_words.x_days", { count: I18n.toNumber( streak.days, { precision: 0 } ) } );
-          const d1 = moment( streak.start ).format( "ll" );
-          const d2 = moment( streak.stop ).format( "ll" );
+          const streakStartedBeforeYear = moment( streak.start ) < moment( `${year}-01-01` );
+          const d1 = streakStartedBeforeYear
+            ? moment( streak.start ).format( "ll" )
+            : shortDate( moment( streak.start ) );
+          const d2 = shortDate( moment( streak.stop ) );
           return (
             <div
               key={`streaks-${streak.login}-${streak.start}`}
@@ -81,9 +108,15 @@ const Streaks = ( {
                   }}
                   title={`${I18n.t( "date_to_date", { d1, d2 } )} • ${xDays}`}
                 >
-                  <span className="days">
-                    { xDays }
-                  </span>
+                  { streakStartedBeforeYear && (
+                    <span
+                      className="triangle"
+                      style={{ borderRightColor: d3.interpolateWarm( dayScale( streak.days ) ) }}
+                    />
+                  ) }
+                  { width > 0.25 && <span className="start">{ d1 }</span> }
+                  { width > 0.05 && <span className="days">{ xDays }</span> }
+                  { width > 0.25 && <span className="stop">{ d2 }</span> }
                 </a>
               </div>
             </div>

--- a/app/webpack/stats/year/components/streaks.jsx
+++ b/app/webpack/stats/year/components/streaks.jsx
@@ -66,7 +66,7 @@ const Streaks = ( {
               <div className="background">
                 <a
                   className="datum"
-                  href={`/observations?user_id=${streak.login}&d1=${streak.start}&d2=${streak.stop}`}
+                  href={`/observations?user_id=${streak.login}&d1=${streak.start}&d2=${streak.stop}&place_id=any&verifiable=true`}
                   style={{
                     left: `${x1 * 100}%`,
                     width: `${width * 100}%`

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6035,8 +6035,10 @@ en:
         # Periods where someone consistently made observations, e.g. "a 10-day streak"
         observation_streaks: Observation Streaks
         observation_streaks_desc: |
-          An observation streak is a period where someone has made observations
-          for at least 5 days running.
+          An observation streak is a period of time when someone got outside and
+          recorded new observations every single day. Here we're showing the
+          longest streaks that began this year or were in progress when these
+          stats were generated.
         sunburst_desc_html: |
           Observed taxa arranged as a hierarchical "sunburst" diagram. The base
           of the hierarchy is at the center, starting with "Life" and ending

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6033,7 +6033,10 @@ en:
           <br/>
           <a href="%{url}">View all %{numStudies} studies</a>
         # Periods where someone consistently made observations, e.g. "a 10-day streak"
-        streaks: Streaks
+        observation_streaks: Observation Streaks
+        observation_streaks_desc: |
+          An observation streak is a period where someone has made observations
+          for at least 5 days running.
         sunburst_desc_html: |
           Observed taxa arranged as a hierarchical "sunburst" diagram. The base
           of the hierarchy is at the center, starting with "Life" and ending

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6032,6 +6032,8 @@ en:
           <a href="https://www.gbif.org/">Global Biodiversity Information Faciltity</a>.
           <br/>
           <a href="%{url}">View all %{numStudies} studies</a>
+        # Periods where someone consistently made observations, e.g. "a 10-day streak"
+        streaks: Streaks
         sunburst_desc_html: |
           Observed taxa arranged as a hierarchical "sunburst" diagram. The base
           of the hierarchy is at the center, starting with "Life" and ending


### PR DESCRIPTION
Adds an observation streaks chart to Year In Review for sites (wasn't that interesting for most individual users). Also fixes a bug with JS pluralization breaking on delimited but not separated numbers like "2,354"