### PR TITLE
Identify fixes: vertical keyboard scroll and no scale-up for images

### DIFF
--- a/app/assets/stylesheets/observations/identify/observation_modal.scss
+++ b/app/assets/stylesheets/observations/identify/observation_modal.scss
@@ -90,7 +90,7 @@ body > [role="dialog"] .ObservationModal {
     display: flex;
     flex-direction: column;
     flex: 2;
-    object-fit: contain;
+    object-fit: none;
     width: 100%;
     height: 100%;
     background-color: transparent;

--- a/app/assets/stylesheets/observations/identify/observation_modal.scss
+++ b/app/assets/stylesheets/observations/identify/observation_modal.scss
@@ -90,7 +90,7 @@ body > [role="dialog"] .ObservationModal {
     display: flex;
     flex-direction: column;
     flex: 2;
-    object-fit: none;
+    object-fit: scale-down;
     width: 100%;
     height: 100%;
     background-color: transparent;

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -82,6 +82,19 @@ class ObservationModal extends React.Component {
     ) ) {
       // focus on the ID or Comment form first fields if either just became visible
       scrollSidebarToForm( ReactDOM.findDOMNode( this ) );
+    } else {
+      // Try to focus on a scrollable element to support vertical keyboard
+      // scrolling
+      const sidebar = $( ".ObservationModal:first" ).find( ".sidebar" );
+      const activeTab = $( ".inat-tab.active", sidebar );
+      // Sometimes the tab itself is not scrollable but a child of that tab is,
+      // which we indicate with tabindex="-1"
+      const scrollableTabChild = $( "[tabindex=-1]:first", activeTab );
+      if ( scrollableTabChild.length > 0 ) {
+        scrollableTabChild.focus( );
+      } else {
+        activeTab.focus( );
+      }
     }
   }
 
@@ -665,7 +678,7 @@ class ObservationModal extends React.Component {
             <div className="sidebar">
               { activeTabs.indexOf( "info" ) < 0 ? null : (
                 <div className={`inat-tab info-tab ${activeTab === "info" ? "active" : ""}`}>
-                  <div className="info-tab-content">
+                  <div className="info-tab-content" tabIndex="-1">
                     <div className="info-tab-inner">
                       <div className="map-and-details">
                         { taxonMap }
@@ -806,7 +819,7 @@ class ObservationModal extends React.Component {
                 </div>
               ) }
               { activeTabs.indexOf( "annotations" ) < 0 ? null : (
-                <div className={`inat-tab annotations-tab ${activeTab === "annotations" ? "active" : ""}`}>
+                <div className={`inat-tab annotations-tab ${activeTab === "annotations" ? "active" : ""}`} tabIndex="-1">
                   <div className="column-header">{ I18n.t( "annotations" ) }</div>
                   <AnnotationsContainer />
                   <div className="column-header">{ I18n.t( "observation_fields" ) }</div>
@@ -814,7 +827,7 @@ class ObservationModal extends React.Component {
                 </div>
               ) }
               { activeTabs.indexOf( "data-quality" ) < 0 ? null : (
-                <div className={`inat-tab data-quality-tab ${activeTab === "data-quality" ? "active" : ""}`}>
+                <div className={`inat-tab data-quality-tab ${activeTab === "data-quality" ? "active" : ""}`} tabIndex="-1">
                   <QualityMetricsContainer />
                 </div>
               ) }

--- a/app/webpack/observations/identify/components/suggestions.jsx
+++ b/app/webpack/observations/identify/components/suggestions.jsx
@@ -213,7 +213,7 @@ class Suggestions extends React.Component {
     return (
       <div className="Suggestions">
         <div className={`suggestions-wrapper ${detailTaxon ? "with-detail" : null}`}>
-          <div className="suggestions-list">
+          <div className="suggestions-list" tabIndex="-1">
             <div className="suggestions-inner">
               <ChooserPopover
                 id="suggestions-sort-chooser"


### PR DESCRIPTION
This should allow the right pane of the observation modal to scroll vertical with keyboard controls. It should also stop scaling up observation photos that are smaller than the space provided to assist detection of plagiarism.