### PR TITLE
Adds a char filter to most ES analyzers for custom char mapping

### DIFF
--- a/lib/elastic_model/elastic_model.rb
+++ b/lib/elastic_model/elastic_model.rb
@@ -31,24 +31,21 @@ module ElasticModel
   KEYWORD_AUTOCOMPLETE_ANALYZER = {
     keyword_autocomplete_analyzer: {
       tokenizer: "keyword",
-      filter: [ "lowercase", "asciifolding", "stop", "edge_ngram_filter" ],
-      char_filter: [ "inat_char_filter" ]
+      filter: [ "lowercase", "asciifolding", "stop", "edge_ngram_filter" ]
     }
   }
   # basic search analyzer that allows sub-matches
   STANDARD_ANALYZER = {
     standard_analyzer: {
       tokenizer: "standard",
-      filter: [ "lowercase", "asciifolding" ],
-      char_filter: [ "inat_char_filter" ]
+      filter: [ "lowercase", "asciifolding" ]
     }
   }
   # basic search analyzer with no sub-matches
   KEYWORD_ANALYZER = {
     keyword_analyzer: {
       tokenizer: "keyword",
-      filter: [ "lowercase", "asciifolding" ],
-      char_filter: [ "inat_char_filter" ]
+      filter: [ "lowercase", "asciifolding" ]
     }
   }
   # for autocomplete analyzers. Needs at least 2 letters (e.g. `P` doesn't find `Park`)
@@ -76,7 +73,8 @@ module ElasticModel
         type: "mapping",
         mappings: [
           # map ʻokina to nothing so searches for ʻokina, 'okina, and okina would all return the same things
-          "ʻ => "
+          "ʻ => ",
+          "× => x"
         ]
       }
     }

--- a/lib/elastic_model/elastic_model.rb
+++ b/lib/elastic_model/elastic_model.rb
@@ -5,7 +5,8 @@ module ElasticModel
   ASCII_SNOWBALL_ANALYZER = {
     ascii_snowball_analyzer: {
       tokenizer: "standard",
-      filter: [ "lowercase", "asciifolding", "stop", "snowball" ]
+      filter: [ "lowercase", "asciifolding", "stop", "snowball" ],
+      char_filter: [ "inat_char_filter" ]
     }
   }
   # basic autocomplete analyzer. Avoids diacritic variations, will find
@@ -13,7 +14,8 @@ module ElasticModel
   AUTOCOMPLETE_ANALYZER = {
     autocomplete_analyzer: {
       tokenizer: "standard",
-      filter: [ "lowercase", "asciifolding", "edge_ngram_filter" ]
+      filter: [ "lowercase", "asciifolding", "edge_ngram_filter" ],
+      char_filter: [ "inat_char_filter" ]
     }
   }
   # autocomplete analyzer for Japanese strings
@@ -29,21 +31,24 @@ module ElasticModel
   KEYWORD_AUTOCOMPLETE_ANALYZER = {
     keyword_autocomplete_analyzer: {
       tokenizer: "keyword",
-      filter: [ "lowercase", "asciifolding", "stop", "edge_ngram_filter" ]
+      filter: [ "lowercase", "asciifolding", "stop", "edge_ngram_filter" ],
+      char_filter: [ "inat_char_filter" ]
     }
   }
   # basic search analyzer that allows sub-matches
   STANDARD_ANALYZER = {
     standard_analyzer: {
       tokenizer: "standard",
-      filter: [ "lowercase", "asciifolding" ]
+      filter: [ "lowercase", "asciifolding" ],
+      char_filter: [ "inat_char_filter" ]
     }
   }
   # basic search analyzer with no sub-matches
   KEYWORD_ANALYZER = {
     keyword_analyzer: {
       tokenizer: "keyword",
-      filter: [ "lowercase", "asciifolding" ]
+      filter: [ "lowercase", "asciifolding" ],
+      char_filter: [ "inat_char_filter" ]
     }
   }
   # for autocomplete analyzers. Needs at least 2 letters (e.g. `P` doesn't find `Park`)
@@ -65,7 +70,16 @@ module ElasticModel
       STANDARD_ANALYZER,
       KEYWORD_ANALYZER
     ].reduce(&:merge),
-    filter: EDGE_NGRAM_FILTER
+    filter: EDGE_NGRAM_FILTER,
+    char_filter: {
+      inat_char_filter: {
+        type: "mapping",
+        mappings: [
+          # map ʻokina to nothing so searches for ʻokina, 'okina, and okina would all return the same things
+          "ʻ => "
+        ]
+      }
+    }
   }
 
   def self.search_criteria(options={})


### PR DESCRIPTION
Specifically, it maps the Hawaiian ʻokina to a blank, which is how our analyzers
seems to treat apostrophes. This means searches for taxon names with the ʻokina
can be performed with the ʻokina, with an apostrophe, or without either.

This will require recreating and reindexing the Taxon index, so we'll have to pull this in and perform this the next time we have downtime.

https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-mapping-charfilter.html

Closes #2560 