### PR TITLE
default to RG photos

### DIFF
--- a/app/webpack/taxa/show/components/photo_chooser_modal.jsx
+++ b/app/webpack/taxa/show/components/photo_chooser_modal.jsx
@@ -316,8 +316,8 @@ class PhotoChooserModal extends React.Component {
                       className="form-control"
                       onChange={e => this.setProvider( e.target.value )}
                     >
-                      <option value="inat">{ I18n.t( "observations" ) }</option>
                       <option value="inat-rg">{ I18n.t( "rg_observations" ) }</option>
+                      <option value="inat">{ I18n.t( "observations" ) }</option>
                       <option value="flickr">Flickr</option>
                       <option value="eol">EOL</option>
                       <option value="wikimedia_commons">Wikimedia Commons</option>


### PR DESCRIPTION
I *think* this will cause the taxon photo chooser to default to RG observations instead of all observations.  The idea is to help prevent incorrect taxon photos.

![image](https://user-images.githubusercontent.com/13769652/72194958-11a4f100-33de-11ea-8f1d-bb3993cca7b6.png)
