### PR TITLE
Move configuration file copying to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -12,10 +12,19 @@ Dir.chdir APP_ROOT do
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   system "cp config/database.yml.sample config/database.yml"
-  # end
+  puts "\n== Copying sample files =="
+  unless File.exist?("config/config.yml")
+    system "cp config/config.yml.example config/config.yml"
+  end
+  unless File.exist?("config/database.yml")
+    system "cp config/database.yml.example config/database.yml"
+  end
+  unless File.exist?("config/secrets.yml")
+    system "cp config/secrets.yml.example config/secrets.yml"
+  end
+  unless File.exist?("config/smtp.yml")
+    system "cp config/smtp.yml.example config/smtp.yml"
+  end
 
   puts "\n== Preparing database =="
   system "bin/rake db:setup"


### PR DESCRIPTION
Should allow simplifying the Rails setup instructions in the [Development Setup Guide][1].

Editing some of these files will likely be needed but duplicating N+1 config file
is needlessly tedious.

[1]: https://github.com/inaturalist/inaturalist/wiki/Development-Setup-Guide#installing-inat