### PR TITLE
Minor fix to bin/setup for Ubuntu

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,7 +27,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts "\n== Creating Template Database =="
-  if system "command -v createdb"
+  if system "command -v createdb > /dev/null"
     system "createdb template_postgis"
     system "psql -d template_postgis -c 'create extension postgis'"
     system "psql -d template_postgis -c 'create extension \"uuid-ossp\"'"


### PR DESCRIPTION
On Ubuntu, I wasn't able to get past the createdb check when setting up a development environment, even with the createdb command available in the shell.

I found when run in `irb`:
`system "command -v createdb"`
returned `nil`.

Changing this to:
`system "command -v createdb > /dev/null"`
returned `true`.

Testing:
`system "command -v invalidcommand > /dev/null"`
returned `false`.

NOTE: I haven't tested on macOS, as I don't have access to a mac.