### PR TITLE
Monitor Google map creation

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js
+++ b/app/assets/javascripts/ang/controllers/observation_search.js
@@ -1163,6 +1163,7 @@ function( ObservationsFactory, PlacesFactory, shared, $scope, $rootScope ) {
     if( $scope.map ) { return; }
     var defaultMapType = PREFERRED_MAP_TYPE || google.maps.MapTypeId.LIGHT;
     $( "#map" ).taxonMap({
+      placement: "observations-search",
       urlCoords: false,
       mapType: defaultMapType,
       showAllLayer: false,

--- a/app/assets/javascripts/inaturalist.js.erb
+++ b/app/assets/javascripts/inaturalist.js.erb
@@ -102,10 +102,10 @@ var iNaturalist = window.iNaturalist = new function(){
 
   this.log = function( params ) {
     try {
-      const apiUrl = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
+      var apiUrl = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
       if ( !apiUrl ) return;
-      const jwt = $( "meta[name='inaturalist-api-token']" ).attr( "content" );
-      let url = apiUrl + "/log";
+      var jwt = $( "meta[name='inaturalist-api-token']" ).attr( "content" );
+      var url = apiUrl + "/log";
       var opts = params || {};
       opts.pathname = window.location.pathname
         ? window.location.pathname.replace( /\d+(\-[^\/\?]+)?$/, ":id" )

--- a/app/assets/javascripts/inaturalist.js.erb
+++ b/app/assets/javascripts/inaturalist.js.erb
@@ -102,6 +102,10 @@ var iNaturalist = window.iNaturalist = new function(){
 
   this.log = function( params ) {
     try {
+      // Restrict logging to the default site for now
+      if ( typeof( SITE ) !== "object" && SITE.name !== "iNaturalist" ) {
+        return;
+      }
       var apiUrl = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
       if ( !apiUrl ) return;
       var jwt = $( "meta[name='inaturalist-api-token']" ).attr( "content" );

--- a/app/assets/javascripts/inaturalist.js.erb
+++ b/app/assets/javascripts/inaturalist.js.erb
@@ -103,7 +103,7 @@ var iNaturalist = window.iNaturalist = new function(){
   this.log = function( params ) {
     try {
       // Restrict logging to the default site for now
-      if ( typeof( SITE ) !== "object" && SITE.name !== "iNaturalist" ) {
+      if ( typeof( SITE ) !== "object" || SITE.name !== "iNaturalist" ) {
         return;
       }
       var apiUrl = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
@@ -114,7 +114,8 @@ var iNaturalist = window.iNaturalist = new function(){
       opts.pathname = window.location.pathname
         ? window.location.pathname.replace( /\d+(\-[^\/\?]+)?$/, ":id" )
         : "unknwown";
-      opts.pathname = opts.pathname.replace( /projects\/[^\/]+$/, "projects/:id" )
+      opts.pathname = opts.pathname.replace( /projects\/[^\/]+$/, "projects/:id" );
+      opts.pathname = opts.pathname.replace( /observations\/[^\/]+$/, "observations/:login" );
       url += "?" + $.param( params );
       var ajaxOpts = { url: url };
       if ( jwt && jwt.length > 0 ) {

--- a/app/assets/javascripts/inaturalist.js.erb
+++ b/app/assets/javascripts/inaturalist.js.erb
@@ -100,6 +100,29 @@ var iNaturalist = window.iNaturalist = new function(){
     }) ]
   end].to_json %>;
 
+  this.log = function( params ) {
+    try {
+      const apiUrl = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
+      if ( !apiUrl ) return;
+      const jwt = $( "meta[name='inaturalist-api-token']" ).attr( "content" );
+      let url = apiUrl + "/log";
+      var opts = params || {};
+      opts.pathname = window.location.pathname
+        ? window.location.pathname.replace( /\d+(\-[^\/\?]+)?$/, ":id" )
+        : "unknwown";
+      opts.pathname = opts.pathname.replace( /projects\/[^\/]+$/, "projects/:id" )
+      url += "?" + $.param( params );
+      var ajaxOpts = { url: url };
+      if ( jwt && jwt.length > 0 ) {
+        ajaxOpts.headers = { "Authorization": jwt };
+      }
+      $.ajax( ajaxOpts );
+    } catch ( e ) {
+      // Logging should never really throw an exception
+      console.log( "[DEBUG] Failed to log: ", e );
+    }
+  }
+
 }; // end of the iNaturalist singleton
 
 // Class properties

--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -413,6 +413,8 @@ iNaturalist.Map.MapTypes.light_no_labels = new google.maps.StyledMapType([
 // static functions
 iNaturalist.Map.createMap = function(options) {
   options = options || {}
+  var placement = options.placement;
+  delete options.placement;
   options = $.extend({}, {
     div: 'map',
     center: new google.maps.LatLng(options.lat || 0, options.lng || 0),
@@ -429,7 +431,7 @@ iNaturalist.Map.createMap = function(options) {
   }, options);
   
   var map;
-  
+  iNaturalist.log( { "map-placement": placement || "unknown" } );
   if (typeof options.div == 'string') {
     map = new google.maps.Map(document.getElementById(options.div), options);
   }

--- a/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
@@ -93,15 +93,13 @@ inatTaxonMap.setupGoogleMap = function( elt ) {
   var options = $(elt).data('taxonMapOptions');
   var map,
       mapOptions = $.extend( true, { }, {
+        backgroundColor: '#E3EAF6',
+        gestureHandling: options.gestureHandling,
         mapTypeControl: (options.mapTypeControl !== false),
         mapTypeControlOptions: options.mapTypeControlOptions,
         minZoom: options.minZoom,
-        backgroundColor: '#E3EAF6',
-        zoomControl: (options.zoomControl !== false),
-        zoomControlOptions: options.zoomControlOptions,
+        placement: options.placement,
         scrollwheel: (options.scrollwheel !== false),
-        gestureHandling: options.gestureHandling,
-        tilt: options.tilt,
         styles: [
           {
             stylers: [
@@ -109,7 +107,10 @@ inatTaxonMap.setupGoogleMap = function( elt ) {
               {saturation: -50}
             ]
           }
-        ]
+        ],
+        tilt: options.tilt,
+        zoomControl: (options.zoomControl !== false),
+        zoomControlOptions: options.zoomControlOptions
       } );
   if ( $(elt).data('taxonMap') ) {
     map = $(elt).data('taxonMap');

--- a/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
@@ -46,6 +46,7 @@ inatTaxonMap.setup = function ( elt, options ) {
   options.featuredLayerDescription = options.featuredLayerDescription || $(elt).data('featured-layer-description');
   options.placeLayerLabel = options.placeLayerLabel || $(elt).data('place-layer-label');
   options.placeLayerDescription = options.placeLayerDescription || $(elt).data('place-layer-description');
+  options.placement = options.placement || $(elt).data( "placement" );
   options.taxonRangeLayerLabel = options.taxonRangeLayerLabel || $(elt).data('taxon-range-layer-label') || I18n.t("maps.overlays.range");
   options.taxonRangeLayerDescription = options.taxonRangeLayerDescription || $(elt).data('taxon-range-layer-description');
   options.taxonPlacesLayerLabel = options.taxonPlacesLayerLabel || $(elt).data('taxon-places-layer-label') || I18n.t("maps.overlays.checklist_places");

--- a/app/assets/javascripts/projects/show.js
+++ b/app/assets/javascripts/projects/show.js
@@ -1,6 +1,6 @@
 $( document ).ready( function( ) {
 
-  $( "#map" ).taxonMap( { preserveViewport: PRESERVE_VIEWPORT } );
+  $( "#map" ).taxonMap( { preserveViewport: PRESERVE_VIEWPORT, placement: "projects-show-traditional" } );
   window.map = $( "#map" ).data( "taxonMap" );
   for ( var i=0; i < KML_ASSET_URLS.length; i++ ) {
     lyr = new google.maps.KmlLayer( KML_ASSET_URLS[i], { preserveViewport: PRESERVE_VIEWPORT } );

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -743,7 +743,8 @@ module ApplicationHelper
       "map-style" => options[:map_style],
       "elastic_params" => options[:elastic_params] ?
         options[:elastic_params].map{ |k,v| "#{k}=#{v}" }.join("&") : nil,
-      "gesture-handling" => options[:gesture_handling]
+      "gesture-handling" => options[:gesture_handling],
+      "placement" => options[:placement]
     }
     append_taxon_layers(map_tag_attrs, options)
     append_place_layers(map_tag_attrs, options)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,13 @@
       I18n.defaultLocale = "en"
       I18n.locale = "<%= I18n.locale %>"
       I18n.fallbacks = true
+      <% if @site %>
+        var SITE = {
+          name: "<%= @site.name %>",
+          short_name: "<%= @site.site_name_short %>",
+          logo_square: "<%= @site.logo_square.url %>"
+        };
+      <% end %>
       <% site_place = @site && @site.place
          user_place = current_user && current_user.place -%>
       <% if site_place -%>

--- a/app/views/observations/by_login.html.erb
+++ b/app/views/observations/by_login.html.erb
@@ -15,7 +15,7 @@
   <script type="text/javascript" charset="utf-8">
     $(document).ready( function( ) {
       // render map
-      $("#map").taxonMap({ appendMarkerToList: true });
+      $("#map").taxonMap({ appendMarkerToList: true, placement: "observations-login" });
       window.map = $("#map").data("taxonMap");
       // Reveal columns
       $('.created_at').show();

--- a/app/views/taxa/map.html.haml
+++ b/app/views/taxa/map.html.haml
@@ -33,6 +33,7 @@
     },
     disable_fullscreen: true,
     min_zoom: 2,
-    url_coords: true
+    url_coords: true,
+    placement: params[:placement]
   )
 #map.fullscreen{ a }

--- a/app/views/taxon_changes/show.html.haml
+++ b/app/views/taxon_changes/show.html.haml
@@ -85,7 +85,7 @@
   .row
     .col-xs-12
       #mapwrapper.stacked
-        %iframe.stacked{:height => "600", :src => "#{taxa_map_url(:taxa => [@taxon_change.taxon, @taxon_change.taxa].flatten.compact.map{|t| t.id})}", :width => "100%"}
+        %iframe.stacked{:height => "600", :src => "#{taxa_map_url(:taxa => [@taxon_change.taxon, @taxon_change.taxa].flatten.compact.map{|t| t.id}, placement: "taxon-changes-show" )}", :width => "100%"}
   .row
     .col-xs-12
       #comments.column.span-18

--- a/app/webpack/observations/compare/components/map_comparison.jsx
+++ b/app/webpack/observations/compare/components/map_comparison.jsx
@@ -68,6 +68,7 @@ class MapComparison extends React.Component {
     if ( mapLayout === "combined" ) {
       maps = (
         <TaxonMap
+          placement={`observations-compare-${mapLayout}`}
           showAllLayer={false}
           gestureHandling="auto"
           minX={bounds.swlng}
@@ -87,6 +88,7 @@ class MapComparison extends React.Component {
           <div key={reloadKey} className="map">
             <h5>{ query.name }</h5>
             <TaxonMap
+              placement={`observations-compare-${mapLayout}`}
               reloadKey={reloadKey}
               showAllLayer={false}
               gestureHandling="auto"

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -174,6 +174,7 @@ class ObservationModal extends React.Component {
       taxonMap = (
         <TaxonMap
           key={`map-for-${obsForMap.id}`}
+          placement="obs-modal"
           reloadKey={`map-for-${obsForMap.id}-${obsForMap.private_latitude ? "full" : ""}`}
           taxonLayers={[taxonLayer]}
           observations={[obsForMap]}

--- a/app/webpack/observations/identify/components/suggestion_row.jsx
+++ b/app/webpack/observations/identify/components/suggestion_row.jsx
@@ -130,6 +130,7 @@ const SuggestionRow = ( {
             ) ) }
           </div>
           <TaxonMap
+            placement="suggestion-row"
             showAllLayer={false}
             minZoom={2}
             zoomLevel={6}

--- a/app/webpack/observations/identify/components/suggestions.jsx
+++ b/app/webpack/observations/identify/components/suggestions.jsx
@@ -401,6 +401,7 @@ class Suggestions extends React.Component {
                   }
                   <h4>{ I18n.t( "observations_map" ) }</h4>
                   <TaxonMap
+                    placement="suggestion-detail"
                     showAllLayer={false}
                     minZoom={2}
                     gbifLayerLabel={I18n.t( "maps.overlays.gbif_network" )}

--- a/app/webpack/observations/show/components/map.jsx
+++ b/app/webpack/observations/show/components/map.jsx
@@ -140,6 +140,7 @@ class Map extends React.Component {
       taxonMap = (
         <TaxonMap
           key={mapKey}
+          placement="observations-show"
           reloadKey={mapKey}
           taxonLayers={[taxonLayer]}
           observations={[obsForMap]}

--- a/app/webpack/observations/uploader/components/location_chooser_map.jsx
+++ b/app/webpack/observations/uploader/components/location_chooser_map.jsx
@@ -61,6 +61,9 @@ class LocationChooserMap extends React.Component {
     if ( this.map && !center ) {
       setTimeout( this.fitCircles, 10 );
     }
+    if ( this.map ) {
+      iNaturalist.log( { "map-placement": "observations-upload-location-chooser" } );
+    }
   }
 
   shouldComponentUpdate( nextProps ) {

--- a/app/webpack/projects/show/components/observations_map_view.jsx
+++ b/app/webpack/projects/show/components/observations_map_view.jsx
@@ -14,6 +14,7 @@ const ObservationsMapView = ( { project, config, updateCurrentUser } ) => {
         <Row>
           <Col xs={12}>
             <TaxonMap
+              placement="projects-show-observations"
               observationLayers={[Object.assign( { captive: "any" }, project.search_params )]}
               showAccuracy
               enableShowAllLayer={false}

--- a/app/webpack/projects/show/components/overview_map.jsx
+++ b/app/webpack/projects/show/components/overview_map.jsx
@@ -35,6 +35,7 @@ const OverviewMap = ( { project, config, updateCurrentUser } ) => {
         <Col xs={12}>
           <h2>{ title }</h2>
           <TaxonMap
+            placement="projects-show-overview"
             observationLayers={[Object.assign( { captive: "any" }, project.search_params )]}
             showAccuracy
             enableShowAllLayer={false}

--- a/app/webpack/projects/show/components/umbrella_map.jsx
+++ b/app/webpack/projects/show/components/umbrella_map.jsx
@@ -56,6 +56,7 @@ class UmbrellaMap extends Component {
           <Col xs={12}>
             <h2>{ I18n.t( "map_of_observations" ) }</h2>
             <TaxonMap
+              placement="projects-show-umbrella"
               key={`umbrellamap${project.id}`}
               observationLayers={[Object.assign( { captive: "any" }, project.search_params )]}
               showAccuracy

--- a/app/webpack/taxa/show/components/taxon_page_map.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_map.jsx
@@ -36,6 +36,7 @@ const TaxonPageMap = ( {
     }
     taxonMap = (
       <TaxonMap
+        placement="taxa-show"
         showAllLayer={false}
         minZoom={2}
         gbifLayerLabel={I18n.t( "maps.overlays.gbif_network" )}


### PR DESCRIPTION
This hits a [new logging endpoint](https://github.com/inaturalist/iNaturalistAPI/commit/558475671abf2de90323f712851ee814e5668959) most times we create a Google Map instance so we can investigate ways to cut down on use. This should monitor almost every Google Map on the site that goes through our custom `createMap` method in `map3.js.erb`, which means it's ignoring the location choose in the Uploader since that's using a third-party React component. The node endpoint is filtering by origin, which means it's denying all requests that don't come from inaturalist.org, so if the source of our extreme usage is on one of the partner sites we're going to miss that, but I figure this will at least get us started.