### PR TITLE
Remove place boundary editor

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -175,9 +175,6 @@ class PlacesController < ApplicationController
       @place.user = current_user
       if params[:file]
         assign_geometry_from_file
-      elsif !params[:geojson].blank?
-        @geometry = geometry_from_geojson(params[:geojson])
-        @place.validate_with_geom( @geometry, user: current_user )
       end
 
       if @geometry # && @place.valid?
@@ -220,9 +217,6 @@ class PlacesController < ApplicationController
       redirect_to place_path(@place)
       return
     end
-    
-    r = Place.connection.execute("SELECT st_npoints(geom) from place_geometries where place_id = #{@place.id}")
-    @npoints = r[0]['st_npoints'].to_i unless r.num_tuples == 0
   end
   
   def update
@@ -233,11 +227,6 @@ class PlacesController < ApplicationController
         @place.add_custom_error(:place_geometry, :is_too_large_to_edit)
       elsif params[:file]
         assign_geometry_from_file
-      elsif !params[:geojson].blank?
-        @geometry = geometry_from_geojson(params[:geojson])
-        if @place.validate_with_geom( @geometry, user: current_user )
-          @place.save_geom(@geometry, user: current_user) if @geometry
-        end
       end
 
       if @place.errors.any?

--- a/app/views/places/edit.html.haml
+++ b/app/views/places/edit.html.haml
@@ -2,97 +2,33 @@
   = t :editing
   = @place.name
 - content_for(:extracss) do
-  = stylesheet_link_tag "leaflet.fullscreen/Control.FullScreen"
   :css
     #map {width: 100%;height: 500px;}
     .edit_place input.text, .edit_place textarea {width: 415px;}
     .latitude_field input.text, .longitude_field input.text { width: 175px;}
     input.ac_loading {background: white url('/assets/spinner-small.gif') 420px 5px no-repeat;}
 - content_for(:extrajs) do
-  = leaflet_js(:draw => true)
-  = javascript_include_tag "shramov-leaflet-plugins/Bing"
-  = javascript_include_tag "leaflet.fullscreen/Control.FullScreen"
   :javascript
-    var PLACE = #{json_escape @place.to_json.html_safe},
-        NPOINTS = #{@npoints.to_i},
-        BING_KEY = #{CONFIG.bing ? CONFIG.bing.key.inspect.html_safe : "null"}
+    var PLACE = #{json_escape @place.to_json.html_safe}
     $(document).ready(function() {
       $('#place_parent_id').chooser({
         collectionUrl: '/places/autocomplete.json',
         resourceUrl: '/places/{{id}}.json?partial=autocomplete_item',
         chosen: eval('(' + $('place_parent_id').attr('data-json') + ')')
       })
-      window.map = L.map('map').setView([PLACE.latitude, PLACE.longitude], 8)
-      if (PLACE.swlat) {
-        var b = new L.LatLngBounds(
-          new L.LatLng(PLACE.swlat, PLACE.swlng),
-          new L.LatLng(PLACE.nelat, PLACE.nelng)
-        )
-        map.fitBounds(b)
-      }
-      var d = new Date()
-      var bing = new L.BingLayer(BING_KEY, {type:"AerialWithLabels"});
-      map.addLayer(bing);
-      var fullScreen = new L.Control.FullScreen();
-      // add fullscreen control to the map
-      map.addControl(fullScreen)
-      window.drawnItems = new L.FeatureGroup()
-      map.addLayer(drawnItems)
-      if (NPOINTS < 5000) {
-        addDrawControls()
-      }
-      if (NPOINTS > 3) {
-        $.getJSON('/places/geometry/'+PLACE.id+'.geojson', function(geojson) {
-          var l = L.geoJson(geojson, {
-            onEachFeature: function(feature, layer) {
-              layer.eachLayer(function(lyr) {
-                drawnItems.addLayer(lyr)
-              })
-            }
-          })
-          l.addTo(map)
-        })
-      }
+    } );
+  = google_maps_js
+  :javascript
+    var PLACE = #{json_escape @place.to_json.html_safe},
+        SHOW_PLACE_GEOMETRY = true
+  = javascript_include_tag 'map_bundle'
+  :javascript
+    $(document).ready(function() {
+      var script = document.createElement("script")
+      script.setAttribute("type", "text/javascript")
+      script.setAttribute("src", "#{asset_path('places/show.gmaps.js')}")
+      document.body.appendChild(script);
     })
