### PR TITLE
Moderator Notes

### DIFF
--- a/app/controllers/moderator_actions_controller.rb
+++ b/app/controllers/moderator_actions_controller.rb
@@ -1,5 +1,6 @@
 class ModeratorActionsController < ApplicationController
   before_filter :authenticate_user!
+  before_filter :curator_required
 
   def create
     @moderator_action = ModeratorAction.new( approved_params )

--- a/app/controllers/moderator_notes_controller.rb
+++ b/app/controllers/moderator_notes_controller.rb
@@ -1,0 +1,56 @@
+class ModeratorNotesController < ApplicationController
+  before_filter :authenticate_user!
+  before_filter :curator_required
+  before_filter :load_record, except: [:create]
+  before_filter :editor_required, except: [:create]
+
+  layout "bootstrap"
+
+  def create
+    @moderator_note = ModeratorNote.new( approved_create_params )
+    @moderator_note.user = current_user
+    if @moderator_note.save
+      flash[:notice] = t(:created)
+    else
+      flash[:error] = t(:failed_to_save_record_with_errors, errors: @moderator_note.errors.full_messages.to_sentence )
+    end
+    redirect_back_or_default root_url
+  end
+
+  def edit
+  end
+
+  def update
+    if @moderator_note.update_attributes( approved_update_params )
+      flash[:notice] = t(:updated)
+    else
+      flash[:error] = t(:failed_to_save_record_with_errors, errors: @moderator_note.errors.full_messages.to_sentence )
+    end
+    redirect_back_or_default person_path( @moderator_note.subject_user.login )
+  end
+
+  def destroy
+    @moderator_note.destroy
+    redirect_back_or_default person_path( @moderator_note.subject_user.login )
+  end
+
+  private
+  def editor_required
+    unless @moderator_note.editable_by?( current_user )
+      flash[:error] = t(:you_dont_have_permission_to_do_that)
+      return redirect_back_or_default person_path( @moderator_note.subject_user.login )
+    end
+  end
+  def approved_create_params
+    params.require(:moderator_note).permit(
+      :body,
+      :subject_user_id
+    )
+  end
+
+  def approved_update_params
+    params.require(:moderator_note).permit(
+      :body
+    )
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1054,7 +1054,7 @@ class UsersController < ApplicationController
           d1 = "#{year}-01-01"
           d2 = "#{year}-12-31"
           moderator_actions_on_comments = moderator_actions_on_comments.
-            where( "moderator_actions.created_at BETWEEN ? AMD ?", d1, d2 )
+            where( "moderator_actions.created_at BETWEEN ? AND ?", d1, d2 )
           moderator_actions_on_identifications = moderator_actions_on_identifications.
             where( "moderator_actions.created_at BETWEEN ? AND ?", d1, d2 )
         end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1005,37 +1005,64 @@ class UsersController < ApplicationController
       flash[:error] = t(:you_dont_have_permission_to_do_that)
       return redirect_back_or_default person_by_login_path( @user.login )
     end
-    moderator_notes = ModeratorNote.
+    max = 100
+    @valid_years = ( 2008..Date.today.year ).to_a.reverse
+    @years = ( params[:years] || [] ).map(&:to_i) & @valid_years
+    @types = ( params[:types] || [] ) & %w(Flag ModeratorNote ModeratorAction)
+    scopes = {}
+    scopes["ModeratorNote"] = ModeratorNote.
       where( subject_user_id: @user ).
       where( "created_at < ?", before ).
-      order( "id desc" ).
-      limit( 100 )
-    moderator_actions_on_identifications = ModeratorAction.
-      where( "moderator_actions.created_at < ?", before ).
-      where( resource_type: "Identification" ).
-      joins( "JOIN identifications i ON i.id = moderator_actions.resource_id" ).
-      where( "i.user_id = ?", @user ).
-      order( "moderator_actions.id desc" ).
-      limit( 100 )
-    moderator_actions_on_comments = ModeratorAction.
-      where( "moderator_actions.created_at < ?", before ).
-      where( resource_type: "Comment" ).
-      joins( "JOIN comments c ON c.id = moderator_actions.resource_id" ).
-      where( "c.user_id = ?", @user ).
-      order( "moderator_actions.id desc" ).
-      limit( 100 )
-    flags = Flag.
+      order( "id desc" )
+    scopes["Flag"] = Flag.
       where( "created_at < ?", before ).
       where( flaggable_user_id: @user ).
       where( "flaggable_type != 'Taxon'" ).
