### PR TITLE
Revise message flagging

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -68,6 +68,9 @@ class MessagesController < ApplicationController
     @flaggable_message = if m = @messages.detect{|m| m.from_user && m.from_user != current_user}
       m.from_user.messages.where(:thread_id => @message.thread_id).first
     end
+    if @flaggable_message && @flaggable_message.flagged?
+      @flag = @flaggable_message.flags.detect{|f| f.user_id == current_user.id }
+    end
     respond_to do |format|
       format.html
       format.json do

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -93,6 +93,5 @@ class Message < ActiveRecord::Base
 
   def flagged_with(flag, options = {})
     evaluate_new_flag_for_spam(flag)
-    Message.where(:user_id => to_user_id, :thread_id => thread_id).destroy_all
   end
 end

--- a/app/views/flags/_flag.html.haml
+++ b/app/views/flags/_flag.html.haml
@@ -13,7 +13,7 @@
           - else
             = @site.site_name_short
       %tr
-        %th=t :content
+        %th=t :flag_object
         %td
           = link_to flaggable.respond_to?( :to_plain_s ) ? flaggable.to_plain_s : t( flag.flaggable_type ), flaggable
       %tr

--- a/app/views/flags/global_index.html.haml
+++ b/app/views/flags/global_index.html.haml
@@ -20,6 +20,8 @@
     }
     td.actions { min-width: 150px; }
     .reason, .resolution { max-width: 300px; overflow: hidden; }
+    .table img { max-width: 100%; }
+    .table blockquote { font-size: 14px; }
 .container
   .row
     .col-xs-12
@@ -122,15 +124,20 @@
                   = link_to_user( flag.flaggable_user ) {|| char_wrap( flag.flaggable_user.login, 20 )}
                   .small.text-muted
                     = link_to t(:view_all), url_for_params( user_id: flag.flaggable_user.login, without: [:user_id] )
-              %td= flaggable_class.name.humanize
+              %td= flag.flaggable_type.humanize
               %td
-                = link_to(flaggable.to_plain_s, flaggable) if flaggable.respond_to?(:to_plain_s)
-                - if !flaggable.is_a?( Message ) && flaggable.respond_to?( :body ) || flaggable.respond_to?( :description )
-                  = truncate_with_more( formatted_user_text( flaggable.try_methods(:body, :description) ), length: 200 )
-                - if flaggable.respond_to?(:user) && flaggable.user
-                  .small
-                    = link_to_user flaggable.user, class: "text-muted" do
-                      = t(:added_by_user_on_date_html, user: flaggable.user.login, date: l( flaggable.created_at) )
+                - if flaggable
+                  = link_to(flaggable.to_plain_s, flaggable) if flaggable.respond_to?(:to_plain_s)
+                  - if !flaggable.is_a?( Message ) && flaggable.respond_to?( :body ) || flaggable.respond_to?( :description )
+                    %blockquote= truncate_with_more( formatted_user_text( flaggable.try_methods(:body, :description) ), length: 200 )
+                  - if flaggable.respond_to?(:user) && flaggable.user
+                    .small
+                      = link_to_user flaggable.user, class: "text-muted" do
+                        = t(:added_by_user_on_date_html, user: flaggable.user.login, date: l( flaggable.created_at) )
+                - else
+                  =t "deleted_#{flag.flaggable_type}"
+                  - if flag.flaggable_content_viewable_by?( current_user )
+                    %blockquote= formatted_user_text( flag.flaggable_content )
               %td.reason=formatted_user_text flag.flag
               %td
                 - if flag.comments.count > 0

--- a/app/views/flags/show.html.haml
+++ b/app/views/flags/show.html.haml
@@ -5,8 +5,10 @@
     t(:flag_for_observation_title_html, title: link_to( @object.to_plain_s, @object ) )
   elsif @object.respond_to?( :title ) || @object.respond_to?( :name )
     t( "flag_for_#{@object.class.name.underscore}_title_html", title: link_to( @object.try_methods(:title, :name), @object ) )
+  elsif @object
+    t( "flag_for_#{@flag.flaggable_type}_id_html", id: @flag.flaggable_id, url: url_for(@object) )
   else
-    t( "flag_for_#{@object.class.name.underscore}_id_html", id: @object.id, url: url_for(@object) )
+    t( "flag_for_#{@flag.flaggable_type}_id_deleted", id: @flag.flaggable_id )
   end
 - content_for(:title) do
   = strip_tags @title
@@ -20,7 +22,7 @@
         %strong
           = link_to t(:back_to_flags_html), url_for_referrer_or_default( @object )
         .pull-right
-          - if @object.is_a?( Comment )
+          - if @object && @object.is_a?( Comment )
             = link_to t(:view_moderation_history_for_this_comment), comment_flags_url( comment_id: @object.id )
             &middot;
           = link_to t(:view_all_flags), flags_url
