### PR TITLE
Add mousetrap bindings for bold, italics, and links in TextEditor

### DIFF
--- a/app/webpack/shared/components/text_editor.jsx
+++ b/app/webpack/shared/components/text_editor.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import mousetrap from "mousetrap";
 import TextEditorFormatButton from "./text_editor_format_button";
 import UserText from "./user_text";
 
@@ -17,9 +18,18 @@ class TextEditor extends React.Component {
   }
 
   componentDidMount( ) {
-    Mousetrap( this.textarea.current ).bind( 'mod+b', ( ) => { this.boldButton.button.current.click( ); } );
-    Mousetrap( this.textarea.current ).bind( 'mod+i', ( ) => { this.italicButton.button.current.click( ); } );
-    Mousetrap( this.textarea.current ).bind( 'mod+k', ( ) => { this.linkButton.button.current.click( ); } );
+    mousetrap( this.textarea.current ).bind( "mod+b", e => {
+      e.preventDefault();
+      this.boldButton.button.current.click( );
+    } );
+    mousetrap( this.textarea.current ).bind( "mod+i", e => {
+      e.preventDefault();
+      this.italicButton.button.current.click( );
+    } );
+    mousetrap( this.textarea.current ).bind( "mod+k", e => {
+      e.preventDefault();
+      this.linkButton.button.current.click( );
+    } );
   }
 
   render( ) {
@@ -52,7 +62,7 @@ class TextEditor extends React.Component {
                 label={<i className="fa fa-bold" />}
                 template={text => `**${text}**`}
                 placeholder={I18n.t( "bold_text" )}
-                ref={(button) => {this.boldButton = button;}}
+                ref={button => { this.boldButton = button; }}
                 newSelectionOffset={2}
                 newSelectionOffsetLength={textLength => textLength}
                 disabled={preview}
@@ -64,7 +74,7 @@ class TextEditor extends React.Component {
                 label={<i className="fa fa-italic" />}
                 template={text => `*${text}*`}
                 placeholder={I18n.t( "italic_text" )}
-                ref={(button) => {this.italicButton = button;}}
+                ref={button => { this.italicButton = button; }}
                 newSelectionOffset={1}
                 newSelectionOffsetLength={textLength => textLength}
                 disabled={preview}
@@ -76,7 +86,7 @@ class TextEditor extends React.Component {
                 label={<i className="icon-link" />}
                 template={text => `[${text}](url)`}
                 placeholder={I18n.t( "linked_text" )}
-                ref={(button) => {this.linkButton = button}}
+                ref={button => { this.linkButton = button; }}
                 newSelectionOffset={textLength => textLength + 3}
                 newSelectionOffsetLength={3}
                 disabled={preview}

--- a/app/webpack/shared/components/text_editor.jsx
+++ b/app/webpack/shared/components/text_editor.jsx
@@ -7,10 +7,19 @@ class TextEditor extends React.Component {
   constructor( props, context ) {
     super( props, context );
     this.textarea = React.createRef();
+    this.boldButton = React.createRef();
+    this.italicButton = React.createRef();
+    this.linkButton = React.createRef();
     this.state = {
       textareaChars: 0,
       preview: false
     };
+  }
+
+  componentDidMount( ) {
+    Mousetrap( this.textarea.current ).bind( 'mod+b', ( ) => { this.boldButton.button.current.click( ); } );
+    Mousetrap( this.textarea.current ).bind( 'mod+i', ( ) => { this.italicButton.button.current.click( ); } );
+    Mousetrap( this.textarea.current ).bind( 'mod+k', ( ) => { this.linkButton.button.current.click( ); } );
   }
 
   render( ) {
@@ -43,6 +52,7 @@ class TextEditor extends React.Component {
                 label={<i className="fa fa-bold" />}
                 template={text => `**${text}**`}
                 placeholder={I18n.t( "bold_text" )}
+                ref={(button) => {this.boldButton = button;}}
                 newSelectionOffset={2}
                 newSelectionOffsetLength={textLength => textLength}
                 disabled={preview}
@@ -54,6 +64,7 @@ class TextEditor extends React.Component {
                 label={<i className="fa fa-italic" />}
                 template={text => `*${text}*`}
                 placeholder={I18n.t( "italic_text" )}
+                ref={(button) => {this.italicButton = button;}}
                 newSelectionOffset={1}
                 newSelectionOffsetLength={textLength => textLength}
                 disabled={preview}
@@ -65,6 +76,7 @@ class TextEditor extends React.Component {
                 label={<i className="icon-link" />}
                 template={text => `[${text}](url)`}
                 placeholder={I18n.t( "linked_text" )}
+                ref={(button) => {this.linkButton = button}}
                 newSelectionOffset={textLength => textLength + 3}
                 newSelectionOffsetLength={3}
                 disabled={preview}

--- a/app/webpack/shared/components/text_editor_format_button.jsx
+++ b/app/webpack/shared/components/text_editor_format_button.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 
 class TextEditorFormatButton extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+  constructor( props, context ) {
+    super( props, context );
     this.button = React.createRef();
-  };
+  }
 
   render( ) {
     const {
@@ -28,29 +28,29 @@ class TextEditorFormatButton extends React.Component {
         title={tip}
         aria-label={tip}
         ref={this.button}
-        onClick={() => {
-          const {selectionStart} = textarea;
-          if (textarea.selectionStart !== undefined && textarea.selectionEnd !== undefined) {
+        onClick={( ) => {
+          const { selectionStart } = textarea;
+          if ( textarea.selectionStart !== undefined && textarea.selectionEnd !== undefined ) {
             let selection = textarea.value.substring(
               textarea.selectionStart,
               textarea.selectionEnd
             );
-            if (selection.length === 0 && placeholder) {
+            if ( selection.length === 0 && placeholder ) {
               selection = placeholder;
             }
             const selectionWithMarkup = template(
               selection,
-              textarea.value.substring(0, textarea.selectionStart)
+              textarea.value.substring( 0, textarea.selectionStart )
             );
-            const newSelectionOffsetVal = typeof (newSelectionOffset) === "function"
-              ? newSelectionOffset(selection.length)
+            const newSelectionOffsetVal = typeof ( newSelectionOffset ) === "function"
+              ? newSelectionOffset( selection.length )
               : newSelectionOffset;
-            const newSelectionOffsetLengthVal = typeof (newSelectionOffsetLength) === "function"
-              ? newSelectionOffsetLength(selection.length)
+            const newSelectionOffsetLengthVal = typeof ( newSelectionOffsetLength ) === "function"
+              ? newSelectionOffsetLength( selection.length )
               : newSelectionOffsetLength;
-            textarea.value = textarea.value.substring(0, textarea.selectionStart)
+            textarea.value = textarea.value.substring( 0, textarea.selectionStart )
               + selectionWithMarkup
-              + textarea.value.substring(textarea.selectionEnd, textarea.value.length);
+              + textarea.value.substring( textarea.selectionEnd, textarea.value.length );
             const rangeStart = selectionStart + newSelectionOffsetVal;
             const rangeEnd = selectionStart
               + newSelectionOffsetVal
@@ -59,7 +59,7 @@ class TextEditorFormatButton extends React.Component {
                   ? selectionWithMarkup.length
                   : newSelectionOffsetLengthVal
               );
-            textarea.setSelectionRange(rangeStart, rangeEnd);
+            textarea.setSelectionRange( rangeStart, rangeEnd );
           }
           textarea.focus();
         }}
@@ -67,7 +67,7 @@ class TextEditorFormatButton extends React.Component {
         {label}
       </button>
     );
-  };
+  }
 }
 
 TextEditorFormatButton.propTypes = {

--- a/app/webpack/shared/components/text_editor_format_button.jsx
+++ b/app/webpack/shared/components/text_editor_format_button.jsx
@@ -1,63 +1,74 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const TextEditorFormatButton = ( {
-  textarea,
-  label,
-  template,
-  className,
-  newSelectionOffset,
-  newSelectionOffsetLength,
-  disabled,
-  placeholder,
-  tip
-} ) => (
-  <button
-    type="button"
-    tabIndex="-1"
-    className={className}
-    disabled={disabled}
-    title={tip}
-    aria-label={tip}
-    onClick={( ) => {
-      const { selectionStart } = textarea;
-      if ( textarea.selectionStart !== undefined && textarea.selectionEnd !== undefined ) {
-        let selection = textarea.value.substring(
-          textarea.selectionStart,
-          textarea.selectionEnd
-        );
-        if ( selection.length === 0 && placeholder ) {
-          selection = placeholder;
-        }
-        const selectionWithMarkup = template(
-          selection,
-          textarea.value.substring( 0, textarea.selectionStart )
-        );
-        const newSelectionOffsetVal = typeof ( newSelectionOffset ) === "function"
-          ? newSelectionOffset( selection.length )
-          : newSelectionOffset;
-        const newSelectionOffsetLengthVal = typeof ( newSelectionOffsetLength ) === "function"
-          ? newSelectionOffsetLength( selection.length )
-          : newSelectionOffsetLength;
-        textarea.value = textarea.value.substring( 0, textarea.selectionStart )
-          + selectionWithMarkup
-          + textarea.value.substring( textarea.selectionEnd, textarea.value.length );
-        const rangeStart = selectionStart + newSelectionOffsetVal;
-        const rangeEnd = selectionStart
-          + newSelectionOffsetVal
-          + (
-            newSelectionOffsetLengthVal === undefined
-              ? selectionWithMarkup.length
-              : newSelectionOffsetLengthVal
-          );
-        textarea.setSelectionRange( rangeStart, rangeEnd );
-      }
-      textarea.focus( );
-    }}
-  >
-    { label }
-  </button>
-);
+class TextEditorFormatButton extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.button = React.createRef();
+  };
+
+  render( ) {
+    const {
+      textarea,
+      label,
+      template,
+      className,
+      newSelectionOffset,
+      newSelectionOffsetLength,
+      disabled,
+      placeholder,
+      tip
+    } = this.props;
+    return (
+      <button
+        type="button"
+        tabIndex="-1"
+        className={className}
+        disabled={disabled}
+        title={tip}
+        aria-label={tip}
+        ref={this.button}
+        onClick={() => {
+          const {selectionStart} = textarea;
+          if (textarea.selectionStart !== undefined && textarea.selectionEnd !== undefined) {
+            let selection = textarea.value.substring(
+              textarea.selectionStart,
+              textarea.selectionEnd
+            );
+            if (selection.length === 0 && placeholder) {
+              selection = placeholder;
+            }
+            const selectionWithMarkup = template(
+              selection,
+              textarea.value.substring(0, textarea.selectionStart)
+            );
+            const newSelectionOffsetVal = typeof (newSelectionOffset) === "function"
+              ? newSelectionOffset(selection.length)
+              : newSelectionOffset;
+            const newSelectionOffsetLengthVal = typeof (newSelectionOffsetLength) === "function"
+              ? newSelectionOffsetLength(selection.length)
+              : newSelectionOffsetLength;
+            textarea.value = textarea.value.substring(0, textarea.selectionStart)
+              + selectionWithMarkup
+              + textarea.value.substring(textarea.selectionEnd, textarea.value.length);
+            const rangeStart = selectionStart + newSelectionOffsetVal;
+            const rangeEnd = selectionStart
+              + newSelectionOffsetVal
+              + (
+                newSelectionOffsetLengthVal === undefined
+                  ? selectionWithMarkup.length
+                  : newSelectionOffsetLengthVal
+              );
+            textarea.setSelectionRange(rangeStart, rangeEnd);
+          }
+          textarea.focus();
+        }}
+      >
+        {label}
+      </button>
+    );
+  };
+}
 
 TextEditorFormatButton.propTypes = {
   textarea: PropTypes.object.isRequired,


### PR DESCRIPTION
#2722 

This adds mousetrap bindings for bold, italics, and links in the `TextEditor` component. The use of refs required converting `TextEditorFormatButton` from a functional component. 

Additionally, this can't really be handled in the `keyboard_shortcuts.js` file as we need to bind to an element rendered by the component rather than the default `document`. 

I'm not 100% certain this is the cleanest approach, but it seems to click-test well. Open to any suggestions to make it more idiomatic.