### PR TITLE
Fluid /observations/:login layout

### DIFF
--- a/app/assets/stylesheets/observations/by_login.scss
+++ b/app/assets/stylesheets/observations/by_login.scss
@@ -1,3 +1,40 @@
+$gutter: 20px;
+#wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  > div {
+    margin: 0 $gutter $gutter;
+  }
+  #pageheader {
+    width: auto;
+    margin-bottom: $gutter / 2;
+    #tools {
+      display: flex;
+      align-items: flex-start;
+      .button, .inter {
+        float: none;
+      }
+      .buttoncontainer {
+        display: flex;
+      }
+    }
+  }
+}
+
+#maincol {
+  display: flex;
+  clear: both;
+  flex-wrap: wrap;
+}
+
+#listcol {
+  flex-basis: 68%;
+  flex-grow: 2;
+  margin-right: $gutter;
+  margin-bottom: $gutter;
+}
+
 .observations.table {
   margin-bottom:2em;
 }
@@ -7,14 +44,10 @@
 .observations.table .observation .icon img.marker {
   cursor:pointer;
 }
-#mapsizectrl {
-  // Temporary,for testing
-  display:none;
-  text-align:right;
-  margin-bottom:0.4em;
-}
 #mapcol {
   min-height:500px;
+  flex-basis: 30%;
+  flex-grow: 1;
 }
 #map {
   height:500px;

--- a/app/assets/stylesheets/observations/by_login.scss
+++ b/app/assets/stylesheets/observations/by_login.scss
@@ -29,7 +29,7 @@ $gutter: 20px;
 }
 
 #listcol {
-  flex-basis: 68%;
+  flex-basis: 65%;
   flex-grow: 2;
   margin-right: $gutter;
   margin-bottom: $gutter;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -712,7 +712,8 @@ module ApplicationHelper
       "control-position" => options[:control_position],
       "map-style" => options[:map_style],
       "elastic_params" => options[:elastic_params] ?
-        options[:elastic_params].map{ |k,v| "#{k}=#{v}" }.join("&") : nil
+        options[:elastic_params].map{ |k,v| "#{k}=#{v}" }.join("&") : nil,
+      "gesture-handling" => options[:gesture_handling]
     }
     append_taxon_layers(map_tag_attrs, options)
     append_place_layers(map_tag_attrs, options)

--- a/app/views/facebook/options.html.erb
+++ b/app/views/facebook/options.html.erb
@@ -40,8 +40,10 @@
     <%= link_to t(:hate_me_facebook, :site_name => @site.name),
       omniauth_disconnect_path('facebook'), :class => 'delete button', :method => 'delete' %>
   <% else %>
-    <%= link_to t(:take_me_facebook), "/auth/facebook", 
-                :onclick => "$('.facebook-button').toggle();", :class => 'facebook-button default button' %>
+    <%= link_to t(:take_me_facebook), "/auth/facebook",
+      onclick: "$('.facebook-button').toggle();",
+      class: "facebook-button default button",
+      method: :post %>
     <div class="facebook-button" style="display:none;">
       <span class="loading status"><%=t :connecting_to_facebook %></span>
     </div>

--- a/app/views/observations/by_login.html.erb
+++ b/app/views/observations/by_login.html.erb
@@ -191,48 +191,57 @@
 
 <%= render :partial => 'shared/by_login_header', :locals => {:after => tools} %>
 
