### PR TITLE
Additional site data in exports

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -173,6 +173,14 @@ class Annotation < ActiveRecord::Base
     true
   end
 
+  def controlled_attribute_label
+    controlled_attribute.try(:label)
+  end
+
+  def controlled_value_label
+    controlled_value.try(:label)
+  end
+
   def self.reassess_annotations_for_taxon_ids( taxon_ids )
     Annotation.
         joins(

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -23,6 +23,7 @@ class Place < ActiveRecord::Base
   has_many :projects, :dependent => :nullify, :inverse_of => :place
   has_many :trips, :dependent => :nullify, :inverse_of => :place
   has_many :sites, :dependent => :nullify, :inverse_of => :place
+  has_many :extra_place_sites, dependent: :nullify, inverse_of: :extra_place, class_name: "Site", foreign_key: :extra_place_id
   has_many :place_taxon_names, :dependent => :delete_all, :inverse_of => :place
   has_many :taxon_names, :through => :place_taxon_names
   has_many :users, :inverse_of => :place, :dependent => :nullify

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -46,6 +46,8 @@ class Site < ActiveRecord::Base
   # default place ID for place filters. Presently only used on /places, but use may be expanded
   belongs_to :place, inverse_of: :sites
 
+  belongs_to :extra_place, inverse_of: :extra_place_sites, class_name: "Place"
+
   # header logo, should be at least 118x22
   if CONFIG.usingS3
     has_attached_file :logo,

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -79,7 +79,11 @@
               - else
                 = f.text_field "preferred_#{pref.name}", label: pref.name.humanize, class: "col-md-4", disabled: disabled, description: pref_descriptions[pref.name.to_sym]
       - if grp == 'geo'
-        = f.text_field :place_id
+        .row
+          .col-md-6
+            = f.text_field :place_id, description: "Primary place the site is associated with, generally the place used for default searches etc."
+          .col-md-6
+            = f.text_field :extra_place_id, description: "An additional place used for data export"
   .row
     .col-md-12
       = f.submit t(:save), :class => 'btn btn-primary'

--- a/app/views/sites/show.html.haml
+++ b/app/views/sites/show.html.haml
@@ -21,9 +21,21 @@
           %tr
             %td=t :site_admins
             %td
-              %ul.unstacked{ style: "padding-left: 1em" }
+              %ul{ style: "padding-left: 1em" }
                 - for sa in @record.site_admins
                   %li= link_to_user sa.user
+              %p These users are entitled to complete data exports including
+              %ul{ style: "padding-left: 1em" }
+                %li User data (including email addresses) of people affiliated with this site
+                %li Observations added by people affiliated with this site
+                - if @record.place
+                  %li
+                    Observations in 
+                    = link_to @record.place.display_name, @record.place
+                - if @record.extra_place
+                  %li
+                    Observations in 
+                    = link_to @record.extra_place.display_name, @record.extra_place
       - for grp, prefs in @pref_groups
         - prefs = prefs.select{|p| !@record.preferences[p.name].blank?}
         - next if prefs.blank?

--- a/db/migrate/20200220211829_add_extra_place_id_to_sites.rb
+++ b/db/migrate/20200220211829_add_extra_place_id_to_sites.rb
@@ -1,0 +1,5 @@
+class AddExtraPlaceIdToSites < ActiveRecord::Migration
+  def change
+    add_column :sites, :extra_place_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3792,7 +3792,8 @@ CREATE TABLE public.sites (
     logo_blog_file_name character varying,
     logo_blog_content_type character varying,
     logo_blog_file_size bigint,
-    logo_blog_updated_at timestamp without time zone
+    logo_blog_updated_at timestamp without time zone,
+    extra_place_id integer
 );
 
 
@@ -10118,4 +10119,6 @@ INSERT INTO schema_migrations (version) VALUES ('20200122231601');
 INSERT INTO schema_migrations (version) VALUES ('20200127213714');
 
 INSERT INTO schema_migrations (version) VALUES ('20200130191142');
+
+INSERT INTO schema_migrations (version) VALUES ('20200220211829');
 

--- a/tools/export_site_data.rb
+++ b/tools/export_site_data.rb
@@ -84,6 +84,7 @@ ASSOC_COLUMNS = {
   annotations: %w(
     id
     uuid
+    resource_type
     resource_id
     created_at
     controlled_attribute_id
@@ -96,6 +97,7 @@ ASSOC_COLUMNS = {
   comments: %w(
     id
     uuid
+    parent_type
     parent_id
     created_at
     updated_at

--- a/tools/export_site_data.rb
+++ b/tools/export_site_data.rb
@@ -276,7 +276,7 @@ obs_csv_path = export_observations(
 # Export observations in place by non-site users *only* obscured by taxon geoprivacy with private coordinates
 obs_csv_path = export_observations(
   not_site_id: @site.id,
-  place_id: @site.place_id,
+  place_id: [@site.place_id, @site.extra_place_id].compact,
   taxon_geoprivacy: ["obscured", "private"],
   geoprivacy: ["open"],
   force_coordinate_visibility: true,
@@ -285,7 +285,7 @@ obs_csv_path = export_observations(
 )
 obs_csv_path = export_observations(
   not_site_id: @site.id,
-  place_id: @site.place_id,
+  place_id: [@site.place_id, @site.extra_place_id].compact,
   taxon_geoprivacy: ["obscured", "private"],
   geoprivacy: ["obscured", "private"],
   csv_path: obs_csv_path,
@@ -294,7 +294,7 @@ obs_csv_path = export_observations(
 # Export observations in place by non-site users *not* obscured by taxon geoprivacy *without* private coordinates
 obs_csv_path = export_observations(
   not_site_id: @site.id,
-  place_id: @site.place_id,
+  place_id: [@site.place_id, @site.extra_place_id].compact,
   not_taxon_geoprivacy: ["obscured", "private"],
   csv_path: obs_csv_path,
   debug_label: "by non-site users of un-threatened taxa"

--- a/tools/export_site_data.rb
+++ b/tools/export_site_data.rb
@@ -80,6 +80,65 @@ OBS_COLUMNS = %w(
   taxon_id
 )
 
+ASSOC_COLUMNS = {
+  annotations: %w(
+    id
+    uuid
+    resource_id
+    created_at
+    controlled_attribute_id
+    controlled_attribute_label
+    controlled_value_id
+    controlled_value_label
+    user_id
+    vote_score
+  ),
+  comments: %w(
+    id
+    uuid
+    parent_id
+    created_at
+    updated_at
+    user_id
+    body
+  ),
+  identifications: %w(
+    id
+    observation_id
+    taxon_id
+    user_id
+    body
+    created_at
+    updated_at
+    current
+    taxon_change_id
+    category
+    uuid
+    previous_observation_taxon_id
+    disagreement
+  ),
+  quality_metrics: %w(
+    id
+    user_id
+    observation_id
+    metric
+    agree
+    created_at
+    updated_at
+  ),
+  observation_field_values: %w(
+    id
+    observation_id
+    observation_field_id
+    value
+    created_at
+    updated_at
+    user_id
+    updater_id
+    uuid
+  )
+}
+
 def system_call(cmd)
   puts "Running #{cmd}" if OPTS[:debug]
   system cmd
@@ -127,6 +186,86 @@ sql = <<-SQL
   WHERE
     site_id = #{@site.id}
     AND spammer != 't'
+SQL
+cmd = "psql #{@dbname} -h #{@dbhost} -c \"COPY (#{sql.gsub( /\s+/m, " ")}) TO STDOUT WITH CSV HEADER\" > #{path}"
+system_call cmd
+
+# Export taxa table
+path = File.join( @work_path, "#{@basename}-taxa.csv" )
+sql = <<-SQL
+  SELECT
+    id,
+    name,
+    rank,
+    created_at,
+    updated_at,
+    iconic_taxon_id,
+    is_iconic,
+    creator_id,
+    updater_id,
+    observations_count,
+    listed_taxa_count,
+    rank_level,
+    unique_name,
+    wikipedia_summary,
+    wikipedia_title,
+    featured_at,
+    ancestry,
+    locked,
+    is_active,
+    complete_rank,
+    complete,
+    taxon_framework_relationship_id,
+    uuid
+  FROM
+    taxa
+SQL
+cmd = "psql #{@dbname} -h #{@dbhost} -c \"COPY (#{sql.gsub( /\s+/m, " ")}) TO STDOUT WITH CSV HEADER\" > #{path}"
+system_call cmd
+
+# Export conservation_statuses table
+path = File.join( @work_path, "#{@basename}-conservation_statuses.csv" )
+sql = <<-SQL
+  SELECT
+    cs.id,
+    cs.taxon_id,
+    cs.user_id,
+    cs.place_id,
+    cs.source_id,
+    cs.authority,
+    cs.status,
+    cs.url,
+    cs.description,
+    cs.geoprivacy,
+    cs.iucn,
+    cs.created_at,
+    cs.updated_at,
+    places.name AS place_name,
+    places.display_name AS place_display_name
+  FROM
+    conservation_statuses cs
+      LEFT JOIN places ON places.id = cs.place_id
+SQL
+cmd = "psql #{@dbname} -h #{@dbhost} -c \"COPY (#{sql.gsub( /\s+/m, " ")}) TO STDOUT WITH CSV HEADER\" > #{path}"
+system_call cmd
+
+# Export observation_fields table
+path = File.join( @work_path, "#{@basename}-observation_fields.csv" )
+sql = <<-SQL
+  SELECT
+    id,
+    name,
+    datatype,
+    user_id,
+    description,
+    created_at,
+    updated_at,
+    allowed_values,
+    values_count,
+    users_count,
+    uuid
+  FROM
+    observation_fields
 SQL
 cmd = "psql #{@dbname} -h #{@dbhost} -c \"COPY (#{sql.gsub( /\s+/m, " ")}) TO STDOUT WITH CSV HEADER\" > #{path}"
 system_call cmd
@@ -189,14 +328,25 @@ def export_observations( options = {} )
 
   puts "[#{Time.now}] Exporting observations in #{num_partitions} partitions, options: #{options}" if OPTS[:verbose]
 
-  csv_path = options[:csv_path]
-  if options[:csv_path].blank?
-    csv_path = File.join( @work_path, "#{@basename}-observations.csv" )
+  csv_path = File.join( @work_path, "#{@basename}-observations.csv" )
+  unless File.exists?( csv_path )
     CSV.open( csv_path, "w" ) do |csv|
       csv << OBS_COLUMNS
     end
   end
   puts "[#{Time.now}] Writing CSV to #{csv_path}" if OPTS[:verbose]
+
+  # Set up CSV files for associate models
+  assoc_csv_paths = {}
+  ASSOC_COLUMNS.each do |k, columns|
+    path = File.join( @work_path, "#{@basename}-#{k}.csv" )
+    unless File.exists?( path )
+      CSV.open( path, "w" ) do |csv|
+        csv << columns
+      end
+    end
+    assoc_csv_paths[k] = path
+  end
 
   Parallel.each_with_index( partitions, in_processes: partitions.size ) do |partition, parition_i|
     partition_filters = filters.dup
@@ -205,43 +355,51 @@ def export_observations( options = {} )
     }
     min_id = 0
     obs_i = 0
-    CSV.open( csv_path, "a" ) do |csv|
-      while true do
-        # filters << { range: { id: { gte: min_id } } }
-        batch_filters = partition_filters.dup
-        batch_filters << { range: { id: { gte: min_id } } }
-        observations = try_and_try_again( [Patron::TimeoutError, Faraday::TimeoutError] ) do
-          Observation.elastic_paginate(
-            track_total_hits: true,
-            filters: batch_filters,
-            inverse_filters: inverse_filters,
-            sort: { id: "asc" },
-            per_page: 1000
-          )
-        end
-        if observations.size == 0
-          puts if OPTS[:verbose]
-          break
-        end
-        if obs_i == 0
-          partition_total_entries = observations.total_entries
-        end
-        if OPTS[:verbose]
-          msg = "[#{Time.now}] "
-          msg += "[#{options[:debug_label]}] " if options[:debug_label]
-          msg += "Obs partition #{parition_i} (#{partition}) from #{min_id} (#{obs_i} / #{partition_total_entries}, #{( obs_i.to_f  / partition_total_entries * 100 ).round( 2 )}%)"
-          print msg
-          print "\r"
-          $stdout.flush
-        end
-        Observation.preload_associations( observations, [
-          :user,
-          { identifications: [:stored_preferences] },
-          { photos: :user },
-          :sounds,
-          :quality_metrics,
-          { observations_places: :place }
-        ] )
+    while true do
+      # filters << { range: { id: { gte: min_id } } }
+      batch_filters = partition_filters.dup
+      batch_filters << { range: { id: { gte: min_id } } }
+      observations = try_and_try_again( [Patron::TimeoutError, Faraday::TimeoutError] ) do
+        Observation.elastic_paginate(
+          track_total_hits: true,
+          filters: batch_filters,
+          inverse_filters: inverse_filters,
+          sort: { id: "asc" },
+          per_page: 1000
+        )
+      end
+      if observations.size == 0
+        puts if OPTS[:verbose]
+        break
+      end
+      if obs_i == 0
+        partition_total_entries = observations.total_entries
+      end
+      if OPTS[:verbose]
+        msg = "[#{Time.now}] "
+        msg += "[#{options[:debug_label]}] " if options[:debug_label]
+        msg += "Obs partition #{parition_i} (#{partition}) from #{min_id} (#{obs_i} / #{partition_total_entries}, #{( obs_i.to_f  / partition_total_entries * 100 ).round( 2 )}%)"
+        print msg
+        print "\r"
+        $stdout.flush
+      end
+      Observation.preload_associations( observations, [
+        :user,
+        { identifications: [:stored_preferences] },
+        { photos: :user },
+        :sounds,
+        :quality_metrics,
+        { observations_places: :place },
+        {
+          annotations: {
+            controlled_attribute: [:labels],
+            controlled_value: [:labels]
+          },
+        },
+        :observation_field_values,
+        :comments
+      ] )
+      CSV.open( csv_path, "a" ) do |csv|
         observations.each do |o|
           if OPTS[:debug]
             msg = "Obs #{obs_i} (#{o.id})"
@@ -262,41 +420,48 @@ def export_observations( options = {} )
           min_id = o.id + 1
         end
       end
+      ASSOC_COLUMNS.each do |association, cols|
+        association = association.to_sym
+        CSV.open( assoc_csv_paths[association], "a" ) do |csv|
+          observations.each do |o|
+            o.send( association ).each do |associate|
+              csv << cols.map {|col| associate.send( col )}
+            end
+          end
+        end
+      end
     end
   end
   csv_path
 end
 
 # Export observations by site users with private coordinates
-obs_csv_path = export_observations(
+export_observations(
   site_id: @site.id,
   force_coordinate_visibility: true,
   debug_label: "by site users"
 )
 # Export observations in place by non-site users *only* obscured by taxon geoprivacy with private coordinates
-obs_csv_path = export_observations(
+export_observations(
   not_site_id: @site.id,
   place_id: [@site.place_id, @site.extra_place_id].compact,
   taxon_geoprivacy: ["obscured", "private"],
   geoprivacy: ["open"],
   force_coordinate_visibility: true,
-  csv_path: obs_csv_path,
   debug_label: "by non-site users w/ taxon_geoprivacy but not geoprivacy"
 )
-obs_csv_path = export_observations(
+export_observations(
   not_site_id: @site.id,
   place_id: [@site.place_id, @site.extra_place_id].compact,
   taxon_geoprivacy: ["obscured", "private"],
   geoprivacy: ["obscured", "private"],
-  csv_path: obs_csv_path,
   debug_label: "by non-site users of w/ taxon_geoprivacy AND geoprivacy"
 )
 # Export observations in place by non-site users *not* obscured by taxon geoprivacy *without* private coordinates
-obs_csv_path = export_observations(
+export_observations(
   not_site_id: @site.id,
   place_id: [@site.place_id, @site.extra_place_id].compact,
   not_taxon_geoprivacy: ["obscured", "private"],
-  csv_path: obs_csv_path,
   debug_label: "by non-site users of un-threatened taxa"
 )
 


### PR DESCRIPTION
Adds an additional place association on sites so they can support data exports from two places (e.g. a national boundary and an EEZ). Also includes data from several other models in the export.

Closes #2572 
Closes #2580