### PR TITLE
Handle malformed date params on obs index

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -100,9 +100,10 @@ class ObservationsController < ApplicationController
     # API methods, and HTML/views and partials
     if human_or_scraper && !showing_partial
       @shareable_description = begin
-                                generate_shareable_description
-                               rescue StandardError
-                                ""
+                                 generate_shareable_description
+                               rescue StandardError => e
+                                 Logstasher.write_exception( e, request: request, session: session, user: current_user )
+                                 ""
                                end
     else
       h = observations_index_search(params)

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -100,11 +100,11 @@ class ObservationsController < ApplicationController
     # API methods, and HTML/views and partials
     if human_or_scraper && !showing_partial
       @shareable_description = begin
-                                 generate_shareable_description
-                               rescue StandardError => e
-                                 Logstasher.write_exception( e, request: request, session: session, user: current_user )
-                                 ""
-                               end
+        generate_shareable_description
+      rescue StandardError => e
+        Logstasher.write_exception( e, request: request, session: session, user: current_user )
+        ""
+      end
     else
       h = observations_index_search(params)
       params = h[:params]

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -99,41 +99,11 @@ class ObservationsController < ApplicationController
     # looked up now as it will use Angular/Node. This is for legacy
     # API methods, and HTML/views and partials
     if human_or_scraper && !showing_partial
-      search_taxon = Taxon.find_by_id( params[:taxon_id] ) unless params[:taxon_id].blank?
-      search_place = unless params[:place_id].blank?
-        Place.find( params[:place_id] ) rescue nil
-      end
-      search_user = unless params[:user_id].blank?
-        User.find_by_id( params[:user_id] ) || User.find_by_login( params[:user_id] )
-      end
-      search_date = Date.parse( params[:on] ) unless params[:on].blank?
-      @shareable_description = if search_taxon
-        key = "observation_brief_taxon"
-        i18n_vars = {}
-        i18n_vars[:taxon] = search_taxon.common_name( locale: I18n.locale ).try(:name)
-        i18n_vars[:taxon] = search_taxon.name if i18n_vars[:taxon].blank?
-        if search_place
-          key += "_from_place"
-          i18n_vars[:place] = search_place.localized_name
-        end
-        if search_date
-          key += "_on_day"
-          i18n_vars[:day] = I18n.l( search_date, format: :long )
-        end
-        if search_user
-          key += "_by_user"
-          i18n_vars[:user] = search_user.try_methods(:name, :login)
-        end
-        I18n.t( key, i18n_vars.merge( default: I18n.t( :observations_of_taxon, taxon_name: i18n_vars[:taxon] ) ) )
-      elsif search_user
-        if search_date
-          I18n.t( :observations_by_user_on_date, user: search_user.try_methods(:name, :login), date: I18n.l( search_date, format: :long ) )
-        else
-          I18n.t( :observations_by_user, user: search_user.try_methods(:name, :login) )
-        end
-      else
-        I18n.t( :x_site_is_a_social_network_for_naturalist, site: @site.name )
-      end
+      @shareable_description = begin
+                                generate_shareable_description
+                               rescue StandardError
+                                ""
+                               end
     else
       h = observations_index_search(params)
       params = h[:params]
@@ -2531,7 +2501,65 @@ class ObservationsController < ApplicationController
     end
     render_404 unless @observation
   end
+
+  def search_taxon
+    return if params[:taxon_id].blank?
+
+    @search_taxon ||= Taxon.find_by_id(params[:taxon_id].to_i)
+  end
+
+  def search_place
+    return if params[:place_id].blank?
+
+    @search_place ||= Place.find_by_id( params[:place_id].to_i )
+  end
+
+  def search_user
+    return if params[:user_id].blank?
+
+    @search_user ||= ( User.find_by_id( params[:user_id].to_i ) || User.find_by_login( params[:user_id] ) )
+  end
   
+  def search_date
+    return if params[:on].blank?
+
+    begin
+      @search_date ||= Date.parse( params[:on] )
+    rescue ArgumentError
+      nil
+    end
+  end
+
+  def generate_shareable_description
+    if search_taxon
+      key = "observation_brief_taxon"
+      i18n_vars = {}
+      i18n_vars[:taxon] = search_taxon.common_name( locale: I18n.locale ).try(:name)
+      i18n_vars[:taxon] = search_taxon.name if i18n_vars[:taxon].blank?
+      if search_place
+        key += "_from_place"
+        i18n_vars[:place] = search_place.localized_name
+      end
+      if search_date
+        key += "_on_day"
+        i18n_vars[:day] = I18n.l( search_date, format: :long )
+      end
+      if search_user
+        key += "_by_user"
+        i18n_vars[:user] = search_user.try_methods(:name, :login)
+      end
+      I18n.t( key, i18n_vars.merge( default: I18n.t( :observations_of_taxon, taxon_name: i18n_vars[:taxon] ) ) )
+    elsif search_user
+      if search_date
+        I18n.t( :observations_by_user_on_date, user: search_user.try_methods(:name, :login), date: I18n.l( search_date, format: :long ) )
+      else
+        I18n.t( :observations_by_user, user: search_user.try_methods(:name, :login) )
+      end
+    else
+      I18n.t( :x_site_is_a_social_network_for_naturalist, site: @site.name )
+    end
+  end
+
   def require_owner
     unless ( logged_in? && current_user.id == @observation.user_id ) || current_user.is_admin?
       msg = t(:you_dont_have_permission_to_do_that)

--- a/spec/controllers/observation_controller_spec.rb
+++ b/spec/controllers/observation_controller_spec.rb
@@ -429,7 +429,17 @@ describe ObservationsController do
   end
 
   describe "index" do
+    let(:user) { User.make! }
+    before { sign_in user }
+
     render_views
+
+    it "should not raise an exception with malformed date params" do
+      expect {
+        get :index, { on: "2020-09", user_id: user.id }
+      }.not_to raise_exception
+    end
+
     it "should just ignore project slugs for projects that don't exist" do
       expect {
         get :index, projects: 'imaginary-project'


### PR DESCRIPTION
#2810 

This should gracefully handle any exceptions that come out of the OG description generation. I'm still concerned that these partial iso8601 params are not being parsed correctly for the obs retrieval being done on the front end, however let me know your thoughts. I suppose it's the difference of landing on the obs index with no results vs whale fail. `by_login` action still is parsing these dates correctly, so I think a similar approach could be taken by the angular front end.

FWIW I also have a WIP branch https://github.com/inaturalist/inaturalist/compare/main...todtb:2810-date-params-for-obs that would start to generate this description based on partial dates, but that I think is lower priority.