### PR TITLE
Some attempts to cut down on the number of requests made in Identify

### DIFF
--- a/app/webpack/observations/identify/actions/identifiers_actions.js
+++ b/app/webpack/observations/identify/actions/identifiers_actions.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import inatjs from "inaturalistjs";
 import { paramsForSearch } from "../reducers/search_params_reducer";
 
@@ -22,6 +23,14 @@ function updateIdentifiers( updates ) {
 function fetchIdentifiers( ) {
   return function ( dispatch, getState ) {
     const s = getState();
+    const currentUserInIdentifiers = _.find(
+      s.identifiers.users, u => u.user_id === s.config.currentUser.id
+    );
+    if ( s.identifiers.users.length > 0 && !currentUserInIdentifiers ) {
+      // If the current user isn't in the list of identifiers, there's no reason
+      // to update that list with every new identification
+      return Promise.resolve( );
+    }
     const apiParams = Object.assign( { }, paramsForSearch( s.searchParams.params ), {
       reviewed: "any",
       quality_grade: "any",

--- a/app/webpack/observations/identify/containers/follow_button_container.js
+++ b/app/webpack/observations/identify/containers/follow_button_container.js
@@ -1,20 +1,23 @@
 import { connect } from "react-redux";
 import FollowButton from "../../show/components/follow_button";
 import { followUser, unfollowUser, subscribe } from "../actions";
+import { fetchSubscriptions } from "../../show/ducks/subscriptions";
 
 function mapStateToProps( state ) {
   return {
     config: state.config,
     observation: state.currentObservation.observation,
-    subscriptions: state.subscriptions
+    subscriptions: state.subscriptions.subscriptions,
+    subscriptionsLoaded: state.subscriptions.loaded
   };
 }
 
 function mapDispatchToProps( dispatch ) {
   return {
-    followUser: ( ) => { dispatch( followUser( ) ); },
-    unfollowUser: ( ) => { dispatch( unfollowUser( ) ); },
-    subscribe: ( ) => { dispatch( subscribe( ) ); }
+    followUser: ( ) => dispatch( followUser( ) ),
+    unfollowUser: ( ) => dispatch( unfollowUser( ) ),
+    subscribe: ( ) => dispatch( subscribe( ) ),
+    fetchSubscriptions: options => dispatch( fetchSubscriptions( options ) )
   };
 }
 

--- a/app/webpack/observations/identify/reducers/observations_reducer.js
+++ b/app/webpack/observations/identify/reducers/observations_reducer.js
@@ -3,12 +3,14 @@ import {
   RECEIVE_OBSERVATIONS,
   UPDATE_OBSERVATION_IN_COLLECTION,
   UPDATE_ALL_LOCAL,
-  SET_REVIEWING
+  SET_REVIEWING,
+  SET_PLACES_BY_ID
 } from "../actions";
 
 const observationsReducer = ( state = {
   results: [],
-  reviewing: false
+  reviewing: false,
+  placesByID: {}
 }, action ) => {
   if ( action.type === RECEIVE_OBSERVATIONS ) {
     return Object.assign( {}, state, {
@@ -48,6 +50,12 @@ const observationsReducer = ( state = {
   if ( action.type === SET_REVIEWING ) {
     const newState = Object.assign( {}, state, {
       reviewing: action.reviewing
+    } );
+    return newState;
+  }
+  if ( action.type === SET_PLACES_BY_ID ) {
+    const newState = Object.assign( {}, state, {
+      placesByID: Object.assign( state.placesByID, action.placesByID )
     } );
     return newState;
   }

--- a/app/webpack/observations/show/containers/follow_button_container.js
+++ b/app/webpack/observations/show/containers/follow_button_container.js
@@ -1,20 +1,23 @@
 import { connect } from "react-redux";
 import FollowButton from "../components/follow_button";
 import { followUser, unfollowUser, subscribe } from "../ducks/observation";
+import { fetchSubscriptions } from "../ducks/subscriptions";
 
 function mapStateToProps( state ) {
   return {
     config: state.config,
     observation: state.observation,
-    subscriptions: state.subscriptions
+    subscriptions: state.subscriptions.subscriptions,
+    subscriptionsLoaded: state.subscriptions.loaded
   };
 }
 
 function mapDispatchToProps( dispatch ) {
   return {
-    followUser: ( ) => { dispatch( followUser( ) ); },
-    unfollowUser: ( ) => { dispatch( unfollowUser( ) ); },
-    subscribe: ( ) => { dispatch( subscribe( ) ); }
+    followUser: ( ) => dispatch( followUser( ) ),
+    unfollowUser: ( ) => dispatch( unfollowUser( ) ),
+    subscribe: ( ) => dispatch( subscribe( ) ),
+    fetchSubscriptions: options => dispatch( fetchSubscriptions( options ) )
   };
 }
 

--- a/app/webpack/observations/show/ducks/subscriptions.js
+++ b/app/webpack/observations/show/ducks/subscriptions.js
@@ -1,12 +1,23 @@
 import inatjs from "inaturalistjs";
 
 const SET_SUBSCRIPTIONS = "obs-show/subscriptions/SET_SUBSCRIPTIONS";
+const RESET_SUBSCRIPTIONS = "obs-show/subscriptions/RESET_SUBSCRIPTIONS";
 
-export default function reducer( state = [], action ) {
+export default function reducer( state = {
+  subscriptions: [],
+  loaded: false
+}, action ) {
   switch ( action.type ) {
     case SET_SUBSCRIPTIONS:
-      return action.subscriptions;
+      state.subscriptions = action.subscriptions;
+      state.loaded = true;
+      break;
+    case RESET_SUBSCRIPTIONS:
+      state.subscriptions = [];
+      state.loaded = false;
+      break;
     default:
+      // Do nothing
   }
   return state;
 }
@@ -16,6 +27,10 @@ export function setSubscriptions( subscriptions ) {
     type: SET_SUBSCRIPTIONS,
     subscriptions
   };
+}
+
+export function resetSubscriptions( ) {
+  return { type: RESET_SUBSCRIPTIONS };
 }
 
 export function fetchSubscriptions( options = {} ) {

--- a/app/webpack/shared/components/observations_grid_item.jsx
+++ b/app/webpack/shared/components/observations_grid_item.jsx
@@ -24,7 +24,7 @@ const ObservationsGridItem = ( {
       <a
         href={`/observations/${o.id}`}
         style={{
-          backgroundImage: o.photo( ) ? `url( '${o.photo( "medium" )}' )` : ""
+          backgroundImage: o.photo( ) ? `url( '${o.photo( "small" )}' )` : ""
         }}
         target={linkTarget}
         className={`photo ${o.hasMedia( ) ? "" : "iconic"} ${o.hasSounds( ) ? "sound" : ""}`}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -9,18 +9,18 @@ const config = {
   entry: {
     // list out the various bundles we need to make for different apps
     "observations-identify": "./observations/identify/webpack-entry",
-    // "observations-uploader": "./observations/uploader/webpack-entry",
-    // "project-slideshow": "./project_slideshow/webpack-entry",
-    // "taxa-show": "./taxa/show/webpack-entry",
-    // "taxa-photos": "./taxa/photos/webpack-entry",
+    "observations-uploader": "./observations/uploader/webpack-entry",
+    "project-slideshow": "./project_slideshow/webpack-entry",
+    "taxa-show": "./taxa/show/webpack-entry",
+    "taxa-photos": "./taxa/photos/webpack-entry",
     "observations-show": "./observations/show/webpack-entry",
-    // "observations-torque": "./observations/torque/webpack-entry",
-    // "computer-vision": "./computer_vision/webpack-entry",
-    // "search-slideshow": "./search_slideshow/webpack-entry",
-    // "stats-year": "./stats/year/webpack-entry",
-    // "projects-form": "./projects/form/webpack-entry",
-    // "projects-show": "./projects/show/webpack-entry",
-    // "observations-compare": "./observations/compare/webpack-entry"
+    "observations-torque": "./observations/torque/webpack-entry",
+    "computer-vision": "./computer_vision/webpack-entry",
+    "search-slideshow": "./search_slideshow/webpack-entry",
+    "stats-year": "./stats/year/webpack-entry",
+    "projects-form": "./projects/form/webpack-entry",
+    "projects-show": "./projects/show/webpack-entry",
+    "observations-compare": "./observations/compare/webpack-entry"
   },
   output: {
     // each bundle will be stored in app/assets/javascripts/[name].output.js

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -9,18 +9,18 @@ const config = {
   entry: {
     // list out the various bundles we need to make for different apps
     "observations-identify": "./observations/identify/webpack-entry",
-    "observations-uploader": "./observations/uploader/webpack-entry",
-    "project-slideshow": "./project_slideshow/webpack-entry",
-    "taxa-show": "./taxa/show/webpack-entry",
-    "taxa-photos": "./taxa/photos/webpack-entry",
+    // "observations-uploader": "./observations/uploader/webpack-entry",
+    // "project-slideshow": "./project_slideshow/webpack-entry",
+    // "taxa-show": "./taxa/show/webpack-entry",
+    // "taxa-photos": "./taxa/photos/webpack-entry",
     "observations-show": "./observations/show/webpack-entry",
-    "observations-torque": "./observations/torque/webpack-entry",
-    "computer-vision": "./computer_vision/webpack-entry",
-    "search-slideshow": "./search_slideshow/webpack-entry",
-    "stats-year": "./stats/year/webpack-entry",
-    "projects-form": "./projects/form/webpack-entry",
-    "projects-show": "./projects/show/webpack-entry",
-    "observations-compare": "./observations/compare/webpack-entry"
+    // "observations-torque": "./observations/torque/webpack-entry",
+    // "computer-vision": "./computer_vision/webpack-entry",
+    // "search-slideshow": "./search_slideshow/webpack-entry",
+    // "stats-year": "./stats/year/webpack-entry",
+    // "projects-form": "./projects/form/webpack-entry",
+    // "projects-show": "./projects/show/webpack-entry",
+    // "observations-compare": "./observations/compare/webpack-entry"
   },
   output: {
     // each bundle will be stored in app/assets/javascripts/[name].output.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,7 +1482,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1776,7 +1776,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1940,6 +1940,20 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -2323,10 +2337,13 @@
       }
     },
     "console-browserify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2395,7 +2412,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2408,7 +2425,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2822,6 +2839,12 @@
       "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
       "dev": true
     },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2979,7 +3002,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3228,18 +3251,6 @@
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-          "dev": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
-        }
       }
     },
     "entities": {
@@ -7931,7 +7942,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -8264,14 +8275,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {
@@ -8435,6 +8438,20 @@
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow=="
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "requires": {
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "locate-path": {


### PR DESCRIPTION
* try to only fetch subscriptions when you follow/unfollow someone, not every
  time you view a tab with the Follow button
* keep a local cache of places, try not to re-fetch lots of places all the time
* Don't refresh the list of top identifiers if the current user isn't on it

Note that following a user from obs/show or Identify was broken before this
commit.