### PR TITLE
i18njs config change

### DIFF
--- a/app/assets/stylesheets/bootstrap-inat.scss
+++ b/app/assets/stylesheets/bootstrap-inat.scss
@@ -25,6 +25,8 @@ h6 {
   color: #1A1A1A;
 }
 
+$font-stack: Whitney, "Trebuchet MS", Arial, sans-serif;
+
 .readable,
 p { 
   font-size: 100%;

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -30,3 +30,4 @@
 fallbacks: true
 translations:
   - file: "app/assets/javascripts/i18n/translations.js"
+    only: "none"


### PR DESCRIPTION
We don't use the i18n/filtered.js file, which contained translations for all languages. This config change basically ensures that file is pretty much empty saving processing time when precompiling assets like on deploys.

This commit also renames bootstrap-inat.css to bootstrap-inat.scss as I was getting errors when precompiling assets locally since it uses some scss syntax.