### PR TITLE
Remove deleted user profile pics from s3 within a month

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1085,8 +1085,8 @@ class User < ActiveRecord::Base
   def self.remove_icon_from_s3( user_id )
     @s3_config ||= YAML.load_file( File.join( Rails.root, "config", "s3.yml") )
     @s3_client ||= ::Aws::S3::Client.new(
-      access_key_id: s3_config["access_key_id"],
-      secret_access_key: s3_config["secret_access_key"],
+      access_key_id: @s3_config["access_key_id"],
+      secret_access_key: @s3_config["secret_access_key"],
       region: CONFIG.s3_region
     )
     user_images = @s3_client.list_objects( bucket: CONFIG.s3_bucket, prefix: "attachments/users/icons/#{user_id}/" ).contents

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1081,6 +1081,20 @@ class User < ActiveRecord::Base
     puts "Ensure all staging servers get synced"
     puts
   end
+
+  def self.remove_icon_from_s3( user_id )
+    @s3_config ||= YAML.load_file( File.join( Rails.root, "config", "s3.yml") )
+    @s3_client ||= ::Aws::S3::Client.new(
+      access_key_id: s3_config["access_key_id"],
+      secret_access_key: s3_config["secret_access_key"],
+      region: CONFIG.s3_region
+    )
+    user_images = @s3_client.list_objects( bucket: CONFIG.s3_bucket, prefix: "attachments/users/icons/#{user_id}/" ).contents
+    if user_images.any?
+      @s3_client.delete_objects( bucket: CONFIG.s3_bucket, delete: { objects: user_images.map{|s| { key: s.key } } } )
+    end
+    # Note that the images might remain in Cloudfront for 24 hours, but by the time this gets called they're probably already gone
+  end
   
   def create_deleted_user
     DeletedUser.create(

--- a/lib/tasks/inaturalist.rake
+++ b/lib/tasks/inaturalist.rake
@@ -90,6 +90,15 @@ namespace :inaturalist do
         break if fails >= 5
       end
     end
+    # Delete user profile pics for users that were deleted over a month ago
+    DeletedUser.where( "created_at < ?", 1.month.ago ).each do |du|
+      begin
+        User.remove_icon_from_s3( du.user_id )
+      rescue
+        fails += 1
+        break if fails >= 5
+      end
+    end
   end
 
   desc "Delete expired local photos"


### PR DESCRIPTION
Prior to this we were only removing the files when a user asked to be forgotten. Patrick, I think this should work, but it's a bit hard to test so I'd appreciate another pair of eyes.