### PR TITLE
2688 checklist export with user locale

### DIFF
--- a/app/controllers/shared/lists_module.rb
+++ b/app/controllers/shared/lists_module.rb
@@ -125,19 +125,19 @@ module Shared::ListsModule
             render :status => :accepted, :text => "This file takes a little while to generate.  It should be ready shortly at #{request.url}"
           end
         else
-          job_id = Rails.cache.read(@list.generate_csv_cache_key(:view => @view))
+          job_id = Rails.cache.read(@list.generate_csv_cache_key(view: @view, user_id: current_user.id))
           job = Delayed::Job.find_by_id(job_id)
           if job
             # Still working
           else
             # no job id, no job, let's get this party started
-            Rails.cache.delete(@list.generate_csv_cache_key(:view => @view))
+            Rails.cache.delete(@list.generate_csv_cache_key(view: @view, user_id: current_user.id))
             job = if @view == "taxonomic"
               @list.delay(:priority => NOTIFICATION_PRIORITY).generate_csv(:path => path_for_taxonomic_csv, :taxonomic => true)
             else
               @list.delay(:priority => NOTIFICATION_PRIORITY).generate_csv(:path => path_for_normal_csv)
             end
-            Rails.cache.write(@list.generate_csv_cache_key(:view => @view), job.id, :expires_in => 1.hour)
+            Rails.cache.write(@list.generate_csv_cache_key(view: @view, user_id: current_user.id), job.id, :expires_in => 1.hour)
           end
           prevent_caching
           render :status => :accepted, :text => "This file takes a little while to generate.  It should be ready shortly at #{request.url}"

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -228,7 +228,7 @@ class List < ActiveRecord::Base
   end
   
   def generate_csv_cache_key(options = {})
-    key = (options[:view] = "taxonomic") ? "generate_csv_taxonomic_#{id}" : "generate_csv_#{id}"
+    key = (options[:view] == "taxonomic") ? "generate_csv_taxonomic_#{id}" : "generate_csv_#{id}"
     key << "_#{options[:user_id]}" if options[:user_id]
     key
   end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -228,11 +228,9 @@ class List < ActiveRecord::Base
   end
   
   def generate_csv_cache_key(options = {})
-    if options[:view] = "taxonomic"
-      "generate_csv_taxonomic_#{id}"
-    else
-      "generate_csv_#{id}"
-    end
+    key = (options[:view] = "taxonomic") ? "generate_csv_taxonomic_#{id}" : "generate_csv_#{id}"
+    key << "_#{options[:user_id]}" if options[:user_id]
+    key
   end
 
   def is_a_users_default_lifelist?


### PR DESCRIPTION
#2688
This would be the proposed fix should you feel ok with adding additional (short-lived) cache keys for csv exports.

Also fixes a small issue in `generate_csv_cache_key`:

```ruby
if options[:view] = "taxonomic"
```
I don't think this should be assignment, but rather comparison operator.