### PR TITLE
Alternate ES delete

### DIFF
--- a/app/models/update_action.rb
+++ b/app/models/update_action.rb
@@ -247,10 +247,7 @@ class UpdateAction < ActiveRecord::Base
     return if args.blank?
     # first delete all entries from Elasticearch
     UpdateAction.where(*args).select(:id).find_in_batches do |batch|
-      ids = batch.map(&:id)
-      if ids.any?
-        UpdateAction.elastic_delete!(filters: [ { terms: { id: ids } } ])
-      end
+      UpdateAction.elastic_delete_by_ids!( batch.map(&:id) )
     end
     # then delete them from Postgres
     UpdateAction.delete_all(*args)

--- a/lib/elastic_model/acts_as_elastic_model.rb
+++ b/lib/elastic_model/acts_as_elastic_model.rb
@@ -260,6 +260,7 @@ module ActsAsElasticModel
       def elastic_delete_by_ids!( ids, options = { } )
         return if ids.blank?
         bulk_delete( ids, options )
+        __elasticsearch__.refresh_index! if Rails.env.test?
       end
 
       private

--- a/lib/elastic_model/acts_as_elastic_model.rb
+++ b/lib/elastic_model/acts_as_elastic_model.rb
@@ -230,9 +230,7 @@ module ActsAsElasticModel
               end : result.records.to_a
             elastic_ids = result.results.results.map{ |r| r.id.to_i }
             elastic_ids_to_delete = elastic_ids - records.map(&:id)
-            unless elastic_ids_to_delete.blank?
-              elastic_delete!(where: { id: elastic_ids_to_delete })
-            end
+            elastic_delete_by_ids!( elastic_ids_to_delete )
             WillPaginate::Collection.create(result.current_page, result.per_page,
               result.total_entries - elastic_ids_to_delete.count) do |pager|
               pager.replace(records)
@@ -250,14 +248,19 @@ module ActsAsElasticModel
         __elasticsearch__.refresh_index! unless Rails.env.test?
       end
 
-    def preload_for_elastic_index( instances )
-      return if instances.blank?
-      klass = instances.first.class
-      if klass.respond_to?(:load_for_index)
-        klass.preload_associations( instances,
-          klass.load_for_index.values[:includes] )
+      def preload_for_elastic_index( instances )
+        return if instances.blank?
+        klass = instances.first.class
+        if klass.respond_to?(:load_for_index)
+          klass.preload_associations( instances,
+            klass.load_for_index.values[:includes] )
+        end
       end
-    end
+
+      def elastic_delete_by_ids!( ids, options = { } )
+        return if ids.blank?
+        bulk_delete( ids, options )
+      end
 
       private
 
@@ -293,6 +296,24 @@ module ActsAsElasticModel
           { index: { _id: obj.id, data: obj.as_indexed_json } }
         end
       end
+
+      def bulk_delete( ids, options = { } )
+        begin
+          __elasticsearch__.client.bulk({
+            index: __elasticsearch__.index_name,
+            type: __elasticsearch__.document_type,
+            body:  ids.map do |id|
+              { delete: { _id: id } }
+            end,
+            refresh: options[:wait_for_index_refresh] ? "wait_for" : false
+          })
+        rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+          Logstasher.write_exception(e)
+          Rails.logger.error "[Error] elastic_delete! failed: #{ e }"
+          Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
+        end
+      end
+
     end
 
     def elastic_index!


### PR DESCRIPTION
Avoid delete_by_query in cases where we have the IDs of records needing to be deleted