### PR TITLE
Add banner to /guides noting its deprecated status

### DIFF
--- a/app/views/guides/index.html.haml
+++ b/app/views/guides/index.html.haml
@@ -9,6 +9,7 @@
       resourceUrl: '/places/{{id}}.json?partial=autocomplete_item'
     })
 .container
+  .notice.box=t "views.guides.index.deprecated_banner"
   #guidesheader.jumbotron.clear{:class => logged_in? ? 'logged_in' : nil}
     %h1= link_to t(:welcome_to_guides, :site_name => @site.name), guides_path
     %p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4613,6 +4613,10 @@ en:
           infringement of copyright, respectively.
     guides:
       index:
+        deprecated_banner: |
+          Please note that as of January 2019, the Guides feature is presented
+          "as is"; while we don’t have any plans to delete it, we don’t plan
+          to develop it any further.
         funding_html: |
           Funding for the development of Guides was provided by
           <a href="http://eol.org"><img src="https://eol.org/assets/blue_logo-1edfd969b808300ae34a9530531df17f0c66a29882303b75452bfa62f7e6fa37.png"></a>


### PR DESCRIPTION
Fixes #2493 by adding a notice box to the guides page with the message suggested by tiwane.