### PR TITLE
Separate locale JS files

### DIFF
--- a/app/assets/javascripts/application_bundle.js
+++ b/app/assets/javascripts/application_bundle.js
@@ -1,6 +1,6 @@
 //= require iso8601
 //= require i18n
-//= require i18n/translations
+//= require i18n/translations/en
 //= require i18n/pluralizations
 //= require i18n/inflections
 //= require jquery/plugins/jquery.qtip2.min

--- a/app/assets/javascripts/i18n/translations/.gitignore
+++ b/app/assets/javascripts/i18n/translations/.gitignore
@@ -1,0 +1,8 @@
+# This directory contains translations in JS that get generated on every
+# release, so there's no need to check them in (and in fact, checking them in
+# will probably lead to a lot of annoying conflict resolution in the future).
+# You can generate these files locally with
+# rake inaturalist:generate_translations_js
+*
+# We want this file to remain
+!.gitignore

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,11 +19,8 @@
     <%= javascript_include_tag "jquery/jquery-1.9.1.min" %>
     <%= javascript_include_tag "jquery/jquery-ui-1.9.1.min" %>
     <%= javascript_include_tag "bootstrap.min" %>
+    <%= render "shared/i18n" %>
     <script type="text/javascript">
-      I18n = { }
-      I18n.defaultLocale = "en"
-      I18n.locale = "<%= I18n.locale %>"
-      I18n.fallbacks = true
       <% if @site %>
         var SITE = {
           name: "<%= @site.name %>",

--- a/app/views/layouts/basic.html.haml
+++ b/app/views/layouts/basic.html.haml
@@ -9,14 +9,11 @@
     %meta{ http_equiv: "Content-Language", content: I18n.locale }
     - if current_user
       %meta{ name: "inaturalist-api-token", content: JsonWebToken.encode(user_id: current_user.id) }
+    = render "shared/i18n"
     = yield :extrahead
   %body
     = content_for?(:content) ? yield(:content) : yield
     %script{ type: "text/javascript" }
-      if( I18n === undefined ) { var I18n = { }; }
-      I18n.defaultLocale = "en";
-      I18n.locale = "#{ I18n.locale }";
-      I18n.fallbacks = true;
       - site_place = @site && @site.place
       - user_place = current_user && current_user.place
       var PREFERRED_PLACE;

--- a/app/views/layouts/basic.html.haml
+++ b/app/views/layouts/basic.html.haml
@@ -10,6 +10,7 @@
     - if current_user
       %meta{ name: "inaturalist-api-token", content: JsonWebToken.encode(user_id: current_user.id) }
     = render "shared/i18n"
+    = javascript_include_tag "i18n/translations/en.js"
     = yield :extrahead
   %body
     = content_for?(:content) ? yield(:content) : yield

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -141,13 +141,8 @@
 
     <%= javascript_include_tag "jquery/jquery-1.11.3.min.js" %>
     <%= javascript_include_tag "jquery/jquery-ui-1.11.4.min.js" %>
-
+    <%= render "shared/i18n" %>
     <script type="text/javascript">
-      I18n = { }
-      <% # Don't set this to CONFIG.default_locale, b/c I18n-js needs en as the final fallback %>
-      I18n.defaultLocale = "en";
-      I18n.locale = "<%= I18n.locale %>";
-      I18n.fallbacks = true;
       <% site_place = @site && @site.place
          user_place = current_user && current_user.place
          user_search_place = current_user && current_user.search_place -%>

--- a/app/views/observations/upload.html.haml
+++ b/app/views/observations/upload.html.haml
@@ -15,7 +15,6 @@
 #app
 = google_maps_js libraries: %w(places geometry drawing)
 - content_for :delayed_js do
-  = javascript_include_tag "i18n/translations"
   = javascript_include_tag "jquery/jquery-1.11.3.min.js"
   = javascript_include_tag "jquery/jquery-ui-1.11.4.min.js"
   = javascript_include_tag "inaturalist"

--- a/app/views/shared/_i18n.html.haml
+++ b/app/views/shared/_i18n.html.haml
@@ -1,0 +1,9 @@
+- # Sets up basica I18n JS, fallbacks, and includes the right translations file
+:javascript
+  I18n = { }
+  I18n.defaultLocale = "en";
+  I18n.locale = "#{I18n.locale}";
+  I18n.fallbacks = true;
+- I18n.fallbacks[I18n.locale].each do |l|
+  - if l != I18n.default_locale
+    = javascript_include_tag "i18n/translations/#{l}.js"

--- a/ci/scripts/before_script.sh
+++ b/ci/scripts/before_script.sh
@@ -22,3 +22,6 @@ RAILS_ENV=test bundle exec rake --trace db:setup
 
 echo "Setting up ES"
 RAILS_ENV=test bundle exec rake --trace es:rebuild
+
+echo "Building translation JS files"
+RAILS_ENV=test bundle exec rake --trace inaturalist:generate_translations_js

--- a/lib/tasks/inaturalist.rake
+++ b/lib/tasks/inaturalist.rake
@@ -450,11 +450,23 @@ namespace :inaturalist do
       end
     end
 
-    # output what should be the new contents of app/assets/javascripts/i18n/translations.js
-    File.open(output_path, "w") do |file|
-      file.puts "I18n.translations || (I18n.translations = {});"
-      all_translations.sort.each do |locale, translations|
+    # Make a JS file for translations in each locale
+    all_translations.sort.each do |locale, translations|
+      locale_file_path = "app/assets/javascripts/i18n/translations/#{locale}.js"
+      File.open( locale_file_path, "w" ) do |file|
+        file.puts "I18n.translations || (I18n.translations = {});"
         file.puts "I18n.translations[\"#{ locale }\"] = #{ JSON.pretty_generate( translations ) };"
+        # Add translations for each locale name translated into that locale's
+        # language so we can show language pickers that show the language
+        # translated into that language
+        all_translations.each do |locale_name_locale, locale_name_translations|
+          next if locale_name_locale == locale
+          file.puts "I18n.translations[\"#{locale_name_locale}\"] = I18n.translations[\"#{locale_name_locale}\"] || {};"
+          json = JSON.pretty_generate( locale_name_translations[:locales].select{ |k,v|
+            k == locale_name_locale
+          } )
+          file.puts "I18n.translations[\"#{locale_name_locale}\"][\"locales\"] = #{json};"
+        end
       end
     end
   end

--- a/spec/controllers/custom_projects_controller_spec.rb
+++ b/spec/controllers/custom_projects_controller_spec.rb
@@ -3,11 +3,11 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe CustomProjectsController, "new" do
   let(:project) { Project.make! }
   it "should not allow access to managers if project isn't trusted" do
-    project.should_not be_trusted
+    expect( project ).not_to be_trusted
     pu = ProjectUser.make!(:project => project, :role => "manager")
     sign_in pu.user
     get :new, :project_id => project.id
-    response.should be_redirect
+    expect( response ).to be_redirect
   end
   
   it "should not allow access to non-managers" do
@@ -15,7 +15,7 @@ describe CustomProjectsController, "new" do
     u = User.make!
     sign_in u
     get :new, :project_id => project.id
-    response.should be_redirect
+    expect( response ).to be_redirect
   end
 
   it "should allow access by managers if project trusted" do
@@ -23,13 +23,13 @@ describe CustomProjectsController, "new" do
     pu = ProjectUser.make!(:project => project, :role => "manager")
     sign_in pu.user
     get :new, :project_id => project.id
-    response.should be_success
+    expect( response ).to be_success
   end
 
   it "should allow access by admins" do
     u = make_admin
     sign_in u
     get :new, :project_id => project.id
-    response.should be_success
+    expect( response ).to be_success
   end
 end

--- a/spec/controllers/trips_controller_api_spec.rb
+++ b/spec/controllers/trips_controller_api_spec.rb
@@ -170,10 +170,13 @@ end
 
 describe TripsController, "oauth authentication" do
   let(:user) { User.make! }
-  let(:token) { double :acceptable? => true, :accessible? => true, :resource_owner_id => user.id, :application => OauthApplication.make! }
   before do
-    request.env["HTTP_AUTHORIZATION"] = "Bearer xxx"
-    controller.stub(:doorkeeper_token) { token }
+    token = Doorkeeper::AccessToken.create(
+      application: OauthApplication.make!,
+      resource_owner_id: user.id,
+      scopes: Doorkeeper.configuration.default_scopes
+    )
+    request.env["HTTP_AUTHORIZATION"] = "Bearer #{token.token}"
   end
   it_behaves_like "a TripsController"
 end


### PR DESCRIPTION
Creates separate JS files for translations in each locale instead of jamming them all into a single file and forcing everyone to download a bunch of stuff they'll never use. Tries to ensure that all locale files include the names of other locales in those locales, and to make sure that locale files for all relevant fallback locales get loaded (that means English is always loaded for everyone since it's the fallback of last resort).

Closes #2336