### PR TITLE
Skip refresh wait

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -6,7 +6,7 @@ class AnnotationsController < ApplicationController
   def create
     p = annotation_params(params[:annotation])
     @annotation = Annotation.new(p)
-    @annotation.wait_for_obs_index_refresh = true
+    @annotation.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     if !@annotation.save
       flash[:error] = @annotation.errors.full_messages.to_sentence
     end
@@ -26,7 +26,7 @@ class AnnotationsController < ApplicationController
   end
 
   def destroy
-    @annotation.wait_for_obs_index_refresh = true
+    @annotation.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     @annotation.destroy
     respond_to do |format|
       format.html do

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -70,7 +70,7 @@ class CommentsController < ApplicationController
   def create
     @comment = Comment.new(params[:comment])
     @comment.user = current_user
-    @comment.wait_for_obs_index_refresh = true
+    @comment.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     @comment.save unless params[:preview]
     respond_to do |format|
       format.html { respond_to_create }
@@ -104,7 +104,7 @@ class CommentsController < ApplicationController
       return
     end
     @comment.attributes = params[:comment]
-    @comment.wait_for_obs_index_refresh = true
+    @comment.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     @comment.save unless params[:preview]
     respond_to do |format|
       format.html do
@@ -153,7 +153,7 @@ class CommentsController < ApplicationController
     end
 
     parent = @comment.parent
-    @comment.wait_for_obs_index_refresh = true
+    @comment.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     @comment.destroy
     respond_to do |format|
       format.html do

--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -166,10 +166,12 @@ class FlagsController < ApplicationController
     if @flag.flag == "other" && !params[:flag_explanation].blank?
       @flag.flag = params[:flag_explanation]
     end
-    if @flag.flaggable_type == "Observation"
-      @flag.flaggable.wait_for_index_refresh = true
-    elsif @flag.flaggable.respond_to?( :wait_for_obs_index_refresh )
-      @flag.flaggable.wait_for_obs_index_refresh = true
+    unless current_user.is_testing_skip_refresh_wait?
+      if @flag.flaggable_type == "Observation"
+        @flag.flaggable.wait_for_index_refresh = true
+      elsif @flag.flaggable.respond_to?( :wait_for_obs_index_refresh )
+        @flag.flaggable.wait_for_obs_index_refresh = true
+      end
     end
     if @flag.save
       flash[:notice] = t(:flag_saved_thanks_html, url: url_for( @flag ) )
@@ -207,10 +209,12 @@ class FlagsController < ApplicationController
     if resolver_id = params[:flag].delete("resolver_id")
       params[:flag]["resolver"] = User.find_by_id(resolver_id)
     end
-    if @flag.flaggable && @flag.flaggable_type == "Observation"
-      @flag.flaggable.wait_for_index_refresh = true
-    elsif @flag.flaggable && @flag.flaggable.respond_to?( :wait_for_obs_index_refresh )
-      @flag.flaggable.wait_for_obs_index_refresh = true
+    unless current_user.is_testing_skip_refresh_wait?
+      if @flag.flaggable && @flag.flaggable_type == "Observation"
+        @flag.flaggable.wait_for_index_refresh = true
+      elsif @flag.flaggable && @flag.flaggable.respond_to?( :wait_for_obs_index_refresh )
+        @flag.flaggable.wait_for_obs_index_refresh = true
+      end
     end
     respond_to do |format|
       msg = if @flag.update_attributes(params[:flag])
@@ -238,10 +242,12 @@ class FlagsController < ApplicationController
   
   def destroy
     @object = @flag.flaggable
-    if @flag.flaggable && @flag.flaggable_type == "Observation"
-      @flag.flaggable.wait_for_index_refresh = true
-    elsif @flag.flaggable && @flag.flaggable.respond_to?( :wait_for_obs_index_refresh )
-      @flag.flaggable.wait_for_obs_index_refresh = true
+    unless current_user.is_testing_skip_refresh_wait?
+      if @flag.flaggable && @flag.flaggable_type == "Observation"
+        @flag.flaggable.wait_for_index_refresh = true
+      elsif @flag.flaggable && @flag.flaggable.respond_to?( :wait_for_obs_index_refresh )
+        @flag.flaggable.wait_for_obs_index_refresh = true
+      end
     end
     @flag.destroy
     if @object.is_a?(Project)

