### PR TITLE
Limit photos uploaded or combined in upload to observations

### DIFF
--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -16218,6 +16218,7 @@ I18n.translations["en"] = {
   "observations": "Observations",
   "observations_": "observations",
   "observations_annotated_with_annotation": "Observations annotated with %{annotation}",
+  "observations_can_only_have_n_photos": "Observations can only have %{limit} photos. To add more you will need to remove some.",
   "observations_by_category": "Observations By category",
   "observations_in_this_project_must": "Observations in this project must meet the following criteria",
   "observations_map": "Observations / Map",

--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -16218,7 +16218,7 @@ I18n.translations["en"] = {
   "observations": "Observations",
   "observations_": "observations",
   "observations_annotated_with_annotation": "Observations annotated with %{annotation}",
-  "observations_can_only_have_n_photos": "Observations can only have %{limit} photos. To add more you will need to remove some.",
+  "observations_can_only_have_n_photos": "Observations can only have %{limit} photos and %{limit} sounds. To add more you will need to remove some.",
   "observations_by_category": "Observations By category",
   "observations_in_this_project_must": "Observations in this project must meet the following criteria",
   "observations_map": "Observations / Map",

--- a/app/webpack/observations/uploader/actions/actions.js
+++ b/app/webpack/observations/uploader/actions/actions.js
@@ -398,7 +398,7 @@ const actions = class actions {
   static movePhoto( photo, toObsCard ) {
     return function ( dispatch ) {
       const { photos: targetPhotos, sounds: targetSounds } = actions.fileCounts( toObsCard.files );
-      const { photos: movedPhotos, sounds: movedSounds } = actions.fileCounts( [photo.file.file] );
+      const { photos: movedPhotos, sounds: movedSounds } = actions.fileCounts( [photo.file] );
       if ( !dispatch( actions.enforceLimit( movedPhotos, targetPhotos ) ) ) { return; }
       if ( !dispatch( actions.enforceLimit( movedSounds, targetSounds ) ) ) { return; }
       const time = new Date( ).getTime( );


### PR DESCRIPTION
#2623 

This should handle file limits for drag and drop, combine cards, and move a single photo from one card to another.

Let me know if I've missed any other ways these might exceed the limit.