### PR TITLE
Filter blank values from conservation status params

### DIFF
--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -1669,6 +1669,7 @@ class TaxaController < ApplicationController
         if existing = @taxon.conservation_statuses.detect{|cs| cs.id == status["id"].to_i }
           cs_attrs = params[:taxon][:conservation_statuses_attributes][position].clone
           cs_attrs.delete(:_destroy)
+          %i[geoprivacy place_id].each {|k| cs_attrs[k] = nil if cs_attrs[k].blank? }
           existing.assign_attributes( cs_attrs )
           if existing.changed?
             params[:taxon][:conservation_statuses_attributes][position][:updater_id] = current_user.id

--- a/spec/controllers/taxa_controller_spec.rb
+++ b/spec/controllers/taxa_controller_spec.rb
@@ -314,7 +314,8 @@ describe TaxaController do
             "0" => {
               "id" => cs.id,
               "status" => cs.status,
-              "authority" => cs.authority
+              "authority" => cs.authority,
+              "geoprivacy" => cs.geoprivacy
             }
           }
         }


### PR DESCRIPTION
https://github.com/inaturalist/inaturalist/issues/3120

Ultimately this comes from a combination of normalizing the geoprivacy field and the params passing blank strings. Since `before_save` still lets the timestamps get touched and the record is "dirty" it shows as updated. Place_id could do something similar after it gets cast from `""` to `nil` on the db end. Nullifying the two offending params is the quickest fix here I think.