@@ -33,16 +35,23 @@
       %table.table
         %thead
           %tr
-            %th=t :created
+            %th=t :content_author
             %th=t :flag_object
             %th=t :flagger
+            %th=t :flag_created
             %th=t :reason
             %th=t :resolved_by
             %th=t :flag_resolution
         %tbody
           %tr
-            %td=l @flag.created_at
-            %td= link_to @object.to_plain_s, @object
+            %td
+              - if @flag.flaggable_user
+                = link_to_user( @flag.flaggable_user ) {|| char_wrap( @flag.flaggable_user.login, 20 )} 
+            %td
+              - if @object
+                = link_to @object.to_plain_s, @object
+              - else
+                =t "deleted_#{@flag.flaggable_type.underscore}"
             %td
               - if @flag.user
                 = link_to @flag.user.login, @flag.user
@@ -50,6 +59,7 @@
                 = @site.site_name_short
               - else
                 =t :deleted_user
+            %td=l @flag.created_at
             %td=formatted_user_text @flag.flag
             %td
               - unless @flag.resolver.nil?
@@ -70,6 +80,10 @@
                 = link_to @flag, class: "btn btn-link", data: { confirm: t(:you_sure_delete_flag?) }, method: :delete do
                   %i.fa.fa-trash
                   = t(:delete)
+  - if @flag.flaggable_content_viewable_by?( current_user )
+    %h3=t :flaggable_content
+    %p=t "views.flags.show.flaggable_content_desc"
+    %blockquote= formatted_user_text( @flag.flaggable_content )
   .row
     .col-xs-8
       = render "comments/comments", parent: @flag

--- a/app/views/messages/show.html.haml
+++ b/app/views/messages/show.html.haml
@@ -11,6 +11,8 @@
 .container
   .row
     .col-xs-12.col-lg-8.col-lg-offset-2
+      - if @flag
+        .alert.alert-warning=t "views.messages.show.flag_notice_html", date: link_to( l(@flag.created_at.to_date, format: :long), @flag )
       #pageheader
         .right.nobr.meta.date= l(@messages.first.created_at.to_datetime, :format => :long)
         .breadcrumbs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1383,10 +1383,13 @@ en:
   flag_an_item: Flag An Item
   flag_as_spammer: Flag As Spammer
   flag_as_non_spammer: Flag As Non-spammer
+  # Label for the date/time when a flag was created
+  flag_created: Flag Created
   flag_description: Flag this content to let the curators know something is wrong with it.
   flag_for_check_list_title_html: |
     Flag for Check List: %{title}
   flag_for_comment_id_html: Flag for <a href="%{url}">Comment %{id}</a>
+  flag_for_comment_id_deleted: Flag for Comment %{id} (deleted)
   flag_for_curation: Flag for Curation
   flag_for_guide_title_html: |
     Flag for Guide: %{title}
@@ -4600,6 +4603,10 @@ en:
           </p>
     flags:
       show:
+        flaggable_content_desc: |
+          The flaggable content is the primary text attribute of the flagged
+          object at the time the flag was created. Only curators and staff can
+          see this. Only staff can see this for messages.
         flags_that_should_not_be_resolved_desc_html: |
           Please resolve <code>spam</code> and <code>copyright
           infringement</code> flags only if the content is not spam or not an
@@ -4987,6 +4994,11 @@ en:
           You'll be able to send new messages after you've added three
           verifiable observations or three identifications for others. For now
           you can read and reply to message other people send you.
+      show:
+        flag_notice_html: |
+          You flagged this conversation on %{date}. The flag will persist even
+          if you delete your copy of this conversation, so it is safe to do so
+          if you no longer want to see this.
     oauth:
       authorizations:
         new:

--- a/db/migrate/20200117011717_add_flaggable_content_to_flags.rb
+++ b/db/migrate/20200117011717_add_flaggable_content_to_flags.rb
@@ -1,0 +1,5 @@
+class AddFlaggableContentToFlags < ActiveRecord::Migration
+  def change
+    add_column :flags, :flaggable_content, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1254,7 +1254,8 @@ CREATE TABLE public.flags (
     resolved boolean DEFAULT false,
     updated_at timestamp without time zone,
     resolved_at timestamp without time zone,
-    flaggable_user_id integer
+    flaggable_user_id integer,
+    flaggable_content text
 );
 
 
@@ -10035,4 +10036,6 @@ INSERT INTO schema_migrations (version) VALUES ('20191115201008');
 INSERT INTO schema_migrations (version) VALUES ('20191203201511');
 
 INSERT INTO schema_migrations (version) VALUES ('20191210173400');
