### PR TITLE
Drop project invitations table

### DIFF
--- a/db/migrate/20210819214533_drop_project_invitations.rb
+++ b/db/migrate/20210819214533_drop_project_invitations.rb
@@ -1,0 +1,16 @@
+class DropProjectInvitations < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :project_invitations if table_exists? :project_invitations
+  end
+
+  def down
+    create_table :project_invitations do |t|
+      t.integer :project_id
+      t.integer :user_id
+      t.integer :observation_id
+
+      t.timestamps
+    end
+    add_index :project_invitations, :observation_id
+  end
+end


### PR DESCRIPTION
#3129 

In order to preserve the best schema dump match to `structure.sql`, I've omitted that here.