-    function saveGeom() {
-      $(':input[name=geojson]').val(JSON.stringify(drawnItems.toGeoJSON()))
-    }
-    function addDrawControls() {
-      var drawControl = new L.Control.Draw({
-        draw: {
-          marker: false,
-          rectangle: false,
-          circle: false,
-          polyline: false,
-          polygon: {
-            allowIntersection: false,
-            drawError: {
-                color: '#e1e100', // Color the shape will turn when intersects
-                message: 'Illegal shape'
-            }
-          }
-        },
-        edit: {
-          featureGroup: drawnItems,
-          marker: false
-        }
-      })
-      map.addControl(drawControl)
-      map.on('draw:created', function(e) {
-        var type = e.layerType,
-            layer = e.layer
-        drawnItems.addLayer(layer)
-        map.addLayer(layer)
-        saveGeom()
-      })
-      map.on('draw:edited', function(e) {
-        var layers = e.layers
-        saveGeom()
-      })
-      map.on('draw:deleted', function(e) {
-        saveGeom()
-      })
-    }
 #pageheader
   .breadcrumbs
     %strong= link_to "&laquo; #{t(:back_to)} #{@place.name}".html_safe, @place, :class => 'crumb'
@@ -117,7 +53,9 @@
           :include_blank => t(:unknown), :class => 'select'
     = f.text_field :woeid, :description => "Yahoo Where On Earth ID"
     = f.text_field :parent_id, :placeholder => t(:type_place_name), "data-chooser-chosen" => @place.parent.to_json.html_safe, :label => t(:parent).capitalize
+
     = link_to_toggle_box t(:replace_boundary_with_kml) do
+      .notice=t :places_warning_editing_places_is_slow
       = file_field_tag :file, :accept => "application/vnd.google-earth.kml+xml"
       .meta= t('views.places.kml_field_desc')
     %input{:type => "hidden", :name => "geojson"}
@@ -128,14 +66,8 @@
         :data => {:confirm => t(:are_you_sure_delete_this_place)}, |
         :class => 'minor delete button'                 |
 .last.column.span-12
-  .notice.box
-    %h3=t :warning_title
-    %p.ui=t :places_warning_editing_places_is_slow
   #map.stacked
-  - if @npoints && @npoints > 5000
-    .notice.box=t 'views.places.edit.complex_boundary_note_html', :url => place_geometry_url(@place, :format => "kml")
-  - else
-    = link_to t(:download_kml), place_geometry_url(@place, :format => "kml")
+  = link_to t(:download_kml), place_geometry_url(@place, :format => "kml")
 .column.span-24
   .small.description
     = t(:is_this_place_a_duplicate)

--- a/app/views/places/new.html.erb
+++ b/app/views/places/new.html.erb
@@ -49,58 +49,10 @@
   </style>
 <%- end -%>
 <%- content_for(:extrajs) do -%>
-  <%= google_maps_js %>
-  <%= javascript_include_tag 'map_bundle' %>
-  <%= leaflet_js(:draw => true) %>
-  <%= javascript_include_tag "shramov-leaflet-plugins/Bing" %>
-  <%= javascript_include_tag "leaflet.fullscreen/Control.FullScreen.js" %>
   <script type="text/javascript" charset="utf-8">
-    var BING_KEY = <%= CONFIG.bing ? raw(CONFIG.bing.key.inspect) : "null" %>,
-        PLACE_INVALID = <%= @place && !@place.errors.blank? ? 'true' : 'false' %>,
+    var PLACE_INVALID = <%= @place && !@place.errors.blank? ? 'true' : 'false' %>,
         CURRENT_USER_IS_CURATOR = <%= logged_in? && current_user.is_curator? ? 'true' : 'false' %>
     $(document).ready(function() {
-      window.map = L.map('drawingMap', { minZoom: 1 }).setView([0,0], 1)
-      var d = new Date()
-      var bing = new L.BingLayer(BING_KEY, {type:"AerialWithLabels"});
-      map.addLayer(bing);
-      var fullScreen = new L.Control.FullScreen();
-      map.addControl(fullScreen)
-      window.drawnItems = new L.FeatureGroup()
-      map.addLayer(drawnItems)
-      var drawControl = new L.Control.Draw({
-        draw: {
-          marker: false,
-          rectangle: false,
-          circle: false,
-          polyline: false,
-          polygon: {
-            allowIntersection: false,
-            drawError: {
-                color: '#e1e100', // Color the shape will turn when intersects
-                message: 'Illegal shape'
-            }
-          }
-        },
-        edit: {
-          featureGroup: drawnItems,
-          marker: false
-        }
-      })
-      map.addControl(drawControl)
-      map.on('draw:created', function(e) {
-        var type = e.layerType,
-            layer = e.layer
-        drawnItems.addLayer(layer)
-        map.addLayer(layer)
-        saveGeom()
-      })
-      map.on('draw:edited', function(e) {
-        var layers = e.layers
-        saveGeom()
-      })
-      map.on('draw:deleted', function(e) {
-        saveGeom()
-      })
 
       $('#place_parent_id').chooser({
         collectionUrl: '/places/autocomplete.json',
@@ -128,12 +80,6 @@
           }).join(' '))
         })
     })
