### PR TITLE
Update it.yml

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -4520,7 +4520,7 @@ it:
   user_added_a_flag_html: "%{user} ha aggiunto un contrassegno"
   user_added_a_project_invitation_html: "%{user} ha aggiunto in invito di progetto"
   user_added_a_x: "%{user} ha aggiunto una %{x}"
-  user_added_a_x_to_noun_by_html: "%{user} ha aggiunto una %{x} a una %{noun} di %{by}"
+  user_added_a_x_to_noun_by_html: "%{user} ha aggiunto una %{x} a %{noun} di %{by}"
   user_added_a_x_to_noun_by_user_html: "%{user} ha aggiunto una/una %{x} a %{noun} di %{by}"
   user_added_a_x_to_noun_by_you_html: "%{user} ha aggiunto una/una %{x} a %{noun} di te"
   user_added_a_x_to_noun_html: "%{user} ha aggiunto una %{x} a %{noun}"


### PR DESCRIPTION
Removing redundant indefinite article that produced "una una osservazione" in the rendered HTML when substituting for %{noun}. 

Note that the use of a feminine indefinite article "una" preceding %{x} in the strings starting at line 4522 on creates an issue when the value is masculine (e.g. "una commento") and there's no easy way to fix this given how these messages are structured. It looks like the previous translator attempted to address this with (what I believe should read) "un/una' on line 4524-4525.