### PR TITLE
Add parameterized lexicon to taxon_name

### DIFF
--- a/app/models/taxon_name.rb
+++ b/app/models/taxon_name.rb
@@ -9,7 +9,7 @@ class TaxonName < ActiveRecord::Base
   has_many :places, :through => :place_taxon_names
   validates_presence_of :taxon
   validates_length_of :name, :within => 1..256, :allow_blank => false
-  validates_uniqueness_of :name, scope: %i[parameterized_lexicon taxon_id], message: :already_exists
+  validates_uniqueness_of :name, scope: %i[parameterized_lexicon taxon_id], message: :already_exists, case_sensitive: false
   validates_format_of :lexicon, with: /\A[^\/,]+\z/, message: :should_not_contain_commas_or_slashes, allow_blank: true
   validate :species_common_name_cannot_match_taxon_name
   validate :valid_scientific_name_must_match_taxon_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7429,7 +7429,9 @@ en:
                 should be in English, but currently it matches the %{suggested_locale} translation of "%{suggested}".
                 Use "%{suggested}" if that is what you meant and it will be translated when you view the site in
                 that language.
+              should_be_in_english: should be in English
             name:
+              already_exists: already exists for this taxon in this lexicon
               cannot_match_the_scientific_name_of_a_species_for_this_lexicon: |
                 cannot match the scientific name of a species for this lexicon
               must_match_the_taxon_if_valid: |

--- a/db/migrate/20200824210059_add_parameterized_lexicon_to_taxon_names.rb
+++ b/db/migrate/20200824210059_add_parameterized_lexicon_to_taxon_names.rb
@@ -1,0 +1,16 @@
+class AddParameterizedLexiconToTaxonNames < ActiveRecord::Migration
+  def up
+    add_column :taxon_names, :parameterized_lexicon, :string
+    
+    # Backfill Parameterized Lexicon
+    TaxonName.uniq.where.not(lexicon: nil).pluck(:lexicon).each do |l|
+      next unless l.parameterize.present?
+
+      TaxonName.where(lexicon: l).update_all(parameterized_lexicon: l.parameterize)
+    end
+  end
+  
+  def down
+    remove_column :taxon_names, :parameterized_lexicon
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4428,7 +4428,8 @@ CREATE TABLE public.taxon_names (
     name_provider character varying(255),
     creator_id integer,
     updater_id integer,
-    "position" integer DEFAULT 0
+    "position" integer DEFAULT 0,
+    parameterized_lexicon character varying
 );
 
 
@@ -10246,4 +10247,6 @@ INSERT INTO schema_migrations (version) VALUES ('20200708223315');
 INSERT INTO schema_migrations (version) VALUES ('20200710004607');
 
 INSERT INTO schema_migrations (version) VALUES ('20200710004608');
+
+INSERT INTO schema_migrations (version) VALUES ('20200824210059');
 

--- a/spec/models/taxon_name_spec.rb
+++ b/spec/models/taxon_name_spec.rb
@@ -80,9 +80,14 @@ describe TaxonName, 'creation' do
   end
 
   it "should not be valid with a non-English translation of a lexicon" do
-    tn = TaxonName.make(lexicon: "简体中文", name: "common")
+    tn = TaxonName.make(lexicon: I18n.with_locale(:"zh-CN") { I18n.t("lexicons.finnish") }, name: "common")
     expect(tn).to_not be_valid
-    expect(tn.errors.messages[:lexicon].count).to eq 2
+    expect(tn.errors.messages[:lexicon]).to include(
+      I18n.t("activerecord.errors.models.taxon_name.attributes.lexicon.should_match_english_translation", 
+             suggested: I18n.with_locale(:en) { I18n.t("lexicons.finnish") }, 
+             suggested_locale: I18n.t("locales.zh-CN")
+      )
+    )
   end
   
   it "should parameterize and store lexicon" do
@@ -93,7 +98,9 @@ describe TaxonName, 'creation' do
   it "should not parameterize and store lexicon with invalid characters" do
     tn = TaxonName.make(lexicon: "测试", name: "common")
     expect(tn).to_not be_valid
-    expect(tn.errors.messages[:lexicon].count).to eq 1
+    expect(tn.errors.messages[:lexicon]).to include(
+      I18n.t("activerecord.errors.models.taxon_name.attributes.lexicon.should_be_in_english")
+    )
   end
   
   it "should not validate presence of a parameterizable lexicon if lexicon not present" do


### PR DESCRIPTION
#2675

I think this is the next step to reducing lexicon variation as well as duplicate names in the same lexicon.

* The backfilling of `parameterized_lexicon` took 2-3 minutes for me if that needs to be a consideration in your planning on when to run the migration.

* Right now it's tough to put in the index as there are already several, albeit only a small fraction (2964/2M+), records that would violate the composite uniqueness constraint. It looks like most if not all are coming from imports. 

* Also, might be worth reexamining the role of `normalize_lexicon` now that `parameterized_lexicon` exists. I think the former will first change "Chinese (TraDitional)" -> Chinese (Tra Ditional)". With `parameterized_lexicon` this results in "chinese-traditional" and "chinese-tra-ditional". 

* Nil/""/null values still need to be allowed for some edge cases in the imports as well as that currently representing "Unknown" for user submitted taxon_names

Let me know if there are any special considerations I should be aware of for iNat DB migrations, as I believe this will be the first I've contributed.