### PR TITLE
Add validations for custom lexicon for taxon names

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7429,9 +7429,6 @@ en:
                 should be in English, but currently it matches the %{suggested_locale} translation of "%{suggested}".
                 Use "%{suggested}" if that is what you meant and it will be translated when you view the site in
                 that language.
-              should_only_contain_latin_script: |
-                should only contain Latin characters, punctuation, and spaces.
-                The following characters are not permitted: "%{problem_chars}".
             name:
               cannot_match_the_scientific_name_of_a_species_for_this_lexicon: |
                 cannot match the scientific name of a species for this lexicon

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7425,6 +7425,10 @@ en:
           attributes:
             lexicon:
               should_not_contain_commas_or_slashes: should not contain commas or slashes
+              should_match_english_translation: should match English translation, did you mean "%{suggested}"?
+              should_only_contain_latin_script: |
+                should only contain Latin characters, punctuation, and spaces.
+                The following characters are not permitted: "%{problem_chars}".
             name:
               cannot_match_the_scientific_name_of_a_species_for_this_lexicon: |
                 cannot match the scientific name of a species for this lexicon

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7425,7 +7425,10 @@ en:
           attributes:
             lexicon:
               should_not_contain_commas_or_slashes: should not contain commas or slashes
-              should_match_english_translation: should match English translation, did you mean "%{suggested}"?
+              should_match_english_translation: |
+                should be in English, but currently it matches the %{suggested_locale} translation of "%{suggested}".
+                Use "%{suggested}" if that is what you meant and it will be translated when you view the site in
+                that language.
               should_only_contain_latin_script: |
                 should only contain Latin characters, punctuation, and spaces.
                 The following characters are not permitted: "%{problem_chars}".


### PR DESCRIPTION
What do you think of this @kueda for checking off a few boxes from #2675?

The first validation will check and recommend the English name for any lexicon we have a translation for.

The second validation will restrict custom lexicon names to the latin character set plus punctuation, spaces, and right now digits. Since these should all be English, we shouldn't allow other character sets through. Let me know if you want to tweak the regex though.

So before jumping further into the list on the path to cleaning up the data, I'd like to know what db constraints, indexes, etc. might be introduced non-disruptively and what kind of real data we will be looking at. In order to do so I was wondering if it would be possible to get an export of select columns (`name`, `lexicon`, and `taxon_id` and possibly `source` and `position`)? Or, since the table doesn't seem to be sensitive in nature, everything but the with the `creator_id` and `updater_id` scrubbed. If not for either data or logistic reasons, I would completely understand.