### PR TITLE
minor changes to taxon change partial revert

### DIFF
--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -748,6 +748,7 @@ class ListedTaxon < ActiveRecord::Base
   end
 
   def expire_caches
+    return unless list.is_a?(CheckList)
     ctrl = ActionController::Base.new
     ctrl.expire_fragment(List.icon_preview_cache_key(list_id))
     ListedTaxon::ORDERS.each do |order|

--- a/app/models/shared/sweepers_module.rb
+++ b/app/models/shared/sweepers_module.rb
@@ -1,5 +1,6 @@
 module Shared::SweepersModule
   def expire_listed_taxon(listed_taxon)
+    return unless listed_taxon.list.is_a?(CheckList)
     listed_taxon.expire_caches
   end
 

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -365,8 +365,7 @@ class TaxonChange < ActiveRecord::Base
     logger = options[:logger] || Rails.logger
     logger.info "[INFO #{Time.now}] Starting partial revert for #{self}"
     if committed_on.nil? && !debug
-      logger.info "Reverting requires committed_on not to be nil"
-      return false
+      raise "Reverting requires committed_on not to be nil"
     end
     logger.info "[INFO #{Time.now}] Destroying identifications..."
     unless debug

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -364,6 +364,10 @@ class TaxonChange < ActiveRecord::Base
     debug = options[:debug]
     logger = options[:logger] || Rails.logger
     logger.info "[INFO #{Time.now}] Starting partial revert for #{self}"
+    if committed_on.nil? && !debug
+      logger.info "Reverting requires committed_on not to be nil"
+      return false
+    end
     logger.info "[INFO #{Time.now}] Destroying identifications..."
     unless debug
       identifications.find_each(&:destroy)
@@ -390,7 +394,7 @@ class TaxonChange < ActiveRecord::Base
     end
     if options[:deactivate_output_taxa]
       output_taxa.each do |output_taxon|
-        output_taxon.update_attributes( is_active: false ) unless debug
+        output_taxon.update_attributes( is_active: false ) unless ( debug || input_taxa.include? output_taxon )
       end
     end
     # output taxa may or may not need to be made inactive, impossible to say in code

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -394,7 +394,9 @@ class TaxonChange < ActiveRecord::Base
     end
     if options[:deactivate_output_taxa]
       output_taxa.each do |output_taxon|
-        output_taxon.update_attributes( is_active: false ) unless ( debug || input_taxa.include? output_taxon )
+        unless input_taxa.include? output_taxon
+          output_taxon.update_attributes( is_active: false ) unless debug
+        end
       end
     end
     # output taxa may or may not need to be made inactive, impossible to say in code


### PR DESCRIPTION
minor changes to partial_revert:

- avoid inactivating output for when same as input
- make sure committed_on exists to avoid error
- try to avoid lifelist caches triggered via identification destroy -> observation.save