### PR TITLE
Captive layer

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -1120,6 +1120,7 @@ google.maps.Map.prototype.addObservationsLayer = function(title, options) {
       gridmaxzoom = options.gridmaxzoom || 9;
   options.title = title;
   options.tile_size = 512;
+  options.color = options.color || "#FF4500"; // default the points to the same color as the grid
   if( options.taxon ) { options.taxon_id = options.taxon.id; }
   // using a less generic name for the elasticmaps param to not show
   // an observation on a tile, because we have a Google marker for it

--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -777,16 +777,16 @@ iNaturalist.OverlayControl.prototype.addWindshaftOverlayControl = function( laye
   legendLeft.append( checkbox );
   var legendRight = $( "<div class='legend-right' />" );
   legendRight.append( label );
-  // // Append an element to show the color of this layer in the legend. Note the
-  // // legend color can be specified independently of the layer color with
-  // // legendColor, otherwise it defaults to color
-  // var legendColor = options.legendColor || options.color;
-  // if ( legendColor ) {
-  //   li.addClass( "with-legend-mark" );
-  //   legendLeft.append(
-  //     $( "<div class='legend-mark' />" ).css( { backgroundColor: legendColor } )
-  //   );
-  // }
+  // Append an element to show the color of this layer in the legend. Note the
+  // legend color can be specified independently of the layer color with
+  // legendColor, otherwise it defaults to color
+  var legendColor = options.legendColor || options.color;
+  if ( legendColor ) {
+    li.addClass( "with-legend-mark" );
+    legendLeft.append(
+      $( "<div class='legend-mark' />" ).css( { backgroundColor: legendColor } )
+    );
+  }
   li.append( legendLeft, legendRight );
   if( options.endpoint === "gbif" && options.gbif_id ) {
      label.append(

--- a/app/webpack/taxa/show/components/taxon_page_map.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_map.jsx
@@ -49,25 +49,25 @@ const TaxonPageMap = ( {
           observationLayers: [
             {
               label: I18n.t( "verifiable_observations" ),
-              verifiable: true
-              // legendColor: COLORS.orange
+              verifiable: true,
+              legendColor: COLORS.orange
             },
             {
               label: I18n.t( "observations_without_media" ),
               verifiable: false,
               captive: false,
-              // color: COLORS.maroon,
+              color: COLORS.maroon,
               disabled: !currentUserPrefersMedialessObs,
               onChange: e => updateCurrentUser( { prefers_medialess_obs_maps: e.target.checked } )
+            },
+            {
+              label: I18n.t( "captive_cultivated" ),
+              verifiable: false,
+              captive: true,
+              color: COLORS.blue,
+              disabled: !currentUserPrefersCaptiveObs,
+              onChange: e => updateCurrentUser( { prefers_captive_obs_maps: e.target.checked } )
             }
-            // {
-            //   label: I18n.t( "captive_cultivated" ),
-            //   verifiable: false,
-            //   captive: true,
-            //   color: COLORS.blue,
-            //   disabled: !currentUserPrefersCaptiveObs,
-            //   onChange: e => updateCurrentUser( { prefers_captive_obs_maps: e.target.checked } )
-            // }
           ],
           gbif: { disabled: true },
           places: true,

--- a/app/webpack/taxa/show/components/taxon_page_map.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_map.jsx
@@ -49,8 +49,7 @@ const TaxonPageMap = ( {
           observationLayers: [
             {
               label: I18n.t( "verifiable_observations" ),
-              verifiable: true,
-              legendColor: COLORS.orange
+              verifiable: true
             },
             {
               label: I18n.t( "observations_without_media" ),


### PR DESCRIPTION
Adds a layer of captive obs to the taxon page map. Also

* layer colors in the legend
* uses default orange color for obs points as well as the grid, instead of switching to iconic taxon color for points

@pleary, one question I have before merging: would it be preferable to make the change to point colors in the API? Not sure which is better re: tile caching.