--- a/app/controllers/identifications_controller.rb
+++ b/app/controllers/identifications_controller.rb
@@ -157,7 +157,7 @@ class IdentificationsController < ApplicationController
     respond_to do |format|
       duplicate_key_violation = false
       begin
-        @identification.wait_for_obs_index_refresh = true
+        @identification.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
         @identification.save
       rescue PG::Error, ActiveRecord::RecordNotUnique => e
         raise e unless e =~ /index_identifications_on_current/
@@ -217,7 +217,7 @@ class IdentificationsController < ApplicationController
       end
       return
     end
-    @identification.wait_for_obs_index_refresh = true
+    @identification.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     if @identification.save
       msg = t(:identification_updated)
       respond_to do |format|
@@ -247,7 +247,7 @@ class IdentificationsController < ApplicationController
   # DELETE identification_url
   def destroy
     observation = @identification.observation
-    @identification.wait_for_obs_index_refresh = true
+    @identification.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     if params[:delete]
       if @identification.hidden?
         respond_to do |format|

--- a/app/controllers/observation_field_values_controller.rb
+++ b/app/controllers/observation_field_values_controller.rb
@@ -78,7 +78,7 @@ class ObservationFieldValuesController < ApplicationController
         @observation_field_value.attributes = ofv_params
       end
     end
-    @observation_field_value.wait_for_obs_index_refresh = true
+    @observation_field_value.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     respond_to do |format|
       if @observation_field_value.save
         format.json { render :json => @observation_field_value }
@@ -97,7 +97,7 @@ class ObservationFieldValuesController < ApplicationController
         update_params[:uuid] = update_params[:id]
         update_params.delete(:id)
       end
-      @observation_field_value.wait_for_obs_index_refresh = true
+      @observation_field_value.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
       if @observation_field_value.update_attributes(update_params)
         format.json { render :json => @observation_field_value }
       else
@@ -127,7 +127,7 @@ class ObservationFieldValuesController < ApplicationController
         status = :unprocessable_entity
         errors << t(:observation_belongs_to_project_requiring_field)
       else
-        @observation_field_value.wait_for_obs_index_refresh = true
+        @observation_field_value.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
         @observation_field_value.destroy
         status = :ok
       end

--- a/app/controllers/observation_photos_controller.rb
+++ b/app/controllers/observation_photos_controller.rb
@@ -61,7 +61,7 @@ class ObservationPhotosController < ApplicationController
     end
     
     begin
-      @observation_photo.observation.wait_for_index_refresh = true if params[:refresh_index]
+      @observation_photo.observation.wait_for_index_refresh = !current_user.is_testing_skip_refresh_wait? if params[:refresh_index]
       @observation_photo.save
     rescue PG::UniqueViolation => e
       raise e unless e.message =~ /index_observation_photos_on_uuid/
@@ -101,7 +101,7 @@ class ObservationPhotosController < ApplicationController
     end
     respond_to do |format|
       if @observation_photo.update_attributes(params[:observation_photo])
-        @observation_photo.observation.wait_for_index_refresh = true
+        @observation_photo.observation.wait_for_index_refresh = !current_user.is_testing_skip_refresh_wait?
         @observation_photo.observation.elastic_index!
         format.json { render :json => @observation_photo.to_json(:include => [:photo]) }
       else

--- a/app/controllers/project_observations_controller.rb
+++ b/app/controllers/project_observations_controller.rb
@@ -53,7 +53,7 @@ class ProjectObservationsController < ApplicationController
         end
         set_curator_coordinate_access
         if @project_observation.save
-          @project_observation.observation.wait_for_index_refresh = true
+          @project_observation.observation.wait_for_index_refresh = !current_user.is_testing_skip_refresh_wait?
           @project_observation.observation.elastic_index!
           render json: @project_observation
         else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -914,7 +914,7 @@ class ProjectsController < ApplicationController
       project: @project,
       observation: @observation,
       user: current_user,
-      wait_for_obs_index_refresh: true
+      wait_for_obs_index_refresh: !current_user.is_testing_skip_refresh_wait?
     )
     
     unless @project_observation.valid?
@@ -981,7 +981,7 @@ class ProjectsController < ApplicationController
       end
       return
     end
-    @project_observation.wait_for_obs_index_refresh = true
+    @project_observation.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     @project_observation.destroy
     respond_to do |format|
       format.html do