-    function saveGeom() {
-      $(':input[name=geojson]').val(JSON.stringify(drawnItems.toGeoJSON()))
-      var c = drawnItems.getBounds().getCenter()
-      $('#place_latitude').val(c.lat)
-      $('#place_longitude').val(c.lng)
-    }
   </script>
 <%- end -%>
 <div id="pageheader">
@@ -161,22 +107,13 @@
     <p class="ui"><%=t :places_warning_the_future %></p>
   </div>
 </div>
-
-<div class="column span-15">
-  <h3>
-  	<%= t('views.places.new.map_instruction') %>
-    <span class="ui small description"><%= t :double_click_to_finish %></span>
-  </h3>
-  <div id="drawingMap"></div>
-</div>
-<div class="last column span-9">
-  <h3><%= t(:give_it_some_detail) %></h3>
+<div class="last column span-24">
   <%= form_for @place, :builder => DefaultFormBuilder, :html => {:multipart => true} do |f| %>
     <%= f.text_field :name, :class => 'text', :required => true %>
-    <%= f.text_field :parent_id, :placeholder => t(:type_place_name), :style => "width: 300px" %>
+    <%= f.text_field :parent_id, :placeholder => t(:type_place_name), :style => "width: 300px", label: t(:parent_) %>
     <%= f.hidden_field :latitude %>
     <%= f.hidden_field :longitude %>
-    <%= f.form_field :kml, :label => "#{t(:kml)} (#{t(:optional)})", :description => t('views.places.kml_field_desc') do %>
+    <%= f.form_field :kml, :label => t(:kml), required: true, :description => t('views.places.kml_field_desc') do %>
       <%= file_field_tag :file, :accept => "application/vnd.google-earth.kml+xml" %>
     <% end -%>
     <%= f.select :place_type, Place::PLACE_TYPE_CODES.map{|type, code| [t("place_geo.geo_planet_place_types.#{type.gsub(" ", "_")}"), code]}.sort,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1508,7 +1508,6 @@ en:
   # Prompt shown when you are dragging a file somewhere and should release it to
   # add the file as, for example, a new photo in the Uploader
   drop_it: Drop it
-  double_click_to_finish: (double click to finish)
   download: Download
   download_bulk_import_template_html: |
     <a href="%{url}">Download template</a> for use in the
@@ -1854,7 +1853,6 @@ en:
   georeferenced: Georeferenced?
   get_started: Get Started
   getting_started_guide: Getting Started Guide
-  give_it_some_detail: Give it some detail!
   # Prompt to donate money on a montly basis
   give_monthly_caps: GIVE MONTHLY
   # Prompt to donate money once

--- a/spec/controllers/places_controller_spec.rb
+++ b/spec/controllers/places_controller_spec.rb
@@ -10,34 +10,34 @@ describe PlacesController do
           place: {
             name: "Pine Island Ridge Natural Area"
           },
-          geojson: test_place_geojson
+          file: test_place_kml
         })
       }.to change(Place, :count).by(1)
       expect( Place.last.place_type ).to be_blank
     end
 
-    it "creates places with geojson" do
+    it "creates places with kml" do
       sign_in user
       post :create, place: {
-        name: "Test geojson",
+        name: "Test kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson
+      }, file: test_place_kml
       p = Place.last
-      expect( p.name ).to eq "Test geojson"
+      expect( p.name ).to eq "Test kml"
       expect( p.place_geometry ).to_not be_nil
     end
 
-    it "fails with invalid geojson" do
+    it "fails with invalid kml" do
       sign_in user
       expect {
         post :create,
           place: {
-            name: "Test geojson",
+            name: "Test kml",
             latitude: 30,
             longitude: 30
           },
-          geojson: test_place_geojson(:invalid)
+          file: test_place_kml(:invalid)
       }.not_to change( Place, :count )
     end
 
@@ -45,10 +45,10 @@ describe PlacesController do
       sign_in user
       place_count = Place.count
       post :create, place: {
-        name: "Test non-admin geojson",
+        name: "Test non-admin kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson(:huge)
+      }, file: test_place_kml(:huge)
       expect( response ).not_to be_redirect
       expect( Place.count ).to eq place_count
     end
