### PR TITLE
Add profile and project links to user curation page

### DIFF
--- a/app/views/users/curation.html.haml
+++ b/app/views/users/curation.html.haml
@@ -148,6 +148,7 @@
       .col-xs-4
         %p
           = user_image( @display_user, size: "large", class: "img-responsive center-block" )
+        = link_to t(:users_profile, user: @display_user.login), user_path(@display_user), class: "btn btn-block btn-default"
         - if @display_user.is_curator?
           = link_to t(:remove_curator_status), remove_role_path(@display_user, :role => "curator"), :method => :delete, class: "btn btn-block btn-warning"
         - else
@@ -198,6 +199,10 @@
             %span.badge= @display_user.comments.count
             %i.fa.fa-comments
             Comments
+          = link_to projects_by_login_path(@display_user.login), class: "list-group-item" do
+            %span.badge= @display_user.projects.count
+            %i.fa.fa-briefcase
+            = t(:projects)
         = render :partial => 'glance', :locals => {:user => @display_user, :extra => extra}
         - unless @display_user.provider_authorizations.blank?
           %h3= t(:provider_authorizations)


### PR DESCRIPTION
#2822 

Adds links to the user curation page to view profile and a user's projects. 

The glance section didn't seem like the right fit for the profile link so it's up top as shown:
![Screen Shot 2020-10-04 at 9 35 56 AM](https://user-images.githubusercontent.com/19367605/95017088-17ee9380-0625-11eb-9561-99f2926bc427.png)

Hope this helps @tiwane