### PR TITLE
Fix complex taxon unique validation

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -110,10 +110,12 @@ class Taxon < ActiveRecord::Base
   after_save :index_observations
 
   validates_presence_of :name, :rank, :rank_level
-  validates_uniqueness_of :name, 
-                          :scope => [:ancestry, :is_active],
-                          :unless => Proc.new { |taxon| (taxon.ancestry.blank? || !taxon.is_active)},
-                          :message => "already used as a child of this taxon's parent"
+  validates_uniqueness_of :name, scope: %i[ancestry is_active],
+                          unless: -> { (ancestry.blank? || !is_active || complex?) }, # If a complex, allow duplicate sibling name for species...
+                          message: "already used as a child of this taxon's parent"
+  validates_uniqueness_of :name, scope: %i[ancestry is_active rank],
+                          if: -> { complex? },  # ... but do not allow duplicate sibling complex name
+                          message: "already used as a child complex of this taxon's parent"
   # validates_uniqueness_of :source_identifier,
   #                         :scope => [:source_id],
   #                         :message => "already exists",

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -202,7 +202,27 @@ describe Taxon, "creation" do
     taxon.reload
     expect(taxon.parent_id).to be(output_taxon.id)
   end
-  
+
+  context "for complex" do
+    before(:all) { load_test_taxa }
+
+    let(:child_species) { Taxon.make! name: "Lontra canadensis", rank: "species", parent: @Hylidae }
+    let(:child_complex) { Taxon.make! name: "Lontra canadensis", rank: "complex", parent: @Hylidae }
+    let(:child_complex2) { Taxon.make! name: "Lontra canadensis", rank: "complex", parent: @Hylidae }
+
+    it "should validate unique name scoped to ancestry and rank" do
+      child_complex
+
+      expect{ child_complex2 }.to raise_exception ActiveRecord::RecordInvalid,
+                                                  "Validation failed: Name already used as a child complex of this taxon's parent"
+    end
+
+    it "should allow sibling if no other complex shares name" do
+      child_species
+
+      expect{ child_complex }.not_to raise_exception
+    end
+  end
 end
 
 describe Taxon, "updating" do


### PR DESCRIPTION
#3150 

Allow a complex to share name with sibling species, but do not allow multiple sibling complexes with the same name.