### PR TITLE
Add Postgres database template setup to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,20 @@ Dir.chdir APP_ROOT do
   #   system "cp config/database.yml.sample config/database.yml"
   # end
 
+  puts "\n== Creating Template Database =="
+  if system "command -v createdb"
+    system "createdb template_postgis"
+    system "psql -d template_postgis -c 'create extension postgis'"
+    system "psql -d template_postgis -c 'create extension \"uuid-ossp\"'"
+    system <<~STRING
+      psql template_postgis -c \
+      "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis'"
+    STRING
+  else
+    puts "\nError: PostgreSQL needs to be installed before setup can be completed."
+    abort
+  end
+
   puts "\n== Preparing database =="
   system "bin/rake db:setup"
 


### PR DESCRIPTION
One less thing to copy and paste from the [Development Setup Guide][1] (which is error prone) by hand when it can be done (and updated in one place) through `bin/setup`.

I've included some logic to abort if `createdb` is not available as a shell command with some error feedback in that case:

> Error: PostgreSQL needs to be installed before setup can be completed.

[1]: https://github.com/inaturalist/inaturalist/wiki/Development-Setup-Guide#set-up-the-template-database