### PR TITLE
Add user filter on project when members only

### DIFF
--- a/app/webpack/projects/show/components/requirements.jsx
+++ b/app/webpack/projects/show/components/requirements.jsx
@@ -56,10 +56,8 @@ const Requirements = ( {
       </a>
     ) );
   let userRules;
-  if ( project.rule_members_only ) {
-    userRules = I18n.t( "project_members_only" );
-  } else if ( _.isEmpty( project.userRules ) ) {
-    userRules = I18n.t( "any_user" );
+  if ( _.isEmpty( project.userRules ) ) {
+    userRules = project.rule_members_only ? I18n.t( "project_members_only" ) : I18n.t( "any_user" );
   } else {
     userRules = _.map( _.sortBy( project.userRules, r => r.user.login ), r => (
       <a key={`project-user-rules-${r.id}`} href={`/people/${r.user.login}`}>


### PR DESCRIPTION
#2948

Shows user filter (if defined) on the project's show page even when "Project Members Only" rule/preference is set.

In other words, if user filter rules are defined, they will always show on the about page. If they are not defined, it will show "Any" or "Project Members Only" depending on whether that option is set.