### PR TITLE
Account for destroyed posts in counter cache update

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -148,7 +148,7 @@ class Post < ActiveRecord::Base
   end
   
   def update_user_counter_cache
-    if parent_type == "User" && published_at_changed?
+    if parent_type == "User" && (published_at_changed? || destroyed?) 
       User.where( id: user_id, ).update_all( journal_posts_count: user.journal_posts.published.count )
     end
     true

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -110,6 +110,21 @@ describe Post do
       end
     end
   end
+  
+  describe "destroy" do
+    describe "for a user" do 
+      it "should decrement the user's counter cache" do
+        u = User.make!
+        expect( u.journal_posts_count ).to eq 0
+        p = Post.make!( parent: u, user: u )
+        u.reload
+        expect( u.journal_posts_count ).to eq 1
+        p.destroy
+        u.reload
+        expect( u.journal_posts_count ).to eq 0
+      end
+    end
+  end
 
   describe "creation for project" do
     it "should generate an update for the owner" do


### PR DESCRIPTION
#2818 

Adjusts `users.journal_posts_count` cache when post is destroyed (previously only when unpublished).