### PR TITLE
Alter default jwt secrets in config.yml.example

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -128,8 +128,8 @@ base: &base
 
     # The secrets used to sign the JWT for authenticated requests to the
     # iNaturalistAPI. These need to be same as in the API's config.js.
-    jwt_secret: jwtSecret
-    jwt_application_secret: jwtApplicationSecret
+    jwt_secret: secret
+    jwt_application_secret: application_secret
 
     # # Path to the CA .crt file
     # ca_file: "/path/to/certs/ca-bundle.crt"


### PR DESCRIPTION
To match tidy of jwt secret defaults in iNaturalistAPI. It makes the example config values match the fallback values in code.

This PR is the pair of  https://github.com/inaturalist/iNaturalistAPI/pull/268 and a follow up to https://github.com/inaturalist/inaturalist/pull/3169