### PR TITLE
Attempts to improve og tags on obs search

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1026,6 +1026,14 @@ class Place < ActiveRecord::Base
     end
   end
 
+  def localized_name
+    if admin_level === COUNTRY_LEVEL
+      I18n.t( "places_name.#{name}", default: display_name )
+    else
+      display_name
+    end
+  end
+
   def self.param_to_array(places)
     if places.is_a?(Place)
       # single places become arrays

--- a/app/views/observations/index.html.haml
+++ b/app/views/observations/index.html.haml
@@ -1,5 +1,5 @@
 - content_for :title do
-  =t :observations
+  = @shareable_title = t(:observations)
 - content_for :extrajs do
   = javascript_include_tag "angular_includes_bundle"
   = javascript_include_tag "angular_bundle"
@@ -17,6 +17,8 @@
   = stylesheet_link_tag "observations/search"
 - content_for :extrahead do
   %base{ href: observations_path }
+  %meta{ property: "og:title", content: @shareable_title }
+  %meta{ property: "og:description", content: html_attributize( @shareable_description ) }
 #main-container{ "ng-app": "ObservationSearch", "ng-controller": "SearchController" }
   .container.container-fixed
     .row.form


### PR DESCRIPTION
This attempts to improve the Open Graph tags we include at https://www.inaturalist.org/observations with some customization based on the search parameters. That requires loading some data in Rails, which might be too much of a performance burden to bear, hence the PR for review. If we don't want to do that, we can show the generic site description as the `og:description` instead.