### PR TITLE
Use Wikidata to fetch the correct Wikipedia taxon page

### DIFF
--- a/app/assets/stylesheets/taxa/show/wikipedia.scss
+++ b/app/assets/stylesheets/taxa/show/wikipedia.scss
@@ -16,27 +16,43 @@
   table.infobox, 
   .infobox_v2,
   table.infobox_v2,
-  .thumb, 
-  .tright {
+  .tright,
+  .tleft {
     float: right;
     clear: right;
-    margin-left: 20px;
-    margin-bottom: 1em;
     background-color: #eee;
-    padding: 1em;
+    border-left: 20px solid white;
+    border-bottom: 20px solid white;
+    padding: 10px;
   }
 
   ul.gallery {
     list-style: none;
     display: flex;
     flex-wrap: wrap;
+    padding: 0;
   }
 
-  .gallerybox .thumb {
-    float: none;
-    margin: 0;
-    margin-bottom: 0.6em;
-    padding: 0;
+  .gallerybox {
+    .thumb {
+      float: none;
+      margin: 0;
+      margin-bottom: 0.6em;
+      padding: 0;
+      background-color: #eee;
+      > div {
+        padding: 10px;
+        text-align: center;
+        margin: 0 !important;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 140px;
+      }
+    }
+    .gallerytext {
+      font-size: smaller;
+    }
   }
 
   .sisterproject {
@@ -75,6 +91,8 @@
 
   .thumbcaption {
     font-style: italic;
+    font-size: smaller;
+    line-height: 1.6;
   }
 
   .thumbcaption,

--- a/app/assets/stylesheets/taxa/show/wikipedia.scss
+++ b/app/assets/stylesheets/taxa/show/wikipedia.scss
@@ -4,7 +4,10 @@
   line-height: 1.6em;
 
   // hide taxobox
-  .infobox.biota {
+  .infobox.biota,
+  .taxobox_v3,
+  .taxobox,
+  .infobox {
     display: none;
   }
 
@@ -21,6 +24,12 @@
     margin-bottom: 1em;
     background-color: #eee;
     padding: 1em;
+  }
+
+  ul.gallery {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
   }
 
   .gallerybox .thumb {
@@ -97,9 +106,16 @@
   .toc {
     line-height: 1.8;
   }
+  .toccolours {
+    background: #f8f9fa;
+  }
 
   a.new {
     color: #ba0000;
+  }
+
+  .navbar {
+    display: none;
   }
 
 }

--- a/app/assets/stylesheets/taxa/show/wikipedia.scss
+++ b/app/assets/stylesheets/taxa/show/wikipedia.scss
@@ -3,6 +3,10 @@
   width: 100%;
   line-height: 1.6em;
 
+  p {
+    line-height: 1.8em;
+  }
+
   // hide taxobox
   .infobox.biota,
   .taxobox_v3,

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -1062,8 +1062,12 @@ class TaxaController < ApplicationController
       ]
     end
     # Perform caching here as opposed to caches_action so we can set request headers appropriately
-    key = "views/taxa/#{@taxon.id}/description?#{request.query_parameters.merge( locale: I18n.locale ).to_a.join{|k,v| "#{k}=#{v}"}}"
-    @description = Rails.cache.read( key )
+    key = "views/taxa/#{@taxon.id}/description?#{request.query_parameters.merge( locale: I18n.locale ).to_a.join{|k,v| "#{k}=#{v}"}}&v2"
+    if cached_description = Rails.cache.read( key )
+      @description = cached_description[:description]
+      @describer_url = cached_description[:url]
+      @describer = TaxonDescribers.get_describer( cached_description[:describer] )&.new( locale: I18n.locale )
+    end
     # We only need to fetch new data for logged in users and when the cache is empty
     if logged_in? || @description.blank?
       # Fall back to English wikipedia as a last resort unless the default
@@ -1098,12 +1102,15 @@ class TaxaController < ApplicationController
         response.headers["X-Describer-URL"] = @describer_url
       end
       if !@description.blank? && !logged_in?
-        Rails.cache.write( key, @description, expires_in: 1.day )
-        Rails.cache.write( "#{key}-describer", @describer.describer_name || @describer.name.split( "::" ).last, expires_in: 1.day )
+        Rails.cache.write( key, {
+          description: @description,
+          describer:  @describer.describer_name || @describer.name.split( "::" ).last,
+          url: @describer_url
+        }, expires_in: 1.day )
       end
     # If we have cached content and a cached describer name, set the response headers
-    elsif !@description.blank? && ( @describer = TaxonDescribers.get_describer( Rails.cache.read( "#{key}-describer" ) ) )
-      @describer_url = @describer.page_url( @taxon )
+    elsif !@description.blank? && @describer
+      @describer_url ||= @describer.page_url( @taxon )
       response.headers["X-Describer-Name"] = @describer.describer_name || @describer.name.split( "::" ).last
       response.headers["X-Describer-URL"] = @describer_url
     end

--- a/app/views/taxa/_description.html.haml
+++ b/app/views/taxa/_description.html.haml
@@ -5,7 +5,7 @@
   css_class = "clear taxon_description"
   if @describer
     css_class += " #{@describer.name.split('::').last.underscore}_description"
-    if @describer.is_a?( TaxonDescribers::Wikipedia ) || @describer.ancestors.include?( TaxonDescribers::Wikipedia )
+    if @describer.is_a?( TaxonDescribers::Wikipedia ) || @describer.class.ancestors.include?( TaxonDescribers::Wikipedia )
       css_class += " wikipedia_description"
     end
   end
@@ -14,8 +14,8 @@
     =t :description_from
     - if @describer
       = select_tag :from, options_for_select(@describers.sort_by(&:name).map{|d| [d.describer_name, d.name.split('::').last]}, :selected => @describer.name.split('::').last)
-      - if page_url = @describer.page_url(@taxon)
-        = link_to "#{t(:view_on)} #{@describer.describer_name} &rarr;".html_safe, page_url, :class => "externallink ui"
+      - if @describer_url
+        = link_to "#{t(:view_on)} #{@describer.describer_name} &rarr;".html_safe, @describer_url, :class => "externallink ui"
     - else
       %a{ href: @describer_url } Wikipedia
   - if @description.blank?

--- a/lib/taxon_describers/lib/taxon_describers/base.rb
+++ b/lib/taxon_describers/lib/taxon_describers/base.rb
@@ -2,6 +2,10 @@ module TaxonDescribers
   class Base
 
     class_attribute :describer
+
+    def initialize( options = {} )
+    end
+
     def describe(taxon)
       taxon.wikipedia_summary || "No description"
     end

--- a/lib/taxon_describers/lib/taxon_describers/eol.rb
+++ b/lib/taxon_describers/lib/taxon_describers/eol.rb
@@ -1,5 +1,10 @@
 module TaxonDescribers
   class Eol < Base
+    def initialize( options = {} )
+      super( options )
+      @page_urls = {}
+    end
+
     def describe(taxon)
       pages = eol_service.search(taxon.name, :exact => true)
       return if pages.blank?
@@ -7,6 +12,7 @@ module TaxonDescribers
       return unless id
       page = eol_service.page( id, texts_per_page: 50, subjects: "all", details: true )
       return unless page
+      @page_urls[taxon.id] = "https://eol.org/pages/#{id}"
       page.remove_namespaces!
       data_objects = data_objects_from_page(page).to_a.uniq do |data_object|
         data_object.at('subject').content
@@ -16,8 +22,8 @@ module TaxonDescribers
       nil
     end
 
-    def page_url(taxon)
-      "http://eol.org/#{taxon.name}"
+    def page_url( taxon )
+      @page_urls[taxon.id] || "https://eol.org/search?q=#{taxon.name}"
     end
 
     def self.describer_name

--- a/lib/taxon_describers/lib/taxon_describers/wikipedia.rb
+++ b/lib/taxon_describers/lib/taxon_describers/wikipedia.rb
@@ -14,9 +14,10 @@ module TaxonDescribers
         # those are the taxon IDs Wikidata has ingested, so unfortunately this
         # can't really be tested
         if r = fetch_head( "https://hub.toolforge.org/P3151:#{taxon.id}?lang=#{@locale}" )
-          r.header[:location].split( "/" ).last
+          r.header[:location].to_s.split( "/" ).last
         end
       end
+      title = CGI.unescape( title ) unless title.blank?
       title = taxon.wikipedia_title if title.blank?
       title = taxon.name if title.blank?
       decoded = ""
@@ -41,7 +42,6 @@ module TaxonDescribers
       decoded = coder.decode(html)
       decoded.gsub!(/href="\/([A-z])/, "href=\"#{wikipedia.base_url}/\\1")
       decoded.gsub!(/src="\/([A-z])/, "src=\"#{wikipedia.base_url}/\\1")
-      decoded.gsub!(/<table .*?class=.*?ambox.*?>.+?<\/table>/, '')
       decoded.gsub!(/<div .*?class=.*?hatnote.*?>.+?<\/div>/, '')
       if options[:strip_references]
         decoded.gsub!(/<sup .*?class=.*?reference.*?>.+?<\/sup>/, '')

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -60,4 +60,5 @@ class WikipediaService < MetaService
   def sanitizer
     @sanitizer ||= HTML::WhiteListSanitizer.new
   end
+
 end

--- a/spec/lib/taxon_describers/wikipedia_spec.rb
+++ b/spec/lib/taxon_describers/wikipedia_spec.rb
@@ -3,14 +3,12 @@ require "spec_helper"
 describe "TaxonDescribers" do
   describe "Wikipedia" do
 
-    before(:all) do
-      @animalia = Taxon.make!(name: "Animalia")
-      @wikipedia = TaxonDescribers::Wikipedia.new
-    end
+    let(:animalia) { Taxon.make!( name: "Animalia" ) }
+    let(:wikipedia) { TaxonDescribers::Wikipedia.new }
 
     it "creates the endpoint" do
       expect(ApiEndpoint.count).to eq 0
-      @wikipedia.describe(@animalia)
+      wikipedia.describe( animalia )
       expect(ApiEndpoint.count).to eq 1
       endpoint = ApiEndpoint.first
       expect(endpoint.title).to eq "Wikipedia (EN)"
@@ -21,41 +19,43 @@ describe "TaxonDescribers" do
     end
 
     it "creates the endpoint based on locale" do
-      I18n.locale = "fr"
-      @wikipedia.describe(@animalia)
-      expect(ApiEndpoint.first.title).to eq "Wikipedia (FR)"
-      I18n.locale = "en"
+      I18n.with_locale :fr do
+        wikipedia.describe( animalia )
+        expect( ApiEndpoint.first.title ).to eq "Wikipedia (FR)"
+      end
     end
 
     it "caches the result" do
-      expect(ApiEndpointCache.count).to eq 0
-      @wikipedia.describe(@animalia)
-      expect(ApiEndpointCache.count).to eq 1
+      expect( ApiEndpointCache.count ).to eq 0
+      wikipedia.describe( animalia )
+      expect( ApiEndpointCache.count ).to eq 1
       cache = ApiEndpointCache.first
-      expect(cache.request_url).to eq(
-        "https://en.wikipedia.org/w/api.php?page=Animalia&redirects=true&action=parse&format=xml")
-      expect(cache.cached?).to be true
+      expect( cache.request_url ).to eq(
+        "https://en.wikipedia.org/w/api.php?page=Animalia&redirects=true&action=parse&format=xml"
+      )
+      expect( cache.cached? ).to be true
     end
 
     it "caches the result based on locale" do
-      I18n.locale = "fr"
-      @wikipedia.describe(@animalia)
-      expect(ApiEndpointCache.first.request_url).to eq(
-        "https://fr.wikipedia.org/w/api.php?page=Animalia&redirects=true&action=parse&format=xml")
-      I18n.locale = "en"
+      I18n.with_locale :fr do
+        wikipedia.describe( animalia )
+        expect( ApiEndpointCache.first.request_url ).to eq(
+          "https://fr.wikipedia.org/w/api.php?page=Animalia&redirects=true&action=parse&format=xml"
+        )
+      end
     end
 
     it "strips references and errors from html" do
       html = "Beggining <sup class='reference.'>1<\/sup> middle <strong class='error'>X<\/strong> end"
-      expect(@wikipedia.clean_html(html)).to eq html
-      expect(@wikipedia.clean_html(html, strip_references: true)).
-        to eq("Beggining  middle  end")
+      expect( wikipedia.clean_html( html ) ).to eq html
+      expect(
+        wikipedia.clean_html( html, strip_references: true )
+      ).to eq( "Beggining  middle  end" )
     end
 
     it "generates a page_url for a taxon" do
-      t = Taxon.make!(name: "Some great name")
-      expect(@wikipedia.page_url(t)).to eq(
-        "https://en.wikipedia.org/wiki/Some_great_name")
+      t = Taxon.make!( name: "Some great name" )
+      expect( wikipedia.page_url( t ) ).to eq( "https://en.wikipedia.org/wiki/Some_great_name" )
     end
 
   end


### PR DESCRIPTION
Specifically, this uses HEAD requests to https://hub.toolforge.org to map the iNat production taxon ID to a Wikipedia URL in a specific locale, so even if that language's Wikipedia doesn't have a page corresponding to that name, we can still show Wikipedia content.

Note that this starts storing the page content *and* the URL in a 24-hour cache, but doesn't cache requests to the hub service with an `ApiEndpointCache` like we do for some other services, b/c this service doesn't actually return a request body to cache.

The hub service is hosted by Wikimedia so presumably it won't stress them out too much if we hit it a lot, but if it does we'll need to start pre-caching these data from Wikidata. Some notes on how best to get this data from Wikidata at

https://forum.inaturalist.org/t/use-wikidata-to-link-to-appropriate-wikipedia-articles-in-all-languages/5538/22
https://forum.inaturalist.org/t/use-wikidata-for-place-names-and-wikipedia-descriptions/7702