-      order( "id desc" ).
-      limit( 100 )
-    @records = [
-      moderator_notes.to_a,
-      moderator_actions_on_comments.to_a,
-      moderator_actions_on_identifications.to_a,
-      flags.to_a
-    ].flatten.sort_by {|r| r.created_at }
+      order( "id desc" )
+    @records = []
+    scopes.each do |type, scope|
+      next unless @types.blank? || @types.include?( type )
+      if @years.blank?
+        scope = scope.limit( max )
+      else
+        @years.each do |year|
+          d1 = "#{year}-01-01"
+          d2 = "#{year}-12-31"
+          scope = scope.where( "#{Object.const_get( type ).table_name}.created_at BETWEEN ? AND ?", d1, d2 )
+        end
+      end
+      @records += scope.to_a
+    end
+    if @types.include?( "ModeratorAction" )
+      moderator_actions_on_identifications = ModeratorAction.
+        where( "moderator_actions.created_at < ?", before ).
+        where( resource_type: "Identification" ).
+        joins( "JOIN identifications i ON i.id = moderator_actions.resource_id" ).
+        where( "i.user_id = ?", @user ).
+        order( "moderator_actions.id desc" )
+      moderator_actions_on_comments = ModeratorAction.
+        where( "moderator_actions.created_at < ?", before ).
+        where( resource_type: "Comment" ).
+        joins( "JOIN comments c ON c.id = moderator_actions.resource_id" ).
+        where( "c.user_id = ?", @user ).
+        order( "moderator_actions.id desc" )
+      if @years.blank?
+        moderator_actions_on_comments = moderator_actions_on_comments.limit( max )
+        moderator_actions_on_identifications = moderator_actions_on_identifications.limit( max )
+      else
+        @years.each do |year|
+          d1 = "#{year}-01-01"
+          d2 = "#{year}-12-31"
+          moderator_actions_on_comments = moderator_actions_on_comments.
+            where( "moderator_actions.created_at BETWEEN ? AMD ?", d1, d2 )
+          moderator_actions_on_identifications = moderator_actions_on_identifications.
+            where( "moderator_actions.created_at BETWEEN ? AND ?", d1, d2 )
+        end
+      end
+      @records += moderator_actions_on_comments.to_a
+      @records += moderator_actions_on_identifications.to_a
+    end
+    @records = @records.flatten.sort_by {|r| r.created_at }
     respond_to do |format|
       format.html do
         render layout: "bootstrap-container"

--- a/app/models/moderator_note.rb
+++ b/app/models/moderator_note.rb
@@ -1,0 +1,22 @@
+class ModeratorNote < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :subject_user, class_name: "User"
+
+  MAX_LENGTH = 750
+
+  validates :body, length: { minimum: 3, maximum: MAX_LENGTH }
+  validate :author_is_curator, on: :create
+
+  def editable_by?( editor )
+    return false if editor.blank?
+    return true if editor.is_admin?
+    editor == user
+  end
+
+  private
+  def author_is_curator
+    unless user.is_curator?
+      errors.add(:user, :must_be_a_curator)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,6 +195,10 @@ class User < ActiveRecord::Base
   has_one :user_parent, dependent: :destroy, inverse_of: :user
   has_many :parentages, class_name: "UserParent", foreign_key: "parent_user_id", inverse_of: :parent_user
   has_many :moderator_actions, inverse_of: :user
