### PR TITLE
Serve site data exports to site admins

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,6 +1,6 @@
 class SitesController < ApplicationController
   before_filter :authenticate_user!, except: %w(network affiliation)
-  before_filter :load_site, only: [:show, :edit, :update, :destroy]
+  before_filter :load_site, only: [:show, :edit, :update, :destroy, :export]
   before_filter :admin_or_any_site_admin_required, only: [:index, :show]
   before_filter :require_admin_of_viewed_site, except: [:index, :show,
     :network, :affiliation]
@@ -23,6 +23,15 @@ class SitesController < ApplicationController
   # GET /sites/1.json
   def show
     @record = Site.find(params[:id])
+
+    if current_user.is_admin? || @record_admin
+      export_path = @record.export_path
+      if File.exists?( export_path )
+        @export_url = export_site_url( @record )
+        @export_mtime = File.mtime( export_path )
+        @export_bytes = File.size( export_path )
+      end
+    end
 
     respond_to do |format|
       format.html # show.html.erb
@@ -100,6 +109,12 @@ class SitesController < ApplicationController
   def affiliation
     @page_title = t(:inaturalist_network_affiliation)
     render layout: "bootstrap-container"
+  end
+
+  def export
+    path = @record.export_path
+    return render_404 unless File.exists?( path )
+    send_file path
   end
 
   private

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -457,4 +457,13 @@ class Site < ActiveRecord::Base
     prefers_google_webmaster_dns_verified? || URI.parse( url.to_s ).host.to_s.include?( default_site_domain )
   end
 
+  # Path where the site data export file *should* be. Actual generation happens
+  # via the export_site_data.rb script and the SiteDataExporter class
+  def export_path
+    private_page_cache_path( File.join(
+      "export_site_data",
+      "#{SiteDataExporter.basename_for_site( self )}.zip"
+    ) )
+  end
+
 end

--- a/app/views/sites/show.html.haml
+++ b/app/views/sites/show.html.haml
@@ -13,7 +13,7 @@
         .well.upstacked
           %h4 Site Data Export
           %p
-            This export contains data for site admins that to which the partner
+            This export contains data for site admins to which the partner
             organization is entitled. It should be updated in June and December.
           = link_to @export_url, class: "btn btn-default btn-block stacked upstacked" do
             %i.fa.fa-download

--- a/app/views/sites/show.html.haml
+++ b/app/views/sites/show.html.haml
@@ -9,6 +9,19 @@
         - if @record.send("#{attc}?")
           .meta.small.stacked{:style => "text-transform: uppercase;"}= attc.humanize
           = image_tag @record.send(attc.to_sym).url, class: "img-responsive stacked"
+      - if @export_url
+        .well.upstacked
+          %h4 Site Data Export
+          %p
+            This export contains data for site admins that to which the partner
+            organization is entitled. It should be updated in June and December.
+          = link_to @export_url, class: "btn btn-default btn-block stacked upstacked" do
+            %i.fa.fa-download
+            =t :download
+            = surround "(", ")" do
+              = number_to_human_size @export_bytes
+          .small.text-center.text-muted
+            =t :bold_label_colon_value_html, label: t(:date_updated), value: l( @export_mtime )
     .col-md-8
       %h2= @record.name
       - if is_admin? || current_user.is_site_admin_of?(@record)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
       get :network
       get :affiliation
     end
+    member do
+      get :export
+    end
   end
 
   uuid_pattern = BelongsToWithUuid::UUID_PATTERN.to_s.gsub( /[\^\$]/, "" )

--- a/lib/site_data_exporter.rb
+++ b/lib/site_data_exporter.rb
@@ -120,10 +120,14 @@ class SiteDataExporter
     @options = options
   end
 
+  def self.basename_for_site( site )
+    "#{site.name.parameterize}-#{site.id}"
+  end
+
   def export
     # Make a temp dir
     @work_dir = Dir.mktmpdir
-    @basename = "#{@site_name.parameterize}-#{@site.id}-#{Date.today.to_s.gsub(/\-/, '')}-#{Time.now.to_i}"
+    @basename = SiteDataExporter.basename_for_site( @site )
     @work_path = File.join( @work_dir, @basename )
     FileUtils.mkdir_p @work_path, :mode => 0755
 


### PR DESCRIPTION
This serves site data exports to the site admins they're intended for via the website, assuming the export files are available in `tmp/page_cache/export_site_data/`. This would allow us to automate the process of generating these files every 6 months by adding a cron job to run `rails r tools/export_site_data.rb --dir tmp/page_cache/export_site_data/`.

The downside is that it furthers our reliance on having a big drive mounted via NFS, plus we have to serve some very large files via Rack / nginx. Upside is that access control is simple and we don't have to worry about sharing sensitive data via Amazon.