### PR TITLE
Use the API for common quick count requests

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -317,7 +317,6 @@ $(document).ready(function() {
       $( "#messagessubnav" ).load( "/messages/new_messages", function( data ) {
         $( this ).html( data );
         $( "#messagessubnav" ).data( "loaded", true );
-        setMessagesCount( 0, { skipAnimation: true } );
       } );
     }
   } );
@@ -1016,6 +1015,21 @@ function getMessagesCount() {
   $.getJSON('/messages/count.json', function(data) {
     setMessagesCount(data.count)
   })
+}
+
+function getHeaderCounts() {
+  var apiToken = $( "meta[name='inaturalist-api-token']" ).attr( "content" );
+  $.ajax({
+    url: "<%= CONFIG.node_api_url %>/users/notification_counts",
+    headers: {
+      Authorization: apiToken
+    },
+    success: function( data ) {
+      setUpdatesCount( data.updates_count );
+      setMessagesCount( data.messages_count );
+    }
+  });
+
 }
 
 $.fn.subscriptionSettings = function() {

--- a/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
@@ -259,7 +259,7 @@ inatTaxonMap.addTaxonLayers = function( map, options ) {
     if ( map.taxonLayerSignatures[sig] ) {
       return;
     }
-    $.getJSON( "/taxa/" + layer.taxon.id + "/map_layers", function( taxonData ) {
+    $.getJSON( "<%= CONFIG.node_api_url %>/taxa/" + layer.taxon.id + "/map_layers", function( taxonData ) {
       inatTaxonMap.addTaxonLayer( map, layer, options, taxonData );
     });
   });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -117,9 +117,8 @@
   <% if logged_in? -%>
     <script type="text/javascript" charset="utf-8">
       setUpdatesCount(<%= session[:updates_count].to_i %>)
-      setTimeout(getUpdatesCount, 1000)
       setMessagesCount(<%= session[:messages_count].to_i %>)
-      setTimeout(getMessagesCount, 1000)
+      setTimeout( getHeaderCounts, 1000 )
     </script>
   <% end -%>
   <script type="text/javascript">

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -201,9 +201,8 @@
     <% if logged_in? && !@minimal_header -%>
       <script type="text/javascript" charset="utf-8">
         setUpdatesCount(<%= session[:updates_count].to_i %>)
-        setTimeout(getUpdatesCount, 1000)
         setMessagesCount(<%= session[:messages_count].to_i %>)
-        setTimeout(getMessagesCount, 1000)
+        setTimeout( getHeaderCounts, 1000 )
       </script>
     <% end -%>
   </body>


### PR DESCRIPTION
Modifies how we fetch message and notification counts for the header for logged-in users. The two have been combined into one endpoint implemented in the node API

The taxa/map_layers endpoint has also been moved to the node API and JS updated accordingly here.

These three endpoints account for nearly 30% of all Rails requests. They are all currently relatively fast, and might see some small performance improvements when moved to node, particularly with two of them combined into one call. But the main benefit will be getting these common requests out of the Rails Passenger queues and into node/express.js