### PR TITLE
Add jwt secret entries to config.yml.example

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -126,6 +126,11 @@ base: &base
     # same code running at CONFIG.tile_servers.elasticsearch
     node_api_url: http://localhost:4000/v1
 
+    # The secrets used to sign the JWT for authenticated requests to the
+    # iNaturalistAPI. These need to be same as in the API's config.js.
+    jwt_secret: jwtSecret
+    jwt_application_secret: jwtApplicationSecret
+
     # # Path to the CA .crt file
     # ca_file: "/path/to/certs/ca-bundle.crt"
     # # Path to the certificates directory


### PR DESCRIPTION
To make setting up a new development environment smoother, as the jwt secret fallbacks in [lib/json_web_token.rb](/inaturalist/inaturalist/blob/main/lib/json_web_token.rb) don't match the jwt secret values in [iNaturalistAPI/config_example.js](https://github.com/inaturalist/iNaturalistAPI/blob/main/config_example.js).
Without this change, authenticated API requests fail out of the box on pages such as the Account Settings page.

These jwt secret values I've added here match the jwt secret values already in `iNaturalistAPI/config_example.js`

Instead of this change, another option could be to strip the jwt secret values from `iNaturalistAPI/config_example.js`, and rely on the fallbacks matching in both codebases for development environments.