### PR TITLE
Add TOS checkbox to signup

### DIFF
--- a/app/views/users/registrations/_form.html.haml
+++ b/app/views/users/registrations/_form.html.haml
@@ -52,5 +52,11 @@
         =t :pi_consent_label
       %a{ href: "#", onclick: "return false;", data: { toggle: "popover", content: t(:pi_consent_desc_html, privacy_url: privacy_policy_url, terms_url: terms_of_service_url ), placement: "top" }, title: t(:pi_consent_desc_title) }
         =t :learn_more
+#tos-privacy-guidelines.form-group.checkbox
+  %label
+    -# TOS, Privacy, and Guideline review exists outside of builder as this information is not being audited
+    = check_box_tag :tos_privacy_guidelines, 1, false, required: true
+    %span
+      = raw t :tos_privacy_guidelines_label
 .form-group.hidden
   = f.select :time_zone, ActiveSupport::TimeZone.all.sort.map{|tz| [tz.to_s, tz.name, { "data-tz-name": tz.tzinfo.name } ]}, { include_blank: true }, { class: "time_zone_select" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4149,6 +4149,7 @@ en:
   top_observer: Top Observer
   top_observers: Top Observers
   top_species: Top Species
+  tos_privacy_guidelines_label: I agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>, and I have reviewed the <a href="/pages/community+guidelines">Community Guidelines</a>.
   total: Total
   totals: Totals
   total_members: Total members
@@ -4556,8 +4557,8 @@ en:
   'yes': "Yes"
   yes_find_them!: "Yes, find them!"
   yes_i_want_to_join: Yes, I want to join
-  yes_license_my_childs_observations: Yes, license my child's photos, sounds, and observations so scientists can use the data.
-  yes_license_my_observations_so_scientists_can_use: Yes, license my photos, sounds, and observations so scientists can use my data.
+  yes_license_my_childs_observations: Yes, license my child's photos, sounds, and observations so scientists can use the data (recommended).
+  yes_license_my_observations_so_scientists_can_use: Yes, license my photos, sounds, and observations so scientists can use my data (recommended).
   yes_reject_it: Yes, reject it
   yes_show_this_in_the_box: Yes, show this in the big box at the top of /taxa
   yesterday: Yesterday


### PR DESCRIPTION
#2745 

Pretty straightforward addition. Only one thing to note: ToS, PP, and CG are not being audited the same way GDPR compliance is (and I don't imagine it necessarily needs to be, but let me know if it does) and therefore this is outside of the form-builder as well as missing any backend validation. 

Although it would be kind of ridiculous you could, say, edit the DOM and submit the form to create a user without actually checking the box. However, unlike the compliance around GDPR there is the explicit:

> By accessing or using any part of the Website, each user ("You", "Your" or "User") agrees to the terms and conditions of this Agreement.

so I don't really see a problem with this.

Maybe you can check it out if you have the time @pleary? If not, I'm sure kueda can upon returning.

![tos-pp-cg](https://user-images.githubusercontent.com/19367605/88469652-eb4e2b00-cec1-11ea-8808-3c3b5aad5eef.png)

