### PR TITLE
Change Dashboard button text to be consistent

### DIFF
--- a/app/views/identifications/_identification_for_dashboard.html.erb
+++ b/app/views/identifications/_identification_for_dashboard.html.erb
@@ -27,7 +27,7 @@
             identification.user_id != current_user.id && 
             (viewers_identification.blank? || viewers_identification.taxon_id != identification.taxon_id) %>
           <span class="btn btn-sm btn-default btn_agree">
-            <%= link_to t(:agree?), {
+            <%= link_to t(:agree), {
                  controller: "identifications",
                  action: "agree",
                  observation_id: identification.observation_id,
@@ -37,14 +37,14 @@
           </span>
         <% end %>
         <% if logged_in? && identification.user_id == current_user.id && identification.current? %>
-          <span class="btn btn-sm btn-default btn_agree"><%= link_to t(:remove), identification_path(identification),
+          <span class="btn btn-sm btn-default btn_agree"><%= link_to t(:withdraw), identification_path(identification),
               :method => :delete,
-              "data-loading-click" => t(:removing),
+              "data-loading-click" => t(:withdrawing),
               :class => "removelink" -%></span>
         <% end %>
       <% end -%>
       <% unless identification.current? -%>
-        <span class="label label-default label_refined">Refined</span>
+        <span class="label label-default label_refined"><%= t(:id_withdrawn) %></span>
       <% end -%>
       <h3 class="dashboard_id">
         <%= render :partial => 'shared/taxon', 


### PR DESCRIPTION
Change Dashboard button text to be consistent with the Observation page button text.
Fixes #1500

I checked for usages of the `:agree?` `:remove` and `:removing` text, and they all look to be used elsewhere still.

What it looks like in English:
![Issue_Dashboard_Buttons](https://user-images.githubusercontent.com/1187769/129702935-c343d6e8-71e1-4c18-9c20-9cae3188c178.PNG)
![Issue_Dashboard_Withdrawing](https://user-images.githubusercontent.com/1187769/129703074-3d120e78-fbd1-459a-8a19-5e7f03ee845b.PNG)
![Issue_Dashboard_ID_Withdrawn](https://user-images.githubusercontent.com/1187769/129702996-8ccd340d-ab33-491f-bb77-5c46636f176c.PNG)