### PR TITLE
DJ improvements

### DIFF
--- a/config/initializers/delayed_jobs_serialization.rb
+++ b/config/initializers/delayed_jobs_serialization.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       end
       coder.map = {
         "attributes" => {
-          self.class.primary_key => self[self.class.primary_key]
+          self.class.primary_key => self[self.class.primary_key].to_s
         }
       }
     end

--- a/config/initializers/delayed_jobs_serialization.rb
+++ b/config/initializers/delayed_jobs_serialization.rb
@@ -1,0 +1,56 @@
+# extend ActiveRecord::Base to add an attribute which can be used to change
+# how the model is serialized to YAML. This attribute is only meant to be set
+# during the enquing of delayed jobs. It will serialize only the primary key
+# to minimize the size of the delayed job handler attribute
+module ActiveRecord
+  class Base
+    attr_accessor :dj_serialize_minimal
+
+    def encode_with(coder)
+      if !self.class.primary_key || !self.class.primary_key.is_a?( String ) || !dj_serialize_minimal
+        super
+        return
+      end
+      coder.map = {
+        "attributes" => {
+          self.class.primary_key => self[self.class.primary_key]
+        }
+      }
+    end
+
+  end
+end
+
+module Delayed
+  module Backend
+    module Base
+      module ClassMethods
+
+        # Add a job to the queue
+        def enqueue(*args)
+          job_options = Delayed::Backend::JobPreparer.new(*args).prepare
+          payload_object = job_options[:payload_object]
+          # check if the payload object is an instance of ActiveRecord::Base with a
+          # single column primary key, and enables the setting of dj_serialize_minimal
+          is_ar_instance = payload_object && payload_object.is_a?( Delayed::PerformableMethod ) &&
+            payload_object.object && payload_object.object.is_a?(::ActiveRecord::Base) &&
+            payload_object.respond_to?("dj_serialize_minimal=")
+
+          # enable minimal sereialization on the instancee
+          if is_ar_instance
+            payload_object.object.dj_serialize_minimal = true
+          end
+          
+          enqueue_job(job_options)
+          
+          # disable minimal sereialization on the instancee
+          if is_ar_instance
+            payload_object.object.dj_serialize_minimal = nil
+          end
+        end
+
+      end
+    end
+  end
+end
+

--- a/spec/initializers/delayed_jobs_serialization_spec.rb
+++ b/spec/initializers/delayed_jobs_serialization_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "Delayed::Jobs serialization" do
+
+  it "adds an dj_serialize_minimal attribute to models" do
+    o = Observation.make!
+    expect( o.dj_serialize_minimal ).to be_nil
+    o.dj_serialize_minimal = true
+    expect( o.dj_serialize_minimal ).to be true
+  end
+
+  it "serializes only primary key when dj_serialize_minimal is set" do
+    o = Observation.make!
+    expect( YAML.load( o.to_yaml ).attributes.length ).to be > 30
+    o.dj_serialize_minimal = true
+    expect( YAML.load( o.to_yaml ).attributes.length ).to be 1
+  end
+
+end


### PR DESCRIPTION
only serialize model primary keys to reduce handler size, since all Delayed Jobs needs is the primary key