### PR TITLE
Reassess community taxa after taxon activation

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -19,8 +19,6 @@ class Taxon < ActiveRecord::Base
   # Skip the more onerous callbacks that happen after grafting a taxon somewhere else
   attr_accessor :skip_after_move
 
-  attr_accessor :skip_after_activate
-
   attr_accessor :locale
 
   # set this when you want methods to respond with user-specific content
@@ -526,7 +524,6 @@ class Taxon < ActiveRecord::Base
 
   def handle_after_activate
     return true unless is_active_changed?
-    return true if skip_after_activate
     Observation.delay( priority: INTEGRITY_PRIORITY, queue: "slow",
       unique_hash: { "Observation::update_stats_for_observations_of": id } ).
       update_stats_for_observations_of( id )

--- a/spec/helpers/make_helpers.rb
+++ b/spec/helpers/make_helpers.rb
@@ -235,7 +235,6 @@ module MakeHelpers
     set_taxon_with_rank_and_parent( "Hylidae", Taxon::FAMILY, @Anura )
     set_taxon_with_rank_and_parent( "Pseudacris", Taxon::GENUS, @Hylidae )
     set_taxon_with_rank_and_parent( "Pseudacris regilla", Taxon::SPECIES, @Pseudacris )
-    set_taxon_with_rank_and_parent( "Pseudacris regilla regilla", Taxon::SUBSPECIES, @Pseudacris_regilla )
 
     set_taxon_with_rank_and_parent( "Aves", Taxon::CLASS, @Chordata, is_iconic: true )
     set_taxon_with_rank_and_parent( "Apodiformes", Taxon::ORDER, @Aves )

--- a/spec/helpers/make_helpers.rb
+++ b/spec/helpers/make_helpers.rb
@@ -235,6 +235,7 @@ module MakeHelpers
     set_taxon_with_rank_and_parent( "Hylidae", Taxon::FAMILY, @Anura )
     set_taxon_with_rank_and_parent( "Pseudacris", Taxon::GENUS, @Hylidae )
     set_taxon_with_rank_and_parent( "Pseudacris regilla", Taxon::SPECIES, @Pseudacris )
+    set_taxon_with_rank_and_parent( "Pseudacris regilla regilla", Taxon::SUBSPECIES, @Pseudacris_regilla )
 
     set_taxon_with_rank_and_parent( "Aves", Taxon::CLASS, @Chordata, is_iconic: true )
     set_taxon_with_rank_and_parent( "Apodiformes", Taxon::ORDER, @Aves )

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -3098,23 +3098,23 @@ describe Observation do
     it "change should be triggered by activating a taxon" do
       load_test_taxa
       o = Observation.make!
-      i1 = Identification.make!( observation: o, taxon: @Pseudacris_regilla_regilla )
-      i2 = Identification.make!( observation: o, taxon: @Pseudacris_regilla_regilla )
+      i1 = Identification.make!( observation: o, taxon: @Pseudacris_regilla )
+      i2 = Identification.make!( observation: o, taxon: @Pseudacris_regilla )
       expect( o.community_taxon ).not_to be_blank
-      t = Taxon.make!( parent: @Pseudacris, rank: "species", is_active: false )
+      t = Taxon.make!( parent: @Hylidae, rank: "genus", is_active: false )
       expect( t.is_active ).to be( false )
-      @Pseudacris_regilla_regilla.update_attributes( is_active: false )
-      expect( @Pseudacris_regilla_regilla.is_active ).to be( false )
-      @Pseudacris_regilla_regilla.parent = t
-      @Pseudacris_regilla_regilla.save
-      expect( @Pseudacris_regilla_regilla.parent ).to eq( t )
+      @Pseudacris_regilla.update_attributes( is_active: false )
+      expect( @Pseudacris_regilla.is_active ).to be( false )
+      @Pseudacris_regilla.parent = t
+      @Pseudacris_regilla.save
+      expect( @Pseudacris_regilla.parent ).to eq( t )
       Delayed::Worker.new.work_off
       o = Observation.find( o.id )
       expect( o.community_taxon ).to be_blank
-      @Pseudacris_regilla_regilla.parent = @Pseudacris_regilla
-      @Pseudacris_regilla_regilla.save
+      @Pseudacris_regilla.parent = @Pseudacris
+      @Pseudacris_regilla.save
       Delayed::Worker.new.work_off
-      @Pseudacris_regilla_regilla.update_attributes( is_active: true )
+      @Pseudacris_regilla.update_attributes( is_active: true )
       Delayed::Worker.new.work_off
       o = Observation.find( o.id )
       expect( o.community_taxon ).not_to be_blank


### PR DESCRIPTION
As reported here https://forum.inaturalist.org/t/obs-with-only-subspecies-ids-can-get-stuck-without-a-cid/15992
The CID algorithm for an observation ignores inactive taxa
But if an taxon is activated the CID of its observations are not reassessed
This means that if a curator does the following set of actions which is common in curating taxa: (1) inactivates a taxon and moves it to a new taxon (this wipes the CIDs because moving a taxon reassesses CID and inactive taxa are ignored)
(2) reactivates the taxon
the CID's are not reassessed/restored because this doesn't happen when a taxon is activated

This pull request introduces a callback that reassesses the CIDs of obs associated with a taxon if the taxon is_active status changes

