### PR TITLE
Change lifelist count based on taxa

### DIFF
--- a/app/assets/javascripts/i18n/translations.js
+++ b/app/assets/javascripts/i18n/translations.js
@@ -17963,6 +17963,7 @@ I18n.translations["en"] = {
       "observations_of_exactly_this_taxon": "Observations of exactly this taxon",
       "observations_within_this_taxon": "Observations within this taxon",
       "observed_species": "Observed Species",
+      "observed_rank": "Observed %{rank}",
       "reset_place_filter": "Reset Place Filter",
       "restrict_to_leaf_taxa": "Restrict to leaf taxa",
       "restrict_to_taxa_observed_in_place": "Restrict to taxa observed in %{place}",

--- a/app/webpack/lifelists/show/components/details_view.jsx
+++ b/app/webpack/lifelists/show/components/details_view.jsx
@@ -123,7 +123,7 @@ const DetailsView = ( {
     }
   } else if ( lifelist.detailsView === "species" ) {
     title = I18n.t( "views.lifelists.all_species" );
-    let count = lifelist.detailsTaxon ? _.size( filteredNodes( lifelist ) ) : lifelist.leavesCount;
+    let count = _.size( filteredNodes( lifelist ) );
     searchLoaded = true;
     if ( lifelist.speciesPlaceFilter ) {
       inatAPIsearch = inatAPI.speciesPlace;
@@ -145,7 +145,8 @@ const DetailsView = ( {
       <div className="stats">
         <span className="stat">
           <span className="attr">
-            { I18n.t( "views.lifelists.observed_rank", { rank: rankLabel( lifelist.speciesViewRankFilter ) } ) }
+            { I18n.t( "views.lifelists.observed_rank",
+              { rank: rankLabel( { rank: lifelist.speciesViewRankFilter, withLeaves: false } ) } ) }
           </span>
           <span className="value">
             { searchLoaded

--- a/app/webpack/lifelists/show/components/details_view.jsx
+++ b/app/webpack/lifelists/show/components/details_view.jsx
@@ -8,6 +8,7 @@ import PlaceAutocomplete from "../../../observations/identify/components/place_a
 import Observations from "./observations";
 import Species from "./species";
 import SpeciesNoAPIContainer from "../containers/species_noapi_container";
+import { filteredNodes, rankLabel } from "../util";
 
 const ObservationsGridContainer = APIWrapper( "observations", Observations );
 const UnobservedSpeciesGridContainer = APIWrapper( "unobservedSpecies", Species );
@@ -122,8 +123,7 @@ const DetailsView = ( {
     }
   } else if ( lifelist.detailsView === "species" ) {
     title = I18n.t( "views.lifelists.all_species" );
-    let count = lifelist.detailsTaxon
-      ? lifelist.detailsTaxon.descendantCount : lifelist.leavesCount;
+    let count = lifelist.detailsTaxon ? _.size( filteredNodes( lifelist ) ) : lifelist.leavesCount;
     searchLoaded = true;
     if ( lifelist.speciesPlaceFilter ) {
       inatAPIsearch = inatAPI.speciesPlace;
@@ -145,7 +145,7 @@ const DetailsView = ( {
       <div className="stats">
         <span className="stat">
           <span className="attr">
-            { I18n.t( "views.lifelists.observed_species" ) }
+            { I18n.t( "views.lifelists.observed_rank", { rank: rankLabel( lifelist.speciesViewRankFilter ) } ) }
           </span>
           <span className="value">
             { searchLoaded

--- a/app/webpack/lifelists/show/components/species_noapi.jsx
+++ b/app/webpack/lifelists/show/components/species_noapi.jsx
@@ -3,66 +3,15 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { DropdownButton, MenuItem } from "react-bootstrap";
 import TaxonThumbnail from "../../../taxa/show/components/taxon_thumbnail";
+import { rankLabel, filteredNodes, nodeObsCount } from "../util";
 
 class SpeciesNoAPI extends Component {
   secondaryNodeList( ) {
     const {
-      lifelist, detailsTaxon, setScrollPage, config, zoomToTaxon,
-      search, setSpeciesPlaceFilter
+      lifelist, detailsTaxon, setScrollPage, config, zoomToTaxon, setSpeciesPlaceFilter
     } = this.props;
-    let nodeShouldDisplay;
-    const nodeIsDescendant = ( !detailsTaxon || detailsTaxon === "root" )
-      ? ( ) => true
-      : node => node.left >= detailsTaxon.left && node.right <= detailsTaxon.right;
-    const obsCount = node => {
-      if ( lifelist.speciesPlaceFilter
-          && search
-          && search.searchResponse
-          && search.loaded
-      ) {
-        return search.searchResponse.results[node.id] || 0;
-      }
-      return node.descendant_obs_count;
-    };
-    if ( lifelist.speciesViewRankFilter === "all" ) {
-      if ( !detailsTaxon || detailsTaxon === "root" ) {
-        nodeShouldDisplay = nodeIsDescendant;
-      } else {
-        nodeShouldDisplay = node => (
-          ( detailsTaxon.left === detailsTaxon.right - 1 && node.id === detailsTaxon.id )
-          || ( node.left > detailsTaxon.left && node.right < detailsTaxon.right )
-        );
-      }
-    } else if ( lifelist.speciesViewRankFilter === "children" ) {
-      nodeShouldDisplay = node => node.parent_id === ( !detailsTaxon || detailsTaxon === "root" ? 0 : detailsTaxon.id );
-    } else if ( lifelist.speciesViewRankFilter === "major" ) {
-      nodeShouldDisplay = node => node.rank_level % 10 === 0;
-    } else if ( lifelist.speciesViewRankFilter === "kingdoms" ) {
-      nodeShouldDisplay = node => node.rank_level === 70;
-    } else if ( lifelist.speciesViewRankFilter === "phyla" ) {
-      nodeShouldDisplay = node => node.rank_level === 60;
-    } else if ( lifelist.speciesViewRankFilter === "classes" ) {
-      nodeShouldDisplay = node => node.rank_level === 50;
-    } else if ( lifelist.speciesViewRankFilter === "orders" ) {
-      nodeShouldDisplay = node => node.rank_level === 40;
-    } else if ( lifelist.speciesViewRankFilter === "families" ) {
-      nodeShouldDisplay = node => node.rank_level === 30;
-    } else if ( lifelist.speciesViewRankFilter === "genera" ) {
-      nodeShouldDisplay = node => node.rank_level === 20;
-    } else if ( lifelist.speciesViewRankFilter === "species" ) {
-      nodeShouldDisplay = node => node.rank_level === 10;
-    } else if ( lifelist.speciesViewRankFilter === "leaves" ) {
-      nodeShouldDisplay = node => (
-        node.rank_level === 10 || (
-          node.left === node.right - 1 && node.rank_level > 10
-        ) || (
-          detailsTaxon && detailsTaxon.rank_level < 10 && detailsTaxon.id === node.id
-        )
-      );
-    }
-    if ( !nodeShouldDisplay ) return null;
-    const secondaryNodes = _.filter( lifelist.taxa,
-      t => nodeIsDescendant( t ) && nodeShouldDisplay( t ) && obsCount( t ) );
+    const obsCount = nodeObsCount( lifelist );
+    const secondaryNodes = filteredNodes( lifelist );
     let moreButton;
     if ( lifelist.speciesViewScrollPage < (
       Math.ceil( _.size( secondaryNodes ) ) / lifelist.speciesViewPerPage ) ) {
@@ -169,29 +118,10 @@ class SpeciesNoAPI extends Component {
       lifelist, detailsTaxon, setRankFilter, setSort, search
     } = this.props;
     if ( !lifelist.taxa || !lifelist.children ) { return ( <span /> ); }
-    let rankLabel = I18n.t( "views.lifelists.dropdowns.children" );
-    if ( lifelist.speciesViewRankFilter === "kingdoms" ) {
-      rankLabel = I18n.t( "ranks.x_kingdoms", { count: 2 } );
-    } else if ( lifelist.speciesViewRankFilter === "phyla" ) {
-      rankLabel = I18n.t( "ranks.x_phyla", { count: 2 } );
-    } else if ( lifelist.speciesViewRankFilter === "classes" ) {
-      rankLabel = I18n.t( "ranks.x_classes", { count: 2 } );
-    } else if ( lifelist.speciesViewRankFilter === "orders" ) {
-      rankLabel = I18n.t( "ranks.x_orders", { count: 2 } );
-    } else if ( lifelist.speciesViewRankFilter === "families" ) {
-      rankLabel = I18n.t( "ranks.x_families", { count: 2 } );
-    } else if ( lifelist.speciesViewRankFilter === "genera" ) {
-      rankLabel = I18n.t( "ranks.x_genera", { count: 2 } );
-    } else if ( lifelist.speciesViewRankFilter === "species" ) {
-      rankLabel = I18n.t( "ranks.species" );
-    } else if ( lifelist.speciesViewRankFilter === "leaves" ) {
-      rankLabel = I18n.t( "ranks.leaves" );
-    }
-    rankLabel = `${I18n.t( "views.lifelists.dropdowns.show" )}: ${rankLabel}`;
 
     const rankOptions = (
       <DropdownButton
-        title={rankLabel}
+        title={`${I18n.t( "views.lifelists.dropdowns.show" )}: ${rankLabel( lifelist.speciesViewRankFilter )}`}
         id="rankDropdown"
         onSelect={key => setRankFilter( key )}
       >

--- a/app/webpack/lifelists/show/components/species_noapi.jsx
+++ b/app/webpack/lifelists/show/components/species_noapi.jsx
@@ -121,7 +121,9 @@ class SpeciesNoAPI extends Component {
 
     const rankOptions = (
       <DropdownButton
-        title={`${I18n.t( "views.lifelists.dropdowns.show" )}: ${rankLabel( lifelist.speciesViewRankFilter )}`}
+        title={`${I18n.t( "views.lifelists.dropdowns.show" )}: ${rankLabel(
+          { rank: lifelist.speciesViewRankFilter }
+        )}`}
         id="rankDropdown"
         onSelect={key => setRankFilter( key )}
       >

--- a/app/webpack/lifelists/show/util.js
+++ b/app/webpack/lifelists/show/util.js
@@ -61,7 +61,7 @@ function filteredNodes( lifelist ) {
     t => nodeIsDescendant( t ) && nodeShouldDisplay( t ) && obsCount( t ) );
 }
 
-function rankLabel( filter ) {
+function rankLabel( { rank: filter, withLeaves = true } = {} ) {
   switch ( filter ) {
     case "kingdoms":
     case "phyla":
@@ -72,7 +72,7 @@ function rankLabel( filter ) {
     case "species":
       return I18n.t( `ranks.x_${filter}`, { count: 2 } );
     case "leaves":
-      return I18n.t( "ranks.leaves" );
+      return ( withLeaves ? I18n.t( "ranks.leaves" ) : I18n.t( "ranks.x_species", { count: 2 } ) );
     default:
       return I18n.t( "views.lifelists.dropdowns.children" );
   }

--- a/app/webpack/lifelists/show/util.js
+++ b/app/webpack/lifelists/show/util.js
@@ -1,0 +1,85 @@
+function nodeObsCount( lifelist ) {
+  const { search } = lifelist;
+  return function ( node ) {
+    if ( lifelist.speciesPlaceFilter
+      && search
+      && search.searchResponse
+      && search.loaded
+    ) {
+      return search.searchResponse.results[node.id] || 0;
+    }
+    return node.descendant_obs_count;
+  };
+}
+
+function filteredNodes( lifelist ) {
+  const { detailsTaxon, search } = lifelist;
+  let nodeShouldDisplay;
+  const nodeIsDescendant = ( !detailsTaxon || detailsTaxon === "root" )
+    ? ( ) => true
+    : node => node.left >= detailsTaxon.left && node.right <= detailsTaxon.right;
+  const obsCount = nodeObsCount( lifelist, search );
+  if ( lifelist.speciesViewRankFilter === "all" ) {
+    if ( !detailsTaxon || detailsTaxon === "root" ) {
+      nodeShouldDisplay = nodeIsDescendant;
+    } else {
+      nodeShouldDisplay = node => (
+        ( detailsTaxon.left === detailsTaxon.right - 1 && node.id === detailsTaxon.id )
+        || ( node.left > detailsTaxon.left && node.right < detailsTaxon.right )
+      );
+    }
+  } else if ( lifelist.speciesViewRankFilter === "children" ) {
+    nodeShouldDisplay = node => node.parent_id === ( !detailsTaxon || detailsTaxon === "root" ? 0 : detailsTaxon.id );
+  } else if ( lifelist.speciesViewRankFilter === "major" ) {
+    nodeShouldDisplay = node => node.rank_level % 10 === 0;
+  } else if ( lifelist.speciesViewRankFilter === "kingdoms" ) {
+    nodeShouldDisplay = node => node.rank_level === 70;
+  } else if ( lifelist.speciesViewRankFilter === "phyla" ) {
+    nodeShouldDisplay = node => node.rank_level === 60;
+  } else if ( lifelist.speciesViewRankFilter === "classes" ) {
+    nodeShouldDisplay = node => node.rank_level === 50;
+  } else if ( lifelist.speciesViewRankFilter === "orders" ) {
+    nodeShouldDisplay = node => node.rank_level === 40;
+  } else if ( lifelist.speciesViewRankFilter === "families" ) {
+    nodeShouldDisplay = node => node.rank_level === 30;
+  } else if ( lifelist.speciesViewRankFilter === "genera" ) {
+    nodeShouldDisplay = node => node.rank_level === 20;
+  } else if ( lifelist.speciesViewRankFilter === "species" ) {
+    nodeShouldDisplay = node => node.rank_level === 10;
+  } else if ( lifelist.speciesViewRankFilter === "leaves" ) {
+    nodeShouldDisplay = node => (
+      node.rank_level === 10 || (
+        node.left === node.right - 1 && node.rank_level > 10
+      ) || (
+        detailsTaxon && detailsTaxon.rank_level < 10 && detailsTaxon.id === node.id
+      )
+    );
+  }
+  if ( !nodeShouldDisplay ) return null;
+
+  return _.filter( lifelist.taxa,
+    t => nodeIsDescendant( t ) && nodeShouldDisplay( t ) && obsCount( t ) );
+}
+
+function rankLabel( filter ) {
+  switch ( filter ) {
+    case "kingdoms":
+    case "phyla":
+    case "classes":
+    case "orders":
+    case "families":
+    case "genera":
+    case "species":
+      return I18n.t( `ranks.x_${filter}`, { count: 2 } );
+    case "leaves":
+      return I18n.t( "ranks.leaves" );
+    default:
+      return I18n.t( "views.lifelists.dropdowns.children" );
+  }
+}
+
+export {
+  rankLabel,
+  filteredNodes,
+  nodeObsCount
+};

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5146,6 +5146,7 @@ en:
       list_view: List View
       tree_view: Tree View
       observed_species: Observed Species
+      observed_rank: Observed %{rank}
       unobserved_species: Unobserved Species
       all_species: All Species
       all_unobserved_species: All Unobserved Species


### PR DESCRIPTION
#2870 

Dynamically changes count based on taxa in new lifelist. The count was
originally calculated in the 'species_noapi' component. Now it, along
with the taxa filter labeling logic, are in a shared util function.