+  has_many :moderator_notes, inverse_of: :user
+  has_many :moderator_notes_as_subject, class_name: "ModeratorNote",
+    foreign_key: "subject_user_id", inverse_of: :subject_user,
+    dependent: :destroy
   
   file_options = {
     processors: [:deanimator],

--- a/app/views/admin/user_detail.html.haml
+++ b/app/views/admin/user_detail.html.haml
@@ -269,6 +269,7 @@
                   = " (#{ I18n.t(:draft) })"
       = link_to "Log in as #{@display_user.login}", { controller: "admin", action: "login_as", id: @display_user.id }, class: "btn btn-block btn-info"
       = link_to "Manage / delete content", admin_user_content_path(@display_user.id), class: "btn btn-block btn-info"
+      = link_to "Moderation History", moderation_person_path( @display_user.id ), class: "btn btn-block btn-info"
       = link_to "Delete user description", admin_update_user_path(@display_user.id, "user[description]" => ""), :method => :put,
         :data => {:confirm => t(:are_you_sure_no_undo)},
         class: "btn btn-block btn-danger"

--- a/app/views/moderator_notes/edit.html.haml
+++ b/app/views/moderator_notes/edit.html.haml
@@ -1,0 +1,9 @@
+- content_for :title do
+  = @title = t( :edit_moderator_note )
+.container
+  .row
+    .col-xs-8
+      %h2= @title
+      = form_for @moderator_note, builder: BootstrapFormBuilder do |f|
+        = f.text_area :body, maxlength: ModeratorNote::MAX_LENGTH
+        = f.submit t(:update), class: "btn btn-primary"

--- a/app/views/users/_show.html.haml
+++ b/app/views/users/_show.html.haml
@@ -42,6 +42,9 @@
                   - unless @user.known_non_spammer?
                     %li
                       = link_to t(:flag_as_non_spammer), set_spammer_path(@user, spammer: false), method: :post, data: { confirm: t(:are_you_sure_you_want_to_remove_spammer) }
+                - if is_admin? || !is_me?( @user )
+                  %li
+                    = link_to t(:moderation_history), moderation_person_path( @user )
                 %li
                   = link_to t(:flags_on_users_content, user: @user.login), flags_path( flagger_type: "any", resolved: "any", flags: ["spam", "copyright infringement", "inappropriate", "other"], user_id: @user.login )
   .col-sm-8{:style => "background-color:white"}

--- a/app/views/users/moderation.html.haml
+++ b/app/views/users/moderation.html.haml
@@ -2,27 +2,56 @@
   = strip_tags( t( :moderation_history_for_user_html, user: link_to_user( @user ) ) )
 
 %h2=t :moderation_history_for_user_html, user: link_to_user( @user )
-%p
-  This includes moderator actions, notes, and flags on everything this user has created other than taxa.
+%p=t :moderation_history_desc_html
+
+.row
+  .col-xs-12
+    #controls.well
+      = form_tag( moderation_person_path( @user.id ), method: "get" ) do
+        .row
+          .col-xs-2
+            .form-group
+              %label
+                =t :year
+                = select_tag :years, options_for_select( @valid_years, selected: @years ), multiple: true, class: "select form-control", include_blank: t(:recent)
+          .col-xs-3
+            .form-group
+              %label
+                =t :type
+                = select_tag :types, options_for_select( %w(Flag ModeratorAction ModeratorNote).map{|m| [t( "activerecord.models.#{m}", default: m ), m]}, selected: @types ), multiple: true, class: "select form-control", include_blank: t(:any_)
+        .row
+          .col-xs-12
+            = submit_tag t(:filter), class: "btn btn-primary"
+            = link_to t(:reset_filters_short), url_for, class: "btn btn-link"
+            = hidden_fields_for_params( without: [:years, :types] )
 
 %table.table
   %thead
     %tr
       %th=t :date_added
       %th=t :type
-      %th=t :author
+      %th=t :moderator_or_flagger
       %th=t :body
       %th=t :actions
   %tbody
     - for record in @records
-      %tr
+      %tr{ style: record.is_a?( Flag ) && record.resolved? ? "opacity: 0.5" : ""}
         %td.nobr
-          %time.datetime{ datetime: record.created_at.iso8601, title: l( record.created_at, format: :long ) }=l record.created_at, format: :long
+          %time.datetime{ datetime: record.created_at.iso8601, title: record.created_at.iso8601 }=l record.created_at, format: :long
         %td.nobr
-          = record.class.name
+          =t "activerecord.models.#{record.class.name}", default: record.class.name
           - if record.is_a?( Flag )
             = surround "(", ")" do
               = link_to record.flaggable_type, record.flaggable
+            - if record.resolved?
+              %span.text-muted
+                = surround "[", "]" do
+                  =t :resolved
+          - elsif record.is_a?( ModeratorAction )
+            = surround "(", ")" do
+              = link_to record.resource_type, record.resource
+            = surround "[", "]" do
+              = record.action
         %td= link_to_user( record.user )
         %td= record.try_methods( :body, :flag, :description )
         %td.nobr
@@ -39,5 +68,5 @@
   .col-xs-8
     = form_for ModeratorNote.new( subject_user: @user ), builder: BootstrapFormBuilder do |f|
       = f.hidden_field :subject_user_id
-      = f.text_area :body, label: t(:add_a_note), maxlength: ModeratorNote::MAX_LENGTH, description: "Moderation notes are records of curator actions, or evidence-based concerns about a user, such as whether they are a possible sockpuppet account. Please do not include personal opinions or hearsay about the user"
+      = f.text_area :body, label: t(:add_a_note), maxlength: ModeratorNote::MAX_LENGTH, description: t(:moderator_note_desc)
       = f.submit t(:add), class: "btn btn-primary"

--- a/app/views/users/moderation.html.haml
+++ b/app/views/users/moderation.html.haml
@@ -1,0 +1,43 @@
+- content_for(:title) do
+  = strip_tags( t( :moderation_history_for_user_html, user: link_to_user( @user ) ) )
+
+%h2=t :moderation_history_for_user_html, user: link_to_user( @user )
+%p
+  This includes moderator actions, notes, and flags on everything this user has created other than taxa.
+
+%table.table
+  %thead
+    %tr
+      %th=t :date_added
+      %th=t :type
+      %th=t :author
+      %th=t :body
+      %th=t :actions
+  %tbody
+    - for record in @records
+      %tr
+        %td.nobr
+          %time.datetime{ datetime: record.created_at.iso8601, title: l( record.created_at, format: :long ) }=l record.created_at, format: :long
+        %td.nobr
+          = record.class.name
+          - if record.is_a?( Flag )
+            = surround "(", ")" do
+              = link_to record.flaggable_type, record.flaggable
+        %td= link_to_user( record.user )
+        %td= record.try_methods( :body, :flag, :description )
+        %td.nobr
+          - if record.is_a?( ModeratorNote )
+            - if record.editable_by?( current_user )
+              = link_to t(:edit), edit_moderator_note_path( record ), class: "btn btn-sm btn-default"
+              = link_to t(:delete), moderator_note_path( record ), method: :delete, confirm: t(:are_you_sure?), class: "btn btn-sm btn-danger"
+          - elsif record.is_a?( ModeratorAction )
+            = link_to t(:view), record.resource, class: "btn btn-sm btn-link"
+          - else
+            = link_to t(:view), record, class: "btn btn-sm btn-link"
+
+.row
+  .col-xs-8
+    = form_for ModeratorNote.new( subject_user: @user ), builder: BootstrapFormBuilder do |f|
+      = f.hidden_field :subject_user_id
+      = f.text_area :body, label: t(:add_a_note), maxlength: ModeratorNote::MAX_LENGTH, description: "Moderation notes are records of curator actions, or evidence-based concerns about a user, such as whether they are a possible sockpuppet account. Please do not include personal opinions or hearsay about the user"
+      = f.submit t(:add), class: "btn btn-primary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2468,6 +2468,7 @@ en:
   # Label shown when a date has not been entered
   missing_date: Missing Date
   mobile: Mobile
+  moderation_history_for_user_html: Moderation history for %{user}
   mollusks: mollusks
   momentjs:
     shortRelativeTime:
@@ -7946,6 +7947,10 @@ en:
           attributes:
             base:
               guide_has_too_many_taxa: "guide can only have 500 taxa"
+        moderator_action:
+          attributes:
+            user_id:
+              must_be_a_curator: must be a curator
         mushroom_observer_import_flow_task:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
   # Tool tip for a button that adds a link to a text area
   add_a_link: Add a link
   add_a_name: Add a Name
+  add_a_note: Add a Note
   add_a_new_change_group: Add a New Change Group
   # Tool tip for a button that adds a numbered list to a text area
   add_a_numbered_list: Add a numbered list
@@ -2469,6 +2470,18 @@ en:
   missing_date: Missing Date
   mobile: Mobile
   moderation_history_for_user_html: Moderation history for %{user}
+  moderation_history_desc_html: |
+    This includes moderator actions (e.g. hiding or unhiding comments), notes,
+    and flags on everything this user has created other than taxa. This is
+    <strong>only visible to curators</strong> and <strong>curators cannot view
+    their own history</strong>, so notes about a person should never be visible
+    to that person.
+  moderator_note_desc: |
+    Moderator notes are records of moderation responses or evidence-based
+    concerns about a user, such as whether they are a possible sockpuppet
+    account. Please do not include personal opinions or hearsay about the user.
+  # Person who executed a moderator action or flagged something
+  moderator_or_flagger: Moderator / Flagger
   mollusks: mollusks
   momentjs:
     shortRelativeTime:
@@ -4636,6 +4649,7 @@ en:
   try_adding_species_form: Try adding some species using the form on this page.
   twitter: Twitter
   two_thirds: 2/3rds
+  # As in a category, not as in a keyboard
   type: Type
   type_authority: Type authority...
   type_one_name_per_line: Type one name per line
@@ -7813,6 +7827,14 @@ en:
       CompleteSet: Complete Set
       # Noun
       Flag: Flag
+      # Action taken by a moderator in response to a flag or concern with
+      # immediate consequences in functionality, e.g. hiding an offensive
+      # comment without deleting it
+      ModeratorAction: Moderator Action
+      # Text note left by a moderator about another user recording a response to
+      # a concern, like messaging someone about plagiarism, or documenting
+      # violations of the Community Guidelines for future reference
+      ModeratorNote: Moderator Note
       TaxonLink: Taxon Link
     attributes:
       assessment:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :moderator_notes
   resources :data_partners
   resources :saved_locations
   apipie
@@ -182,6 +183,9 @@ Rails.application.routes.draw do
     collection do
       get :search
       get 'leaderboard(/:year(/:month))' => :leaderboard, :as => 'leaderboard_for'
+    end
+    member do
+      get :moderation
     end
   end
   resources :relationships, controller: :relationships, only: [:index, :update, :destroy]

--- a/db/migrate/20210408221535_create_moderator_notes.rb
+++ b/db/migrate/20210408221535_create_moderator_notes.rb
@@ -1,0 +1,13 @@
+class CreateModeratorNotes < ActiveRecord::Migration
+  def change
+    create_table :moderator_notes do |t|
+      t.integer :user_id
+      t.text :body
+      t.integer :subject_user_id
+
+      t.timestamps null: false
+    end
+    add_index :moderator_notes, :user_id
+    add_index :moderator_notes, :subject_user_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2264,6 +2264,40 @@ ALTER SEQUENCE public.moderator_actions_id_seq OWNED BY public.moderator_actions
 
 
 --
+-- Name: moderator_notes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.moderator_notes (
+    id integer NOT NULL,
+    user_id integer,
+    body text,
+    subject_user_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: moderator_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.moderator_notes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: moderator_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.moderator_notes_id_seq OWNED BY public.moderator_notes.id;
+
+
+--
 -- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5617,6 +5651,13 @@ ALTER TABLE ONLY public.moderator_actions ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
+-- Name: moderator_notes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.moderator_notes ALTER COLUMN id SET DEFAULT nextval('public.moderator_notes_id_seq'::regclass);
+
+
+--
 -- Name: oauth_access_grants id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6543,6 +6584,14 @@ ALTER TABLE ONLY public.model_attribute_changes
 
 ALTER TABLE ONLY public.moderator_actions
     ADD CONSTRAINT moderator_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: moderator_notes moderator_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.moderator_notes
+    ADD CONSTRAINT moderator_notes_pkey PRIMARY KEY (id);
 
 
 --
@@ -7951,6 +8000,20 @@ CREATE INDEX index_moderator_actions_on_resource_type_and_resource_id ON public.
 --
 
 CREATE INDEX index_moderator_actions_on_user_id ON public.moderator_actions USING btree (user_id);
+
+
+--
+-- Name: index_moderator_notes_on_subject_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_moderator_notes_on_subject_user_id ON public.moderator_notes USING btree (subject_user_id);
+
+
+--
+-- Name: index_moderator_notes_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_moderator_notes_on_user_id ON public.moderator_notes USING btree (user_id);
 
 
 --
@@ -10395,4 +10458,6 @@ INSERT INTO schema_migrations (version) VALUES ('20210213020914');
 INSERT INTO schema_migrations (version) VALUES ('20210220195556');
 
 INSERT INTO schema_migrations (version) VALUES ('20210305235042');
+
+INSERT INTO schema_migrations (version) VALUES ('20210408221535');
 

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -203,6 +203,12 @@ ModeratorAction.blueprint do
   reason { Faker::Lorem.sentence }
 end
 
+ModeratorNote.blueprint do
+  user { make_curator }
+  body { Faker::Lorem.paragraph }
+  subject_user { User.make! }
+end
+
 MushroomObserverImportFlowTask.blueprint do
   user { User.make! }
 end

--- a/spec/controllers/moderator_notes_controller_spec.rb
+++ b/spec/controllers/moderator_notes_controller_spec.rb
@@ -1,0 +1,61 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe ModeratorNotesController, "create" do
+  let(:subject_user) { User.make! }
+  it "should be possible for curators" do
+    sign_in make_curator
+    expect {
+      post :create, moderator_note: { subject_user_id: subject_user.id, body: "darn it" }
+    }.to change( ModeratorNote, :count ).by( 1 )
+  end
+  it "should not be possible for non-curators" do
+    sign_in User.make!
+    expect {
+      post :create, moderator_note: { subject_user_id: subject_user.id, body: "darn it" }
+    }.to change( ModeratorNote, :count ).by( 0 )
+  end
+end
+
+describe ModeratorNotesController, "update" do
+  let(:moderator_note) { ModeratorNote.make! }
+  it "should be allowed for the author" do
+    sign_in moderator_note.user
+    new_body = "this is a new body #{Time.now.to_i}"
+    patch :update, id: moderator_note.id, moderator_note: { body: new_body }
+    moderator_note.reload
+    expect( moderator_note.body ).to eq new_body
+  end
+  it "should be allowed for admins" do
+    sign_in make_admin
+    new_body = "this is a new body #{Time.now.to_i}"
+    patch :update, id: moderator_note.id, moderator_note: { body: new_body }
+    moderator_note.reload
+    expect( moderator_note.body ).to eq new_body
+  end
+  it "should not be allowed for other curators" do
+    sign_in make_curator
+    new_body = "this is a new body #{Time.now.to_i}"
+    patch :update, id: moderator_note.id, moderator_note: { body: new_body }
+    moderator_note.reload
+    expect( moderator_note.body ).not_to eq new_body
+  end
+end
+
+describe ModeratorNotesController, "destroy" do
+  let(:moderator_note) { ModeratorNote.make! }
+  it "should be allowed for the author" do
+    sign_in moderator_note.user
+    delete :destroy, id: moderator_note.id
+    expect( ModeratorNote.find_by_id( moderator_note.id ) ).to be_blank
+  end
+  it "should be allowed for admins" do
+    sign_in make_admin
+    delete :destroy, id: moderator_note.id
+    expect( ModeratorNote.find_by_id( moderator_note.id ) ).to be_blank
+  end
+  it "should not be allowed for other curators" do
+    sign_in make_curator
+    delete :destroy, id: moderator_note.id
+    expect( ModeratorNote.find_by_id( moderator_note.id ) ).not_to be_blank
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -376,3 +376,29 @@ describe UsersController, "show" do
     expect( response ).to be_success
   end
 end
+
+describe UsersController, "moderation" do
+  let(:subject_user) { User.make! }
+  it "should be viewable by curators" do
+    sign_in make_curator
+    get :moderation, id: subject_user.login
+    expect( response.response_code ).to eq 200
+  end
+  it "should not be viewable by non-curators" do
+    sign_in User.make!
+    get :moderation, id: subject_user.login
+    expect( response.response_code ).not_to eq 200
+  end
+  it "should not be viewable by a curator if it's about the curator" do
+    curator = make_curator
+    sign_in curator
+    get :moderation, id: curator.login
+    expect( response.response_code ).not_to eq 200
+  end
+  it "should be viewable by an admin if it's about the admin" do
+    admin = make_admin
+    sign_in admin
+    get :moderation, id: admin.login
+    expect( response.response_code ).to eq 200
+  end
+end

--- a/spec/models/moderator_note_spec.rb
+++ b/spec/models/moderator_note_spec.rb
@@ -1,0 +1,23 @@
+# encoding: UTF-8
+require File.dirname(__FILE__) + '/../spec_helper.rb'
+
+describe ModeratorNote, "creation" do
+  it "should be possible for a curator" do
+    expect( ModeratorNote.make( user: make_curator ) ).to be_valid
+  end
+  it "should be not be possible for a non-curator" do
+    expect( ModeratorNote.make( user: User.make! ) ).not_to be_valid
+  end
+  it "should not allow body to exceed 750 chars" do
+    expect( ModeratorNote.make( body: "what" * 700 ) ).not_to be_valid
+  end
+end
+
+describe ModeratorNote, "updating" do
+  let(:moderator_note) { ModeratorNote.make! }
+  it "should be possible if the author is no longer a curator" do
+    moderator_note.user.roles.delete_all
+    moderator_note.updated_at = Time.now
+    expect( moderator_note ).to be_valid
+  end
+end


### PR DESCRIPTION
Adds a page to collect information relevant to user moderation, only visible to staff and curators, and not visible to the user who it concerns. Also adds a new `ModeratorNote` model to store notes concerning the moderation history of a particular user.

Closes #3009 