--- a/app/controllers/quality_metrics_controller.rb
+++ b/app/controllers/quality_metrics_controller.rb
@@ -6,7 +6,7 @@ class QualityMetricsController < ApplicationController
   
   def vote
     if @existing = @observation.quality_metrics.where(user_id: current_user.id, metric: params[:metric]).first
-      @existing.wait_for_obs_index_refresh = true
+      @existing.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
       @existing.destroy
     end
     
@@ -42,7 +42,7 @@ class QualityMetricsController < ApplicationController
   def respond_to_create
     qm = @observation.quality_metrics.build(:user_id => current_user.id, 
       :metric => params[:metric], :agree => params[:agree] != "false")
-    qm.wait_for_obs_index_refresh = true
+    qm.wait_for_obs_index_refresh = !current_user.is_testing_skip_refresh_wait?
     if qm.save
       respond_to do |format|
         format.html do

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -19,11 +19,13 @@ class VotesController < ApplicationController
   end
 
   def vote
-    if @record.respond_to?(:wait_for_index_refresh) && !params[:skip_refresh]
-      @record.wait_for_index_refresh = true
-    end
-    if @record.respond_to?(:wait_for_obs_index_refresh)
-      @record.wait_for_obs_index_refresh = true
+    unless current_user.is_testing_skip_refresh_wait?
+      if @record.respond_to?(:wait_for_index_refresh) && !params[:skip_refresh]
+        @record.wait_for_index_refresh = true
+      end
+      if @record.respond_to?(:wait_for_obs_index_refresh)
+        @record.wait_for_obs_index_refresh = true
+      end
     end
     @record.vote_by voter: current_user, vote: params[:vote], vote_scope: params[:scope]
     respond_to do |format|
@@ -35,11 +37,13 @@ class VotesController < ApplicationController
   end
 
   def unvote
-    if @record.respond_to?(:wait_for_index_refresh) && !params[:skip_refresh]
-      @record.wait_for_index_refresh = true
-    end
-    if @record.respond_to?(:wait_for_obs_index_refresh)
-      @record.wait_for_obs_index_refresh = true
+    unless current_user.is_testing_skip_refresh_wait?
+      if @record.respond_to?(:wait_for_index_refresh) && !params[:skip_refresh]
+        @record.wait_for_index_refresh = true
+      end
+      if @record.respond_to?(:wait_for_obs_index_refresh)
+        @record.wait_for_obs_index_refresh = true
+      end
     end
     @record.unvote voter: current_user, vote: params[:vote], vote_scope: params[:scope]
     respond_to do |format|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1310,6 +1310,10 @@ class User < ActiveRecord::Base
     test_groups_array.include?( group)
   end
 
+  def is_testing_skip_refresh_wait?
+    is_admin?
+  end
+
   def flagged_with( flag, options = {} )
     evaluate_new_flag_for_spam( flag )
     elastic_index!

--- a/app/webpack/observations/uploader/models/obs_card.js
+++ b/app/webpack/observations/uploader/models/obs_card.js
@@ -135,7 +135,11 @@ const ObsCard = class ObsCard {
       project_id: _.map( this.projects, "id" ),
       uploader: true
     };
-    if ( !options.refresh ) { params.skip_refresh = true; }
+    if ( options.refresh ) {
+      params.force_refresh = true;
+    } else {
+      params.skip_refresh = true;
+    }
     if ( this.taxon_id ) { params.observation.taxon_id = this.taxon_id; }
     if ( this.species_guess ) { params.observation.species_guess = this.species_guess; }
     if ( this.date && !util.dateInvalid( this.date ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4974,7 +4974,7 @@
       "dev": true
     },
     "inaturalistjs": {
-      "version": "github:inaturalist/inaturalistjs#42f97bedbcab9629939ebed1187ce3b57ba68579",
+      "version": "github:inaturalist/inaturalistjs#2584d7d5d67fab88b34ed03e50c2c9a47bec5cf2",
       "requires": {
         "cross-fetch": "2.2.3",
         "form-data": "3.0.1"


### PR DESCRIPTION
all admin users will no longer wait for an ES refresh after most data modification requests. The exceptions for now are obs delete, and obs create via the web uploader until we can ensure the web obs dashboard doesn't use ES _search