### PR TITLE
Exclude not-nearby by default in taxon autocomplete

### DIFF
--- a/app/assets/javascripts/jquery/plugins/inat/generic_autocomplete.js
+++ b/app/assets/javascripts/jquery/plugins/inat/generic_autocomplete.js
@@ -8,7 +8,7 @@ var genericAutocomplete = { };
 $.widget( "ui.autocomplete", $.ui.autocomplete, {
   _create: function ( ) {
     this._super( );
-    this.widget( ).menu( "option", "items", "> :not(.category)" );
+    this.widget( ).menu( "option", "items", "> :not(.non-option)" );
   }
 } );
 

--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -35,10 +35,12 @@ $label-start: 7px;
     background: white;
     cursor: default;
     list-style: none;
-    padding-left: 10px;
+    padding: 5px 10px;
     color: #666;
-    line-height: 32px;
     background: #eee;
+  }
+  .header-category:after {
+    content: ":"
   }
   .nearby-toggle {
     list-style: none;

--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -1,3 +1,5 @@
+@import "./colors";
+
 $img-width: 40px;
 $img-margin: 3px;
 $label-start: 7px;
@@ -37,6 +39,17 @@ $label-start: 7px;
     color: #666;
     line-height: 32px;
     background: #eee;
+  }
+  .nearby-toggle {
+    list-style: none;
+    border-top: 1px solid $border-grey;
+    button {
+      padding: 5px 10px;
+      border: 0;
+      background-color: white;
+      width: 100%;
+      text-align: center;
+    }
   }
 }
 .ac-message[data-type='message'] {

--- a/app/views/layouts/basic.html.haml
+++ b/app/views/layouts/basic.html.haml
@@ -29,6 +29,8 @@
           login: "#{ current_user.login }",             |
           prefers_scientific_name_first: #{ current_user.prefers_scientific_name_first }, |
           preferred_observations_search_map_type: "#{ current_user.preferred_observations_search_map_type }", |
+          prefers_not_nearby_suggestions: #{!!session[:prefers_not_nearby_suggestions]}, |
+          roles: #{current_user.roles.map(&:name).to_json.html_safe}, |
           icon: "#{ current_user.icon.url(:thumb) }" }; |
       var TIMEZONE = "#{ Time.zone.tzinfo.name }";
       var SITE = #{ @site.to_json(                      |

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -170,6 +170,7 @@
           prefers_medialess_obs_maps: <%= current_user.prefers_medialess_obs_maps %>,
           prefers_captive_obs_maps: <%= current_user.prefers_captive_obs_maps %>,
           preferred_observations_search_map_type: "<%= current_user.preferred_observations_search_map_type %>",
+          prefers_not_nearby_suggestions: <%= !!session[:prefers_not_nearby_suggestions] %>
         };
       <% end -%>
       var RAILS_FLASH = <%= flash.to_hash.compact.to_json.html_safe %>;

--- a/app/views/observations/show.html.haml
+++ b/app/views/observations/show.html.haml
@@ -45,6 +45,7 @@
         preferred_observation_license: (current_user.preferred_observation_license || "").downcase,
         preferred_observations_search_map_type: current_user.preferred_observations_search_map_type,
         prefers_scientific_name_first: current_user.prefers_scientific_name_first,
+        prefers_not_nearby_suggestions: !!session[:prefers_not_nearby_suggestions],
         blockedUserHashes: current_user.user_blocks.map{|ub| Digest::MD5.hexdigest( ub.blocked_user_id.to_s ) },
         blockedByUserHashes: current_user.user_blocks_as_blocked_user.map{|ub| Digest::MD5.hexdigest( ub.user_id.to_s ) },
         trusted_user_ids: current_user.friendships.where( "trust" ).pluck(:friend_id),

--- a/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";
 import inaturalistjs from "inaturalistjs";
 import { Glyphicon } from "react-bootstrap";
+import { updateSession } from "../../../shared/util";
 
 let searchInProgress;
 
@@ -216,7 +217,6 @@ class TaxonAutocomplete extends React.Component {
                 : I18n.t( "only_view_nearby_suggestions" )
             );
             setState( { viewNotNearby: !innerViewNotNearby } );
-            // eslint-disable-next-line no-undef
             updateSession( { prefers_not_nearby_suggestions: !innerViewNotNearby } );
             that.inputElement( ).autocomplete( "search" );
             return false;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2021,6 +2021,7 @@ en:
   inbox: Inbox
   include_places: Include Places
   include_projects: Include Projects
+  include_suggestions_not_seen_nearby: Include suggestions not seen nearby
   include_taxa: Include Taxa
   include_users: Include Users
   including: including
@@ -5159,7 +5160,6 @@ en:
   youve_successfully_linked_your_provider_account: "You've successfully linked your %{provider} account"
   verifiable: Verifiable
   verifiable_observations: Verifiable Observations
-  view_suggestions_not_seen_nearby: View suggestions not seen nearby
   views:
     views: 'Views'
     announcements:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1911,6 +1911,7 @@ en:
   help_translate!: Help Translate!
   helped_the_observer_make: helped the observer make their final ID (i.e. they were made before the final ID and they match it)
   here_are_3_examples: Here are 3 examples of well-formed data
+  here_are_our_top_suggestions: Here are our top suggestions
   here_are_our_top_species_suggestions: Here are our top species suggestions
   hex_color_eg: Hex color, e.g. 65644F
   hi: Hi,
@@ -2735,6 +2736,7 @@ en:
   none_found: None found
   normal: normal
   not_completed: Not Completed
+  not_confident_top_suggestions: We're not confident enough to make a recommendation, but here are our top suggestions
   not_covered_by_any_taxon_frameworks: Not covered by any taxon frameworks
   not_evaluated: not evaluated
   not_findig_what_you_want: Not finding what you want?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2982,6 +2982,7 @@ en:
   only_staff_can_edit_standard_places: Only site staff can edit places in the standard hierarchy
   only_the_owner_of_this_list_can_do_that: Only the owner of this list can do that.  Don't be evil.
   only_the_project_admin_can_delete_this_project: Only the project admin can delete this project.
+  only_view_nearby_suggestions: Only view nearby suggestions
   only_you: Only you
   open: open
   open_: Open
@@ -5156,6 +5157,7 @@ en:
   youve_successfully_linked_your_provider_account: "You've successfully linked your %{provider} account"
   verifiable: Verifiable
   verifiable_observations: Verifiable Observations
+  view_suggestions_not_seen_nearby: View suggestions not seen nearby
   views:
     views: 'Views'
     announcements:


### PR DESCRIPTION
Like we've started doing in the Android app, this excludes not-nearby suggestions from the automated suggestions in the taxon autocomplete component (in situations where we're showing automated suggestions). Ideally this will reduce errors due to choosing the top automated suggestion when that is visually similar but not seen nearby).

This PR introduces this as an admin-only test.