### PR TITLE
Modify path for cancel button when new observation is a result of dup

### DIFF
--- a/app/views/observations/new.html.erb
+++ b/app/views/observations/new.html.erb
@@ -98,7 +98,7 @@
       <%= submit_tag(t(:save_observation), :class => 'default button', "data-loading-click" => true) %>
       <%= submit_tag t(:save_and_add_another), :class => 'button', :style => "display:none", :id => "add_another_button" %>
       <%= link_to_function t(:save_and_add_another), "$('#add_another_button').click()", :class => "button" %>
-      <%= link_to(t(:cancel), session[:return_to], :class => 'button') %>
+      <%= link_to(t(:cancel), params[:copy] ? observation_path(params[:copy]) : session[:return_to], :class => 'button') %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
#2765 

Changes "Cancel" button to consistently return to original observation if duplicating.