### PR TITLE
Clarifying description of taxon swap, per issue 2276

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -764,7 +764,7 @@ en:
   change_descriptions:
       split: Old taxon split into multiple new taxa
       merge: Several old taxa lumped into one new taxon
-      swap: 1-to-1 name change
+      swap: Replace input taxon with output taxon
       drop: Taxon concept completely invalid, maintained for historical purposes or partner compatibility
       stage: Prepare an inactive concept for release as part of a change group
   change_geoprivacy: 'Change geoprivacy'


### PR DESCRIPTION
Changing the description of taxon swap from "1-to-1 name change" to "Replace input taxon with output taxon".