@@ -57,12 +57,12 @@ describe PlacesController do
       user = make_admin
       sign_in user
       post :create, place: {
-        name: "Test admin geojson",
+        name: "Test admin kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson(:huge)
+      }, file: test_place_kml(:huge)
       p = Place.last
-      expect( p.name ).to eq "Test admin geojson"
+      expect( p.name ).to eq "Test admin kml"
       expect( p.place_geometry ).to_not be_nil
     end
   end
@@ -85,16 +85,16 @@ describe PlacesController do
   end
 
   describe "update" do
-    it "updates places with geojson" do
+    it "updates places with kml" do
       p = make_place_with_geom(user: user)
       sign_in user
       put :update, id: p.id, place: {
-        name: "Test geojson",
+        name: "Test kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson
+      }, file: test_place_kml
       p = Place.last
-      expect( p.name ).to eq "Test geojson"
+      expect( p.name ).to eq "Test kml"
       expect( p.place_geometry ).to_not be_nil
     end
 
@@ -102,10 +102,10 @@ describe PlacesController do
       p = make_place_with_geom(user: user)
       sign_in user
       put :update, id: p.id, place: {
-        name: "Test non-admin geojson",
+        name: "Test non-admin kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson(:huge)
+      }, file: test_place_kml(:huge)
       expect( response ).not_to be_redirect
     end
 
@@ -113,10 +113,10 @@ describe PlacesController do
       p = make_place_with_geom( user: user, wkt: "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))" )
       sign_in user
       put :update, id: p.id, place: {
-        name: "Test non-admin geojson",
+        name: "Test non-admin kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson
+      }, file: test_place_kml
       expect( response ).not_to be_redirect
     end
 
@@ -125,12 +125,12 @@ describe PlacesController do
       p = make_place_with_geom(user: user)
       sign_in user
       put :update, id: p.id, place: {
-        name: "Test admin geojson",
+        name: "Test admin kml",
         latitude: 30,
         longitude: 30
-      }, geojson: test_place_geojson(:huge)
+      }, file: test_place_kml(:huge)
       p = Place.last
-      expect( p.name ).to eq "Test admin geojson"
+      expect( p.name ).to eq "Test admin kml"
       expect( p.place_geometry ).to_not be_nil
     end
 
@@ -141,18 +141,6 @@ describe PlacesController do
       put :update, id: p.id, place: { name: "the new name" }
       p.reload
       expect( p.name ).to eq "the new name"
-    end
-
-    it "does not allow removal of the geometry with blank geojson" do
-      p = make_place_with_geom( user: user )
-      put :update, id: p.id,
-        place: {
-          name: "something else"
-        },
-        geojson: ""
-      expect( response ).not_to be_success
-      p.reload
-      expect( p.place_geometry ).not_to be_blank
     end
     it "does not allow removal of the geometry with old remove_geom" do
       p = make_place_with_geom( user: user )
@@ -288,23 +276,38 @@ describe PlacesController, "geometry" do
   end
 end
 
-def test_place_geojson(size = :default)
+def test_place_kml(size = :default)
   coords = if size == :default
-    [[ [0,0], [0,1], [1,1], [1,0], [0,0] ]]
+    [[0,0], [0,1], [1,1], [1,0], [0,0]]
   elsif size == :huge
-    [[ [0,0], [0,60], [60,60], [60,0], [0,0] ]]
+    [[0,0], [0,60], [60,60], [60,0], [0,0]]
   elsif size == :invalid
-    [[ [0,0], [0,1] ]]
+    [[0,0], [0,1]]
   end
-  {
-    type: "FeatureCollection",
-    features: [{
-      type: "Feature",
-      properties: { },
-      geometry: {
-        type: "Polygon",
-        coordinates: coords
-      }
-    }]
-  }.to_json
+  path = File.join(Dir::tmpdir, "test-place-kml-#{size}.kml")
+  if File.exists?( path )
+    Rack::Test::UploadedFile.new( path, "application/vnd.google-earth.kml+xml", false )
+  end
+  kml = <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.1">
+  <Document>
+    <Placemark>
+      <MultiGeometry>
+        <Polygon>
+          <outerBoundaryIs>
+            <LinearRing>
+              <coordinates>#{coords.map{|c| c.join( "," )}.join( " " )}</coordinates>
+            </LinearRing>
+          </outerBoundaryIs>
+        </Polygon>
+      </MultiGeometry>
+    </Placemark>
+  </Document>
+</kml>
+  XML
+  open( path, "w" ) do |f|
+    f << kml
+  end
+  Rack::Test::UploadedFile.new( path, "application/vnd.google-earth.kml+xml", false )
 end


### PR DESCRIPTION
Removes the place boundary editing UI, leaving KML as the only way to add or edit a boundary.