+
+INSERT INTO schema_migrations (version) VALUES ('20200117011717');
 

--- a/lib/acts_as_flaggable/acts_as_flaggable.rb
+++ b/lib/acts_as_flaggable/acts_as_flaggable.rb
@@ -9,7 +9,7 @@ module Gonzo
 
       module ClassMethods
         def acts_as_flaggable
-          has_many :flags, :as => :flaggable, :dependent => :destroy
+          has_many :flags, :as => :flaggable
           include Gonzo::Acts::Flaggable::InstanceMethods
           extend Gonzo::Acts::Flaggable::SingletonMethods
         end

--- a/lib/acts_as_flaggable/flag.rb
+++ b/lib/acts_as_flaggable/flag.rb
@@ -32,6 +32,7 @@ class Flag < ActiveRecord::Base
 
   before_save :set_resolved_at
   before_create :set_flaggable_user_id
+  before_create :set_flaggable_content
 
   after_create :notify_flaggable_on_create
   after_update :notify_flaggable_on_update
@@ -121,7 +122,9 @@ class Flag < ActiveRecord::Base
   end
   
   def flagged_object
-    eval("#{flaggable_type}.find(#{flaggable_id})")
+    if klass = Object.const_get( flaggable_type )
+      klass.find_by_id( flaggable_id )
+    end
   end
 
   def set_resolved_at
@@ -153,5 +156,18 @@ class Flag < ActiveRecord::Base
       self.flaggable_user_id = u.id
     end
     true
+  end
+
+  def set_flaggable_content
+    return true unless flaggable
+    self.flaggable_content = flaggable.try_methods(:body, :description)
+    true
+  end
+
+  def flaggable_content_viewable_by_current_user?( user )
+    if flaggable_type == "Message"
+      return false unless user && user.is_admin?
+    end
+    !flaggable_content.blank? && user && user.is_curator?
   end
 end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -29,6 +29,25 @@ describe Flag, "creation" do
     expect( f2 ).to be_valid
     expect( f2.errors[:user_id] ).to be_blank
   end
+
+  it "should set the flaggable content for an observation to the description" do
+    o = Observation.make!( description: "some bad stuff" )
+    f = Flag.make!( flaggable: o )
+    expect( f.flaggable_content ).to eq o.description
+  end
+
+  [Post, Comment, Identification].each do |model|
+    it "should set the flaggable content for a #{model.name} to the body" do
+      r = if model == Post
+        u = User.make!
+        model.make!( parent: u, user: u, body: "some bad stuff" )
+      else
+        model.make!( body: "some bad stuff" )
+      end
+      f = Flag.make!( flaggable: r )
+      expect( f.flaggable_content ).to eq r.body
+    end
+  end
 end
 
 describe Flag, "update" do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Message, "flagging" do
   it "should suspend the from_user if their messages have been flagged 3 times" do
-    offender = UserPrivilege.make!.user # User.make!
+    offender = UserPrivilege.make!.user
     3.times do
       m = make_message(user: offender, from_user: offender)
       m.send_message
@@ -13,19 +13,20 @@ describe Message, "flagging" do
     expect( offender ).to be_suspended
   end
 
-  it "should destroy the flagger's copies of the messages in this thread" do
-    from_user = UserPrivilege.make!.user # User.make!
-    to_user = UserPrivilege.make!.user # User.make!
+  it "should not destroy the flagger's copies of the messages in this thread" do
+    from_user = UserPrivilege.make!.user
+    to_user = UserPrivilege.make!.user
     m = make_message(from_user: from_user, to_user: to_user, user: from_user)
     m.send_message
     flag = Flag.make(flaggable: m, user: m.to_user, flag: Flag::SPAM)
-    flag.save!
-    expect( Message.where(user_id: m.to_user, thread_id: m.thread_id).count ).to eq 0
+    expect {
+      flag.save!
+    }.not_to change( Message.where(user_id: m.to_user, thread_id: m.thread_id ), :count )
   end
 
   it "should not destroy the spammer's copies" do
-    from_user = UserPrivilege.make!.user # User.make!
-    to_user = UserPrivilege.make!.user # User.make!
+    from_user = UserPrivilege.make!.user
+    to_user = UserPrivilege.make!.user
     m = make_message(from_user: from_user, to_user: to_user, user: from_user)
     m.send_message
     flag = Flag.make(flaggable: m, user: m.to_user, flag: Flag::SPAM)


### PR DESCRIPTION
* ensures messages do not get deleted after flagging
* messages remain visible after flagging
* flags persist after the flaggable record gets deleted
* flags preserve the main text attribute of the flaggable record so some history of what was actually flagged gets preserved even if the owner of the flaggable record deletes that record; this content is visible to curators except for messages