-<div id="listcol" class="column span-17">
-  <div class="observations table">
-    <%= render :partial => 'observations_table_header' %>
-    <%= render(:partial => 'cached_component', 
-               :collection => @observations) %>
-  </div><!-- end observations table -->
-  <% if @observations.empty? %>
-    <div id="no_obs_message" class="description">
-      <%=t :no_matching_observations %>
-      <br><br>
-      <% if logged_in? && current_user.login == @login %>
-      <%= link_to t(:add_observations), upload_observations_path,
-                  :class => 'default inline button' %>
-      <% end %>
+<div id="maincol">
+  <div id="listcol">
+    <div class="observations table">
+      <%= render :partial => 'observations_table_header' %>
+      <%= render(:partial => 'cached_component', 
+                 :collection => @observations) %>
+    </div><!-- end observations table -->
+    <% if @observations.empty? %>
+      <div id="no_obs_message" class="description">
+        <%=t :no_matching_observations %>
+        <br><br>
+        <% if logged_in? && current_user.login == @login %>
+        <%= link_to t(:add_observations), upload_observations_path,
+                    :class => 'default inline button' %>
+        <% end %>
+      </div>
+    <% end %>
+    <div id="pagination">
+      <% if logged_in? -%>
+        <%= form_for :preferences, :url => url_for, :html => {:style => "float: left", :method => :get} do |f| %>
+          <%= hidden_fields_for_params(:without => [:per_page, :page, :preferences]) %>
+          <%= f.label t(:per_page) %>
+          <%= f.select :per_page, ApplicationController::PER_PAGES, 
+            {:selected => @prefs["per_page"].to_i}, :onchange => "$(this).parents('form:first').submit()" %>
+        <% end %>
+      <% end -%>
+      <%= will_paginate @observations, renderer: INatLinkRenderer, skip_right: true %>
     </div>
-  <% end %>
-  <div id="pagination">
-    <% if logged_in? -%>
-      <%= form_for :preferences, :url => url_for, :html => {:style => "float: left", :method => :get} do |f| %>
-        <%= hidden_fields_for_params(:without => [:per_page, :page, :preferences]) %>
-        <%= f.label t(:per_page) %>
-        <%= f.select :per_page, ApplicationController::PER_PAGES, 
-          {:selected => @prefs["per_page"].to_i}, :onchange => "$(this).parents('form:first').submit()" %>
-      <% end %>
-    <% end -%>
-    <%= will_paginate @observations, renderer: INatLinkRenderer, skip_right: true %>
+  </div>
+
+  <div id="mapcol">
+    <%- map_attributes = setup_map_tag_attrs( {
+      observations: @observations,
+      focus: "observations",
+      flag_letters: true,
+      min_y: params[:swlat],
+      min_x: params[:swlng],
+      max_y: params[:nelat],
+      max_x: params[:nelng],
+      gesture_handling: "auto"
+    }.merge( @map_params || {} ) ) %>
+    <%= content_tag("div", "", map_attributes.merge({ id: "map" })) %>
+    <%= link_to_function t(:redo_search_in_map_area),
+      "redoSearchInMapArea()", 
+      :id => 'redo_search_in_map_area_button',
+      "data-loading-click" => t(:loading) %>
   </div>
 </div>
 
-<div id="mapcol" class="column span-7 last stacked">
-  <%- map_attributes = setup_map_tag_attrs({
-    observations: @observations, focus: "observations", flag_letters: true,
-    min_y: params[:swlat], min_x: params[:swlng],
-    max_y: params[:nelat], max_x: params[:nelng] }.merge(@map_params || {})) %>
-  <%= content_tag("div", "", map_attributes.merge({ id: "map" })) %>
-  <%= link_to_function t(:redo_search_in_map_area),
-    "redoSearchInMapArea()", 
-    :id => 'redo_search_in_map_area_button',
-    "data-loading-click" => t(:loading) %>
-</div>
 
-<div class="last column span-24">
+<div class="clear">
   <div id="feeds" class="small ui description">
     <% if is_me?(@selected_user) -%>
       <span>


### PR DESCRIPTION
Minor alteration to /observations/:login so

1. Increasing font size does not hide text under the map
1. Content fills the whole screen
1. Map wraps to the bottom when the width of the screen won't fit both the table and the map side-by-side

Font size issues were causing issues for both people trying to increase the font size on the page and people viewing the site in languages where long word lengths were causing similar width problems.

It would have been nice to move this over the Bootstrap too, but ironically that would have negated the accessibility improvements, because our bootstrap styles currently hardcode the font sizes making them impossible for the user to increase. Fixing that will require removing the hard-coded base font sizes on the `body` tag and then adjust all other font sizes to equivalents using rems assuming a 16px base font size.