### PR TITLE
Add UUID columns to more tables

### DIFF
--- a/app/models/controlled_term.rb
+++ b/app/models/controlled_term.rb
@@ -2,6 +2,7 @@
 class ControlledTerm < ActiveRecord::Base
 
   include ActsAsElasticModel
+  include ActsAsUUIDable
 
   has_many :controlled_term_values, foreign_key: :controlled_attribute_id,
     class_name: "ControlledTermValue", dependent: :destroy

--- a/app/models/observation_field.rb
+++ b/app/models/observation_field.rb
@@ -1,6 +1,7 @@
 class ObservationField < ActiveRecord::Base
 
   include ActsAsElasticModel
+  include ActsAsUUIDable
 
   belongs_to :user
   has_many :observation_field_values, :dependent => :destroy

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -12,6 +12,7 @@ class Photo < ActiveRecord::Base
   serialize :metadata
 
   include Shared::LicenseModule
+  include ActsAsUUIDable
   
   before_save :set_license, :trim_fields
   after_save :update_default_license,

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -2,6 +2,7 @@
 class Place < ActiveRecord::Base
 
   include ActsAsElasticModel
+  include ActsAsUUIDable
 
   has_ancestry orphan_strategy: :adopt
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ActiveRecord::Base
   acts_as_spammable :fields => [ :title, :body ],
                     :comment_type => "blog-post"
+  include ActsAsUUIDable
 
   has_subscribers to: {
     comments: { notification: "activity", include_owner: true }

--- a/app/models/sound.rb
+++ b/app/models/sound.rb
@@ -7,6 +7,7 @@ class Sound < ActiveRecord::Base
 
   include Shared::LicenseModule
   acts_as_flaggable
+  include ActsAsUUIDable
 
   attr_accessor :orphan
   

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -25,7 +25,7 @@ class Taxon < ActiveRecord::Base
   attr_accessor :current_user
 
   include ActsAsElasticModel
-
+  include ActsAsUUIDable
   acts_as_flaggable
   has_ancestry orphan_strategy: :adopt
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   include ActsAsSpammable::User
   include ActsAsElasticModel
+  include ActsAsUUIDable
 
   acts_as_voter
   acts_as_spammable fields: [ :description ],

--- a/db/migrate/20200116234248_add_uuid_columns.rb
+++ b/db/migrate/20200116234248_add_uuid_columns.rb
@@ -1,0 +1,37 @@
+class AddUuidColumns < ActiveRecord::Migration
+  def change
+    # small stuff
+    add_column :controlled_terms, :uuid, :uuid, default: "uuid_generate_v4()"
+    add_index :controlled_terms, :uuid, unique: true
+    add_column :flags, :uuid, :uuid, default: "uuid_generate_v4()"
+    add_index :flags, :uuid, unique: true
+    add_column :observation_fields, :uuid, :uuid, default: "uuid_generate_v4()"
+    add_index :observation_fields, :uuid, unique: true
+    add_column :sounds, :uuid, :uuid, default: "uuid_generate_v4()"
+    add_index :sounds, :uuid, unique: true
+    add_column :places, :uuid, :uuid, default: "uuid_generate_v4()"
+    add_index :places, :uuid, unique: true
+    add_column :posts, :uuid, :uuid, default: "uuid_generate_v4()"
+    add_index :posts, :uuid, unique: true
+
+    # big stuff
+    add_column :taxa, :uuid, :uuid
+    add_column :users, :uuid, :uuid
+    add_column :photos, :uuid, :uuid
+
+    # Run these commands elsewhere to populate the columns in these tables. It
+    # will be slow, but it won't hang the site
+    # UPDATE taxa SET uuid = uuid_generate_v4() WHERE uuid IS NULL;
+    # UPDATE users SET uuid = uuid_generate_v4() WHERE uuid IS NULL;
+    # UPDATE photos SET uuid = uuid_generate_v4() WHERE uuid IS NULL;
+
+    # After you've slowly populated the UUID columns for these tables, make a
+    # new migration that does this
+    # change_column :taxa, :uuid, :uuid, default: "uuid_generate_v4()"
+    # add_index :taxa, :uuid, unique: true
+    # change_column :users, :uuid, :uuid, default: "uuid_generate_v4()"
+    # add_index :users, :uuid, unique: true
+    # change_column :photos, :uuid, :uuid, default: "uuid_generate_v4()"
+    # add_index :photos, :uuid, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -875,7 +875,8 @@ CREATE TABLE public.controlled_terms (
     user_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    blocking boolean DEFAULT false
+    blocking boolean DEFAULT false,
+    uuid uuid DEFAULT public.uuid_generate_v4()
 );
 
 
@@ -1254,7 +1255,9 @@ CREATE TABLE public.flags (
     resolved boolean DEFAULT false,
     updated_at timestamp without time zone,
     resolved_at timestamp without time zone,
-    flaggable_user_id integer
+    flaggable_user_id integer,
+    flaggable_content text,
+    uuid uuid DEFAULT public.uuid_generate_v4()
 );
 
 
