### PR TITLE
Update docs, links from master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you've found a problem in the code, please supply detailed reproduction condi
 1. Leave a comment on the issue saying you're working on it
 1. Fork the repo, and make an issue-specific branch in your fork that starts with the issue number followed by some descriptive, hyphen-separated text. For example, if the issue is number 1234 with a title like "Flagging a message blocks recipient from viewing it again," you should make a branch like `1234-message-flagging`
 1. Work on your changes
-1. When you're done, issue a pull request to the master branch in the main repo. iNat staff will review it when we have time
+1. When you're done, issue a pull request to the main branch in the [inaturalist repo](https://github.com/inaturalist/inaturalist). iNat staff will review it when we have time
 
 # Reporting Security Issues
 

--- a/app/webpack/stats/year/components/translators.jsx
+++ b/app/webpack/stats/year/components/translators.jsx
@@ -63,8 +63,8 @@ class Translators extends React.Component {
                 iphone_link_tag: "<a href='https://itunes.apple.com/us/app/inaturalist/id421397028?mt=8'>",
                 android_link_tag: "<a href='https://play.google.com/store/apps/details?id=org.inaturalist.android'>",
                 seek_link_tag: "<a href='https://www.inaturalist.org/seek'>",
-                view_all_web_link_tag: "<a href='https://github.com/inaturalist/inaturalist/blob/master/config/locales/CONTRIBUTORS.md'>",
-                view_all_mobile_link_tag: "<a href='https://github.com/inaturalist/iNaturalistAndroid/blob/master/iNaturalist/src/main/res/CONTRIBUTORS.md'>"
+                view_all_web_link_tag: "<a href='https://github.com/inaturalist/inaturalist/blob/main/config/locales/CONTRIBUTORS.md'>",
+                view_all_mobile_link_tag: "<a href='https://github.com/inaturalist/iNaturalistAndroid/blob/main/iNaturalist/src/main/res/CONTRIBUTORS.md'>"
               } )
               : I18n.t( "views.stats.year.translators_desc", {
                 x_languages: I18n.t( "x_languages", {
@@ -78,8 +78,8 @@ class Translators extends React.Component {
                 iphone_link_tag: "<a href='https://itunes.apple.com/us/app/inaturalist/id421397028?mt=8'>",
                 android_link_tag: "<a href='https://play.google.com/store/apps/details?id=org.inaturalist.android'>",
                 seek_link_tag: "<a href='https://www.inaturalist.org/seek'>",
-                view_all_web_link_tag: "<a href='https://github.com/inaturalist/inaturalist/blob/master/config/locales/CONTRIBUTORS.md'>",
-                view_all_mobile_link_tag: "<a href='https://github.com/inaturalist/iNaturalistAndroid/blob/master/iNaturalist/src/main/res/CONTRIBUTORS.md'>"
+                view_all_web_link_tag: "<a href='https://github.com/inaturalist/inaturalist/blob/main/config/locales/CONTRIBUTORS.md'>",
+                view_all_mobile_link_tag: "<a href='https://github.com/inaturalist/iNaturalistAndroid/blob/main/iNaturalist/src/main/res/CONTRIBUTORS.md'>"
               } )
           }}
         />

--- a/tools/seek_common_names.rb
+++ b/tools/seek_common_names.rb
@@ -2,7 +2,7 @@ require "rubygems"
 require "optimist"
 
 # The official list of locales current supported by Seek can be found at:
-# https://github.com/inaturalist/SeekReactNative/blob/master/i18n.js
+# https://github.com/inaturalist/SeekReactNative/blob/main/i18n.js
 
 SEEK_LOCALES = [
   "af", "ar", "ca", "cs", "da", "de", "en", "es", "eu", 


### PR DESCRIPTION
Noticed and updated a few places where the older master branch was referenced. There's also `deploy.rb.example:11` but I wasn't sure it's still being used as a basis for anything cap related so I left it as is.