### PR TITLE
Taxon split with same input output

### DIFF
--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -600,7 +600,7 @@ class Identification < ActiveRecord::Base
     ident_ids = []
     scope.find_each do |ident|
       next unless output_taxon = taxon_change.output_taxon_for_record( ident )
-      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
+      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
       new_ident = Identification.new(
         observation_id: ident.observation_id,
         taxon: output_taxon, 

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -600,7 +600,7 @@ class Identification < ActiveRecord::Base
     ident_ids = []
     scope.find_each do |ident|
       next unless output_taxon = taxon_change.output_taxon_for_record( ident )
-      next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
+      next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
       new_ident = Identification.new(
         observation_id: ident.observation_id,
         taxon: output_taxon, 

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -600,7 +600,7 @@ class Identification < ActiveRecord::Base
     ident_ids = []
     scope.find_each do |ident|
       next unless output_taxon = taxon_change.output_taxon_for_record( ident )
-      next if taxon_change.automatable_for_output?( output_taxon.id )
+      next if !taxon_change.automatable_for_output?( output_taxon.id )
       new_ident = Identification.new(
         observation_id: ident.observation_id,
         taxon: output_taxon, 

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -600,7 +600,7 @@ class Identification < ActiveRecord::Base
     ident_ids = []
     scope.find_each do |ident|
       next unless output_taxon = taxon_change.output_taxon_for_record( ident )
-      next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
+      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
       new_ident = Identification.new(
         observation_id: ident.observation_id,
         taxon: output_taxon, 

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -600,7 +600,7 @@ class Identification < ActiveRecord::Base
     ident_ids = []
     scope.find_each do |ident|
       next unless output_taxon = taxon_change.output_taxon_for_record( ident )
-      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
+      next if taxon_change.automatable_for_output?( output_taxon.id )
       new_ident = Identification.new(
         observation_id: ident.observation_id,
         taxon: output_taxon, 

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -600,6 +600,7 @@ class Identification < ActiveRecord::Base
     ident_ids = []
     scope.find_each do |ident|
       next unless output_taxon = taxon_change.output_taxon_for_record( ident )
+      next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
       new_ident = Identification.new(
         observation_id: ident.observation_id,
         taxon: output_taxon, 

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -842,7 +842,7 @@ class ListedTaxon < ActiveRecord::Base
     scope.find_each do |lt|
       lt.force_update_cache_columns = true
       if output_taxon = taxon_change.output_taxon_for_record( lt )
-        next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
+        next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
         if existing = ListedTaxon.where( list_id: lt.list_id, taxon_id: output_taxon.id ).first
           existing.skip_index_taxon = true
           existing.merge( lt )

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -842,7 +842,7 @@ class ListedTaxon < ActiveRecord::Base
     scope.find_each do |lt|
       lt.force_update_cache_columns = true
       if output_taxon = taxon_change.output_taxon_for_record( lt )
-        next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
+        next if taxon_change.automatable_for_output?( output_taxon.id )
         if existing = ListedTaxon.where( list_id: lt.list_id, taxon_id: output_taxon.id ).first
           existing.skip_index_taxon = true
           existing.merge( lt )

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -842,7 +842,7 @@ class ListedTaxon < ActiveRecord::Base
     scope.find_each do |lt|
       lt.force_update_cache_columns = true
       if output_taxon = taxon_change.output_taxon_for_record( lt )
-        next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
+        next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
         if existing = ListedTaxon.where( list_id: lt.list_id, taxon_id: output_taxon.id ).first
           existing.skip_index_taxon = true
           existing.merge( lt )

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -842,7 +842,7 @@ class ListedTaxon < ActiveRecord::Base
     scope.find_each do |lt|
       lt.force_update_cache_columns = true
       if output_taxon = taxon_change.output_taxon_for_record( lt )
-        next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
+        next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
         if existing = ListedTaxon.where( list_id: lt.list_id, taxon_id: output_taxon.id ).first
           existing.skip_index_taxon = true
           existing.merge( lt )

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -842,6 +842,7 @@ class ListedTaxon < ActiveRecord::Base
     scope.find_each do |lt|
       lt.force_update_cache_columns = true
       if output_taxon = taxon_change.output_taxon_for_record( lt )
+        next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
         if existing = ListedTaxon.where( list_id: lt.list_id, taxon_id: output_taxon.id ).first
           existing.skip_index_taxon = true
           existing.merge( lt )

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -842,7 +842,7 @@ class ListedTaxon < ActiveRecord::Base
     scope.find_each do |lt|
       lt.force_update_cache_columns = true
       if output_taxon = taxon_change.output_taxon_for_record( lt )
-        next if taxon_change.automatable_for_output?( output_taxon.id )
+        next if !taxon_change.automatable_for_output?( output_taxon.id )
         if existing = ListedTaxon.where( list_id: lt.list_id, taxon_id: output_taxon.id ).first
           existing.skip_index_taxon = true
           existing.merge( lt )

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2806,7 +2806,7 @@ class Observation < ActiveRecord::Base
     scope.find_each do |observation|
       if observation.owners_identification && input_taxon_ids.include?( observation.owners_identification.taxon_id )
         if output_taxon = taxon_change.output_taxon_for_record( observation )
-          next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
+          next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
           Identification.create(
             user: observation.user,
             observation: observation,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2806,7 +2806,7 @@ class Observation < ActiveRecord::Base
     scope.find_each do |observation|
       if observation.owners_identification && input_taxon_ids.include?( observation.owners_identification.taxon_id )
         if output_taxon = taxon_change.output_taxon_for_record( observation )
-          next if taxon_change.automatable_for_output?( output_taxon.id )
+          next if !taxon_change.automatable_for_output?( output_taxon.id )
           Identification.create(
             user: observation.user,
             observation: observation,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2806,7 +2806,7 @@ class Observation < ActiveRecord::Base
     scope.find_each do |observation|
       if observation.owners_identification && input_taxon_ids.include?( observation.owners_identification.taxon_id )
         if output_taxon = taxon_change.output_taxon_for_record( observation )
-          next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
+          next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
           Identification.create(
             user: observation.user,
             observation: observation,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2806,6 +2806,7 @@ class Observation < ActiveRecord::Base
     scope.find_each do |observation|
       if observation.owners_identification && input_taxon_ids.include?( observation.owners_identification.taxon_id )
         if output_taxon = taxon_change.output_taxon_for_record( observation )
+          next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
           Identification.create(
             user: observation.user,
             observation: observation,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2806,7 +2806,7 @@ class Observation < ActiveRecord::Base
     scope.find_each do |observation|
       if observation.owners_identification && input_taxon_ids.include?( observation.owners_identification.taxon_id )
         if output_taxon = taxon_change.output_taxon_for_record( observation )
-          next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
+          next if taxon_change.automatable_for_output?( output_taxon.id )
           Identification.create(
             user: observation.user,
             observation: observation,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2806,7 +2806,7 @@ class Observation < ActiveRecord::Base
     scope.find_each do |observation|
       if observation.owners_identification && input_taxon_ids.include?( observation.owners_identification.taxon_id )
         if output_taxon = taxon_change.output_taxon_for_record( observation )
-          next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
+          next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
           Identification.create(
             user: observation.user,
             observation: observation,

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -290,7 +290,7 @@ class ObservationFieldValue < ActiveRecord::Base
     obs_ids = Set.new
     scope.find_each do |ofv|
       next unless output_taxon = taxon_change.output_taxon_for_record( ofv )
-      next if taxon_change.automatable_for_output?( output_taxon.id )
+      next if !taxon_change.automatable_for_output?( output_taxon.id )
       ofv.update_attributes( value: output_taxon.id )
       obs_ids << ofv.observation_id
     end

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -290,7 +290,7 @@ class ObservationFieldValue < ActiveRecord::Base
     obs_ids = Set.new
     scope.find_each do |ofv|
       next unless output_taxon = taxon_change.output_taxon_for_record( ofv )
-      next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
+      next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
       ofv.update_attributes( value: output_taxon.id )
       obs_ids << ofv.observation_id
     end

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -290,7 +290,7 @@ class ObservationFieldValue < ActiveRecord::Base
     obs_ids = Set.new
     scope.find_each do |ofv|
       next unless output_taxon = taxon_change.output_taxon_for_record( ofv )
-      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
+      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
       ofv.update_attributes( value: output_taxon.id )
       obs_ids << ofv.observation_id
     end

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -290,7 +290,7 @@ class ObservationFieldValue < ActiveRecord::Base
     obs_ids = Set.new
     scope.find_each do |ofv|
       next unless output_taxon = taxon_change.output_taxon_for_record( ofv )
-      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching? && taxon_change.need_not_push_to?( output_taxon.id )
+      next if taxon_change.automatable_for_output?( output_taxon.id )
       ofv.update_attributes( value: output_taxon.id )
       obs_ids << ofv.observation_id
     end

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -290,7 +290,7 @@ class ObservationFieldValue < ActiveRecord::Base
     obs_ids = Set.new
     scope.find_each do |ofv|
       next unless output_taxon = taxon_change.output_taxon_for_record( ofv )
-      next if taxon_change.is_a?(TaxonSplit) && taxon_change.is_branching?
+      next if taxon_change.is_a?( TaxonSplit ) && taxon_change.is_branching?
       ofv.update_attributes( value: output_taxon.id )
       obs_ids << ofv.observation_id
     end

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -290,6 +290,7 @@ class ObservationFieldValue < ActiveRecord::Base
     obs_ids = Set.new
     scope.find_each do |ofv|
       next unless output_taxon = taxon_change.output_taxon_for_record( ofv )
+      next if input_taxon_ids.count == 1 && input_taxon_ids.first == output_taxon.id
       ofv.update_attributes( value: output_taxon.id )
       obs_ids << ofv.observation_id
     end

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -127,7 +127,11 @@ class TaxonChange < ActiveRecord::Base
     end
     return true
   end
-    
+  
+  def is_branching?
+    taxon_change_taxa.map(&:taxon_id).include? taxon_id
+  end
+
   def committable_by?( u )
     return false unless u
     return false unless u.is_curator?
@@ -181,11 +185,11 @@ class TaxonChange < ActiveRecord::Base
       raise RankLevelError, "Output taxon rank level not coarser than rank level of an input taxon's active children"
       return
     end
-    unless type == "TaxonSplit" && input_taxa.count == 1 && output_taxa.map{|a| a.id == input_taxa[0].id}.any?
+    unless is_a?(TaxonSplit) && is_branching?
       input_taxa.each {|t| t.update_attributes!(is_active: false, skip_only_inactive_children_if_inactive: (move_children? || !active_children_conflict?) )}
     end
     output_taxa.each do |t|
-      next if type == "TaxonSplit" && input_taxa.count == 1 && t.id == input_taxa[0].id
+      next if is_a?(TaxonSplit) && t.id == taxon_id
       t.update_attributes!(
         is_active: true,
         skip_only_inactive_children_if_inactive: move_children?,

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -17,6 +17,7 @@ class TaxonChange < ActiveRecord::Base
   
   validates_presence_of :taxon_id
   validate :uniqueness_of_taxa
+  validate :uniqueness_of_output_taxa
   validate :taxa_below_order
   accepts_nested_attributes_for :source
   accepts_nested_attributes_for :taxon_change_taxa, :allow_destroy => true,
@@ -397,6 +398,14 @@ class TaxonChange < ActiveRecord::Base
     taxon_ids = [taxon_id, taxon_change_taxa.map(&:taxon_id)].flatten.compact
     if taxon_ids.size != taxon_ids.uniq.size
       errors.add(:base, "input and output taxa must be unique")
+    end
+  end
+
+  def uniqueness_of_output_taxa
+    return true unless type == "TaxonSplit"
+    taxon_ids = taxon_change_taxa.map(&:taxon_id)
+    if taxon_ids.size != taxon_ids.uniq.size
+      errors.add(:base, "output taxa must be unique")
     end
   end
 

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -134,7 +134,7 @@ class TaxonChange < ActiveRecord::Base
   end
 
   def need_not_push_to?( output_taxon_id )
-    taxon_id != output_taxon_id
+    taxon_id == output_taxon_id
   end
 
   def committable_by?( u )

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -180,8 +180,11 @@ class TaxonChange < ActiveRecord::Base
       raise RankLevelError, "Output taxon rank level not coarser than rank level of an input taxon's active children"
       return
     end
-    input_taxa.each {|t| t.update_attributes!(is_active: false, skip_only_inactive_children_if_inactive: (move_children? || !active_children_conflict?) )}
+    unless type == "TaxonSplit" && input_taxa.count == 1 && output_taxa.map{|a| a.id == input_taxa[0].id}.any?
+      input_taxa.each {|t| t.update_attributes!(is_active: false, skip_only_inactive_children_if_inactive: (move_children? || !active_children_conflict?) )}
+    end
     output_taxa.each do |t|
+      next if type == "TaxonSplit" && input_taxa.count == 1 && t.id == input_taxa[0].id
       t.update_attributes!(
         is_active: true,
         skip_only_inactive_children_if_inactive: move_children?,

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -133,6 +133,10 @@ class TaxonChange < ActiveRecord::Base
     taxon_change_taxa.map( &:taxon_id ).include? taxon_id
   end
 
+  def need_not_push_to?( output_taxon_id )
+    taxon_id != output_taxon_id
+  end
+
   def committable_by?( u )
     return false unless u
     return false unless u.is_curator?

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -130,9 +130,9 @@ class TaxonChange < ActiveRecord::Base
   end
 
   def automatable_for_output?( output_taxon )
-    return false unless is_a?( TaxonSplit ) && is_branching?
+    return true unless is_a?( TaxonSplit ) && is_branching?
     output_taxon_id = output_taxon.is_a?( Taxon ) ? output_taxon.id : output_taxon
-    input_taxon.id == output_taxon_id
+    input_taxon.id != output_taxon_id
   end
 
   def committable_by?( u )

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -390,6 +390,7 @@ class TaxonChange < ActiveRecord::Base
   end
 
   def uniqueness_of_taxa
+    return true if type == "TaxonSplit"
     taxon_ids = [taxon_id, taxon_change_taxa.map(&:taxon_id)].flatten.compact
     if taxon_ids.size != taxon_ids.uniq.size
       errors.add(:base, "input and output taxa must be unique")

--- a/app/models/taxon_split.rb
+++ b/app/models/taxon_split.rb
@@ -22,6 +22,10 @@ class TaxonSplit < TaxonChange
     false
   end
 
+  def is_branching?
+    output_taxa.map(&:id).include?( input_taxon.id )
+  end
+
   def output_ancestor( options = { })
     if !@output_ancestor || options[:force]
       output_ancestor_id = output_taxa.first.ancestor_ids.reverse.detect do |aid|

--- a/spec/models/taxon_split_spec.rb
+++ b/spec/models/taxon_split_spec.rb
@@ -12,6 +12,17 @@ describe TaxonSplit, "validation" do
     expect(tc).to be_valid
   end
 
+  it "should not allow both output taxa to be the same" do
+    old_taxon = Taxon.make!( rank: Taxon::FAMILY )
+    new_taxon = Taxon.make!( rank: Taxon::FAMILY )
+    tc = TaxonSplit.make
+    tc.add_input_taxon(old_taxon)
+    tc.add_output_taxon(new_taxon)
+    tc.add_output_taxon(new_taxon)
+    tc.save
+    expect(tc).not_to be_valid
+  end
+
   it "should now allow a split with only one output" do
     tc = TaxonSplit.make
     tc.add_input_taxon( Taxon.make! )

--- a/spec/models/taxon_split_spec.rb
+++ b/spec/models/taxon_split_spec.rb
@@ -1,7 +1,7 @@
 require File.dirname(__FILE__) + '/../spec_helper.rb'
 
 describe TaxonSplit, "validation" do
-  it "should not allow the same taxon on both sides of the split" do
+  it "should allow the same taxon on both sides of the split" do
     old_taxon = Taxon.make!( rank: Taxon::FAMILY )
     new_taxon = Taxon.make!( rank: Taxon::FAMILY )
     tc = TaxonSplit.make
@@ -9,7 +9,7 @@ describe TaxonSplit, "validation" do
     tc.add_output_taxon(new_taxon)
     tc.add_output_taxon(old_taxon)
     tc.save
-    expect(tc).not_to be_valid
+    expect(tc).to be_valid
   end
 
   it "should now allow a split with only one output" do


### PR DESCRIPTION
I altered taxon splits so that if one of the output taxa is the same as the input taxon the split is still allowed. It leaves the input taxon active and doesn't touch content (identificiations etc.) determined (by atlases) to stay with that taxon. Content determined to go to the other output taxon behaves normally.

The idea here is that with a taxon lump (e.g. Taricha torosa is folded into Taricha granulosa thereby broadening Taricha granulosa) we don't recommend making a new taxon for the broadened Taricha granulosa. Instead we simply swap Taricha torosa with Taricha granulosa and advise curators to make sure that any content may no longer match the broadened Taricha granulosa (e.g. taxon ranges, common names) be manually altered. And with lumps, IDs don't become misspecified - an ID of narrow Taricha granulosa still applies to broadened Taricha granulosa.

With splits (e.g. splitting Taricha torosa off from Taricha granulosa), in the past we have always recommended creating a new taxon for the narrowed taxon (e.g. Taricha granulosa). However, sometimes this creates a lot of disruption with content associated with the narrowed taxon (e.g. removing IDs of Taricha granulosa only to replace them with IDs of Taricha granulosa when its not always clear to the community why they are different) for the sole benefit of being able to preserve a record of how the broader Taricha granulosa compares to the narrower Taricha granulosa. But since we're not doing this for lumps (as explained above) it doesn't seem totally consistent/necessary to do them for splits and the system seems to be working fine with lumps.

Also, in many cases with splits the carved off taxon (e.g. Taricha torosa) has an extremely small range (e.g. it occurs on just a tiny island) carved off from the narrowed taxon (e.g. Taricha granulosa) which is largely unchanged. It seems overkill to touch all the often thousands of IDs associated with such only slightly narrowed taxa such as this to accomodate carving off an island.

In case its not clear, this functionality still uses 'normal split' functionality to properly handle identifications and other content moving towards the carved off taxon (e.g. Taricha torosa) so IDs don't become misspecified anymore than they would with a normal split. The only cost we're incurring here is a slightly less concrete record of how the broadened taxon as distinct from the narrowed taxon. But I think thats well worth it to minimize disruption caused by these massive splits.



