### PR TITLE
Fixes char counter not behaving as expected

### DIFF
--- a/app/webpack/shared/components/text_editor.jsx
+++ b/app/webpack/shared/components/text_editor.jsx
@@ -60,14 +60,10 @@ class TextEditor extends React.Component {
       showCharsRemainingAt,
       onBlur
     } = this.props;
-    const { textareaChars, preview, content } = this.state;
+    const { preview, content } = this.state;
+    const textareaChars = content ? content.length : 0;
     const textareaOnChange = e => {
       this.setState( { content: e.target.value } );
-      if ( maxLength ) {
-        if ( e.target.value.length > showCharsRemainingAt ) {
-          this.setState( { textareaChars: e.target.value.length } );
-        }
-      }
     };
     return (
       <div className={`TextEditor ${className} ${preview && "with-preview"}`}>


### PR DESCRIPTION
Fixes https://github.com/inaturalist/inaturalist/issues/2738 where the comment textarea character counter would not disappear if the text was deleted with cmd+a then backspace. Furthermore, the counter wasn't even accurate if only a small amount of content was typed after deleting the original text.