### PR TITLE
Prevent disagreeing with non-current identifications

### DIFF
--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -195,6 +195,12 @@ class Identification < ActiveRecord::Base
       return true
     end
 
+    # Can't disagree if no current identifications
+    if observation.identifications.current.empty?
+      self.disagreement = nil
+      return true
+    end
+
     # Can't disagree when suggesting an ungrafted taxon
     if !taxon.grafted? && !taxon.children.exists?
       self.disagreement = nil

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -121,6 +121,7 @@ class Identification < ActiveRecord::Base
     c[0] = "taxa.id = #{taxon.id} OR #{c[0]}"
     joins(:taxon).where(c)
   }
+  scope :older_than, -> (date) { where("created_at < ?", date) }
   scope :on, lambda {|date| where(Identification.conditions_for_date("identifications.created_at", date)) }
   scope :current, -> { where(:current => true) }
   scope :outdated, -> { where(:current => false) }
@@ -179,8 +180,8 @@ class Identification < ActiveRecord::Base
     end
     unless previous_observation_taxon_id
       working_created_at = created_at || Time.now
-      previous_ident = observation.identifications.select{|i| i.persisted? && i.current && i.created_at < working_created_at }.last
-      previous_ident ||= observation.identifications.select{|i| i.persisted? && i.created_at < working_created_at }.last
+      previous_ident = observation.identifications.by(user_id).older_than(working_created_at).current.select(&:persisted?).last
+      previous_ident ||= observation.identifications.by(user_id).older_than(working_created_at).select(&:persisted?).last
       self.previous_observation_taxon_id = previous_ident.try(:taxon_id) || observation.taxon_id
     end
     true

--- a/spec/models/identification_spec.rb
+++ b/spec/models/identification_spec.rb
@@ -1047,7 +1047,7 @@ describe Identification, "disagreement" do
     expect( i ).not_to be_disagreement
   end
   it "should not be automatically set to true if no other identifications are current" do
-    o = make_research_grade_candidate_observation
+    o = Identification.make!( current: false ).observation
     Identification.make!( observation: o, taxon: @Calypte_anna )
     o.identifications.each { |i| i.update( current: false ) }
     i = Identification.make!( observation: o, taxon: @Pseudacris_regilla )

--- a/spec/models/identification_spec.rb
+++ b/spec/models/identification_spec.rb
@@ -1046,6 +1046,13 @@ describe Identification, "disagreement" do
     i.reload
     expect( i ).not_to be_disagreement
   end
+  it "should not be automatically set to true if no other identifications are current" do
+    o = make_research_grade_candidate_observation
+    Identification.make!( observation: o, taxon: @Calypte_anna )
+    o.identifications.each { |i| i.update( current: false ) }
+    i = Identification.make!( observation: o, taxon: @Pseudacris_regilla )
+    expect( i ).not_to be_disagreement
+  end
 
   describe "implicit disagreement" do
     it "should set disagreement to true" do


### PR DESCRIPTION
#2751 

Fixes first issue
> An identification added to an observation without any current identifications should not be a disagreement