@@ -2382,7 +2385,8 @@ CREATE TABLE public.observation_fields (
     updated_at timestamp without time zone,
     allowed_values text,
     values_count integer,
-    users_count integer
+    users_count integer,
+    uuid uuid DEFAULT public.uuid_generate_v4()
 );
 
 
@@ -2900,7 +2904,8 @@ CREATE TABLE public.photos (
     file_updated_at timestamp without time zone,
     metadata text,
     subtype character varying(255),
-    native_original_image_url character varying(512)
+    native_original_image_url character varying(512),
+    uuid uuid
 );
 
 
@@ -3054,7 +3059,8 @@ CREATE TABLE public.places (
     ancestry character varying(255),
     slug character varying(255),
     source_id integer,
-    admin_level integer
+    admin_level integer,
+    uuid uuid DEFAULT public.uuid_generate_v4()
 );
 
 
@@ -3099,7 +3105,8 @@ CREATE TABLE public.posts (
     longitude numeric(15,10),
     radius integer,
     distance double precision,
-    number integer
+    number integer,
+    uuid uuid DEFAULT public.uuid_generate_v4()
 );
 
 
@@ -3862,7 +3869,8 @@ CREATE TABLE public.sounds (
     file_content_type character varying,
     file_file_size integer,
     file_updated_at timestamp without time zone,
-    subtype character varying(255)
+    subtype character varying(255),
+    uuid uuid DEFAULT public.uuid_generate_v4()
 );
 
 
@@ -4087,7 +4095,8 @@ CREATE TABLE public.taxa (
     is_active boolean DEFAULT true NOT NULL,
     complete_rank character varying,
     complete boolean,
-    taxon_framework_relationship_id integer
+    taxon_framework_relationship_id integer,
+    uuid uuid
 );
 
 
@@ -4903,7 +4912,8 @@ CREATE TABLE public.users (
     donorbox_donor_id integer,
     donorbox_plan_type character varying,
     donorbox_plan_status character varying,
-    donorbox_plan_started_at date
+    donorbox_plan_started_at date,
+    uuid uuid
 );
 
 
@@ -7190,6 +7200,13 @@ CREATE INDEX index_controlled_term_taxa_on_taxon_id ON public.controlled_term_ta
 
 
 --
+-- Name: index_controlled_terms_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_controlled_terms_on_uuid ON public.controlled_terms USING btree (uuid);
+
+
+--
 -- Name: index_counties_simplified_01_on_geom; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7306,6 +7323,13 @@ CREATE INDEX index_exploded_atlas_places_on_place_id ON public.exploded_atlas_pl
 --
 
 CREATE INDEX index_flags_on_flaggable_id_and_flaggable_type ON public.flags USING btree (flaggable_id, flaggable_type);
+
+
+--
+-- Name: index_flags_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_flags_on_uuid ON public.flags USING btree (uuid);
 
 
 --
@@ -7841,6 +7865,13 @@ CREATE INDEX index_observation_fields_on_name ON public.observation_fields USING
 
 
 --
+-- Name: index_observation_fields_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_observation_fields_on_uuid ON public.observation_fields USING btree (uuid);
+
+
+--
 -- Name: index_observation_links_on_observation_id_and_href; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8331,6 +8362,13 @@ CREATE INDEX index_places_on_user_id ON public.places USING btree (user_id);
 
 
 --
+-- Name: index_places_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_places_on_uuid ON public.places USING btree (uuid);
+
+
+--
 -- Name: index_posts_on_place_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8342,6 +8380,13 @@ CREATE INDEX index_posts_on_place_id ON public.posts USING btree (place_id);
 --
 
 CREATE INDEX index_posts_on_published_at ON public.posts USING btree (published_at);
+
+
+--
+-- Name: index_posts_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_posts_on_uuid ON public.posts USING btree (uuid);
 
 
 --
@@ -8615,6 +8660,13 @@ CREATE INDEX index_sounds_on_type ON public.sounds USING btree (type);
 --
 
 CREATE INDEX index_sounds_on_user_id ON public.sounds USING btree (user_id);
+
+
+--
+-- Name: index_sounds_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_sounds_on_uuid ON public.sounds USING btree (uuid);
 
 
 --
@@ -10035,4 +10087,8 @@ INSERT INTO schema_migrations (version) VALUES ('20191115201008');
 INSERT INTO schema_migrations (version) VALUES ('20191203201511');
 
 INSERT INTO schema_migrations (version) VALUES ('20191210173400');
+
+INSERT INTO schema_migrations (version) VALUES ('20200116234248');
+
+INSERT INTO schema_migrations (version) VALUES ('20200117011717');
 

--- a/lib/acts_as_flaggable/flag.rb
+++ b/lib/acts_as_flaggable/flag.rb
@@ -1,4 +1,5 @@
 class Flag < ActiveRecord::Base
+  include ActsAsUUIDable
   SPAM = "spam"
   INAPPROPRIATE = "inappropriate"
   COPYRIGHT_INFRINGEMENT = "copyright infringement"


### PR DESCRIPTION
Adds UUIDs to several more models that are accessible via the API. Holds off on populating these columns for large tables so we can do that without hanging the site.