### PR TITLE
More slow specs

### DIFF
--- a/spec/factories/identifications.rb
+++ b/spec/factories/identifications.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :identification do
+    user
+    observation
+    taxon
+  end
+end

--- a/spec/factories/observation_fields.rb
+++ b/spec/factories/observation_fields.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :observation_field do
+    name { Faker::Lorem.sentence }
+    datatype {'text'}
+    user
+  end
+end

--- a/spec/factories/observation_photos.rb
+++ b/spec/factories/observation_photos.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :observation_photo do
+    observation
+    photo
+  end
+end

--- a/spec/factories/observation_sounds.rb
+++ b/spec/factories/observation_sounds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :observation_sound do
+    observation
+    sound
+  end
+end

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -6,5 +6,35 @@ FactoryBot.define do
     description { Faker::Lorem.sentence }
     uri { Faker::Internet.url }
     observed_on_string { 'yesterday at noon' }
+    observed_on { Date.yesterday }
+    time_observed_at { Date.yesterday.noon }
+    time_zone { 'UTC' }
+    zic_time_zone { 'UTC' }
+  end
+
+  trait :without_times do
+    observed_on { nil }
+    observed_on_string { nil }
+    time_observed_at { nil }
+    time_zone { nil }
+    zic_time_zone { nil }
+  end
+
+  trait :research_grade do
+    taxon { build :taxon, :as_species }
+    latitude { 1 }
+    longitude { 1 }
+    quality_grade { Observation::RESEARCH_GRADE }
+    identifications { [association(:identification)] }
+  end
+
+  trait :with_sounds do
+    transient { count { 1 } }
+    observation_sounds { Array.new(count) { association(:observation_sound) } }
+  end
+
+  trait :with_photos do
+    transient { count { 1 } }
+    observation_photos { Array.new(count) { association(:observation_photo) } }
   end
 end

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -1,7 +1,10 @@
 FactoryBot.define do
   factory :observation do
     user
+    taxon
     license { Observation::CC_BY }
     description { Faker::Lorem.sentence }
+    uri { Faker::Internet.url }
+    observed_on_string { 'yesterday at noon' }
   end
 end

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :photo do
+    user
+    sequence :native_photo_id
+  end
+end

--- a/spec/factories/project_observation_fields.rb
+++ b/spec/factories/project_observation_fields.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :project_observation_field do
+    project
+    observation_field
+  end
+end

--- a/spec/factories/project_observation_rules.rb
+++ b/spec/factories/project_observation_rules.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :project_observation_rule do
+    ruler { build :project }
+    operator { 'identified?' }
+  end
+end

--- a/spec/factories/project_observations.rb
+++ b/spec/factories/project_observations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :project_observation do
+    observation
+    project
+    user { observation.user }
+  end
+end

--- a/spec/factories/sounds.rb
+++ b/spec/factories/sounds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :sound do
+    user
+    sequence :native_sound_id
+  end
+end

--- a/spec/models/guide_taxon_spec.rb
+++ b/spec/models/guide_taxon_spec.rb
@@ -240,7 +240,6 @@ describe GuideTaxon do
       expect(guide_photos.last.position).to be > gp.position
     end
 
-<<<<<<< HEAD
     # it "should not add maps" do
     #   page = EolService.page(791500, :common_names => true, :maps => 1, :details => true, :photos => 0)
     #   gt.sync_eol_photos(:page => page)
@@ -263,19 +262,6 @@ describe GuideTaxon do
       expect(subject.tag_list).to include("color=yellow")
       expect(subject.tag_list).to include("color=blue")
     end
-=======
-describe GuideTaxon, "add_color_tags" do
-  let(:yellow) { build :color, value: "yellow" }
-  let(:blue) { build :color, value: "blue" }
-  let(:taxon) { build :taxon, colors: [yellow, blue] }
-  let(:subject) { build :guide_taxon, taxon: taxon }
-
-  before { subject.add_color_tags }
-
-  it "should add tags" do
-    expect(subject.tag_list).to include("color=yellow")
-    expect(subject.tag_list).to include("color=blue")
->>>>>>> Address slow spec
   end
 
   describe "add_rank_tag" do

--- a/spec/models/guide_taxon_spec.rb
+++ b/spec/models/guide_taxon_spec.rb
@@ -240,6 +240,7 @@ describe GuideTaxon do
       expect(guide_photos.last.position).to be > gp.position
     end
 
+<<<<<<< HEAD
     # it "should not add maps" do
     #   page = EolService.page(791500, :common_names => true, :maps => 1, :details => true, :photos => 0)
     #   gt.sync_eol_photos(:page => page)
@@ -262,6 +263,19 @@ describe GuideTaxon do
       expect(subject.tag_list).to include("color=yellow")
       expect(subject.tag_list).to include("color=blue")
     end
+=======
+describe GuideTaxon, "add_color_tags" do
+  let(:yellow) { build :color, value: "yellow" }
+  let(:blue) { build :color, value: "blue" }
+  let(:taxon) { build :taxon, colors: [yellow, blue] }
+  let(:subject) { build :guide_taxon, taxon: taxon }
+
+  before { subject.add_color_tags }
+
+  it "should add tags" do
+    expect(subject.tag_list).to include("color=yellow")
+    expect(subject.tag_list).to include("color=blue")
+>>>>>>> Address slow spec
   end
 
   describe "add_rank_tag" do

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -28,8 +28,6 @@ describe Observation do
   it { is_expected.to have_many :observations_places }
   it { is_expected.to have_many(:observation_reviews).dependent :destroy }
   it { is_expected.to have_many(:confirmed_reviews).class_name 'ObservationReview' }
-
-
   context 'when geo_x present' do
     subject { Observation.new geo_x: 1 }
     it { is_expected.to validate_presence_of :geo_y }
@@ -56,211 +54,247 @@ describe Observation do
   elastic_models( Observation, Taxon )
 
   describe "creation" do
+    subject { build :observation }
 
-    before(:each) do
-      @taxon = Taxon.make!
-      @observation = Observation.make!(:taxon => @taxon, :observed_on_string => 'April 1st 1994 at 1am')
-    end
-  
-    it "should be in the past" do
-      expect(@observation.observed_on).to be <= Date.today
-    end
-  
-    it "should not be in the future" do
-      expect {
-        Observation.make!(:observed_on_string => '2 weeks from now')
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-  
-    it "should properly set date and time" do
-      Time.use_zone(@observation.time_zone) do
-        expect(@observation.observed_on.year).to eq 1994
-        expect(@observation.observed_on.month).to eq 4
-        expect(@observation.observed_on.day).to eq 1
-        expect(@observation.time_observed_at.hour).to eq 1
-      end
-    end
-  
-    it "should parse time from strings like October 30, 2008 10:31PM" do
-      @observation.observed_on_string = 'October 30, 2008 10:31PM'
-      @observation.save
-      expect(@observation.time_observed_at.in_time_zone(@observation.time_zone).hour).to eq 22
-    end
-  
-    it "should parse time from strings like 2011-12-23T11:52:06-0500" do
-      @observation.observed_on_string = '2011-12-23T11:52:06-0500'
-      @observation.save
-      expect(@observation.time_observed_at.in_time_zone(@observation.time_zone).hour).to eq 11
-    end
+    describe "parses and sets time" do
+      context "with observed_on_string" do
+        subject { build_stubbed :observation }
 
-    it "should parse time from strings like 2011-12-23 11:52:06 -05" do
-      @observation.observed_on_string = "2011-12-23 11:52:06 -05"
-      @observation.save
-      expect( @observation.time_observed_at.in_time_zone( @observation.time_zone ).hour ).to eq 11
-    end
-  
-    it "should parse time from strings like 2011-12-23T11:52:06.123" do
-      @observation.observed_on_string = '2011-12-23T11:52:06.123'
-      @observation.save
-      expect(@observation.time_observed_at.in_time_zone(@observation.time_zone).hour).to eq 11
-    end
-  
-    it "should parse time and zone from July 9, 2012 7:52:39 AM ACST" do
-      @observation.observed_on_string = 'July 9, 2012 7:52:39 AM ACST'
-      @observation.save
-      expect(@observation.time_observed_at.in_time_zone(@observation.time_zone).hour).to eq 7
-      expect(@observation.time_zone).to eq ActiveSupport::TimeZone['Adelaide'].name
-    end
+        before do |spec|
+          subject.observed_on_string = spec.metadata[:time]
+          subject.run_callbacks :validation
+        end
 
-    it "should parse a bunch of test date strings" do
-      [
-        ['Fri Apr 06 2012 16:23:35 GMT-0500 (GMT-05:00)', {:month => 4, :day => 6, :hour => 16, :offset => "-05:00"}],
-        ['Sun Nov 03 2013 08:15:25 GMT-0500 (GMT-5)', {:month => 11, :day => 3, :hour => 8, :offset => "-05:00"}],
+        it "should be in the past", time: 'April 1st 1994 at 1am'  do
+          expect(subject.observed_on).to be <= Date.today
+        end
 
-        # This won't work given our current setup because if we lookup a time
-        # zone by offset like this, it will return the first *named* timezone,
-        # which in this case is Amsterdam, which is the same as CET, which, in
-        # September, observes daylight savings time, so it's actually CEST and
-        # the offset is +2:00. The main problem here is that if the client just
-        # specifies an offset, we can't reliably find the zone
-        # ['September 27, 2012 8:09:50 AM GMT+01:00', :month => 9, :day => 27, :hour => 8, :offset => "+01:00"],
+        it "should properly set date and time", time: 'April 1st 1994 at 1am' do
+          Time.use_zone(subject.time_zone) do
+            expect(subject.observed_on.year).to eq 1994
+            expect(subject.observed_on.month).to eq 4
+            expect(subject.observed_on.day).to eq 1
+            expect(subject.time_observed_at.hour).to eq 1
+          end
+        end
 
-        # This *does* work b/c in December, Amsterdam is in CET, standard time
-        ['December 27, 2012 8:09:50 AM GMT+01:00', :month => 12, :day => 27, :hour => 8, :offset => "+01:00"],
+        it "should parse time from strings like October 30, 2008 10:31PM", time: "October 30, 2008 10:31PM" do
+          expect(subject.time_observed_at.in_time_zone(subject.time_zone).hour).to eq 22
+        end
 
-        # Spacy AM, offset w/o named zone
-        ["2019-01-29 9:21:46 a. m. GMT-05:00", month: 1, day: 29, hour: 9, offset: "-05:00"],
+        it "should parse time from strings like 2011-12-23T11:52:06-0500", time: "2011-12-23T11:52:06-0500" do
+          expect(subject.time_observed_at.in_time_zone(subject.time_zone).hour).to eq 11
+        end
 
-        ['Thu Dec 26 2013 11:18:22 GMT+0530 (GMT+05:30)', :month => 12, :day => 26, :hour => 11, :offset => "+05:30"],
-        ["Thu Feb 20 2020 11:46:32 GMT+1030 (GMT+10:30)", month: 2, day: 20, hour: 11, offset: "+10:30"],
-        ["Thu Feb 20 2020 11:46:32 GMT+10:30", month: 2, day: 20, hour: 11, offset: "+10:30"],
-        # ['2010-08-23 13:42:55 +0000', :month => 8, :day => 23, :hour => 13, :offset => "+00:00"],
-        ['2014-06-18 5:18:17 pm CEST', :month => 6, :day => 18, :hour => 17, :offset => "+02:00"],
-        ["2017-03-12 12:17:00 pm PDT", month: 3, day: 12, hour: 12, offset: "-07:00"],
-        ["2017/03/12 12:17 PM PDT", month: 3, day: 12, hour: 12, offset: "-07:00"],
-        ["2017/03/12 12:17 P.M. PDT", month: 3, day: 12, hour: 12, offset: "-07:00"],
-        # ["2017/03/12 12:17 AM PDT", month: 3, day: 12, hour: 0, offset: "-07:00"], # this doesn't work.. why...
-        ["2017/04/12 12:17 AM PDT", month: 4, day: 12, hour: 0, offset: "-07:00"],
-        ["2020/09/02 8:28 PM UTC", month: 9, day: 2, hour: 20, offset: "+00:00"],
-        ["2020/09/02 8:28 PM GMT", month: 9, day: 2, hour: 20, offset: "+00:00"],
-        ["2021-03-02T13:00:10.000-06:00", month: 3, day: 2, hour: 13, offset: "-06:00"]
-      ].each do |date_string, opts|
-        o = Observation.make!(:observed_on_string => date_string)
-        expect(o.observed_on.day).to eq opts[:day]
-        expect(o.observed_on.month).to eq opts[:month]
-        t = o.time_observed_at.in_time_zone(o.time_zone)
-        expect(t.hour).to eq opts[:hour]
-        expect(t.formatted_offset).to eq opts[:offset]
-      end
-    end
+        it "should parse time from strings like 2011-12-23 11:52:06 -05", time: "2011-12-23 11:52:06 -05" do
+          expect(subject.time_observed_at.in_time_zone(subject.time_zone).hour ).to eq 11
+        end
 
-    it "should parse Spanish date strings" do
-      [
-        ['lun nov 04 2013 04:22:34 p.m. GMT-0600 (GMT-6)', {:month => 11, :day => 4, :hour => 16, :offset => "-06:00"}],
-        ['lun dic 09 2013 23:37:08 GMT-0800 (GMT-8)', {:month => 12, :day => 9, :hour => 23, :offset => "-08:00"}],
-        ['jue dic 12 2013 00:54:02 GMT-0800 (GMT-8)', {:month => 12, :day => 12, :hour => 0, :offset => "-08:00"}]
-      ].each do |date_string, opts|
-        o = Observation.make!(:observed_on_string => date_string)
-        zone = ActiveSupport::TimeZone[o.time_zone]
-        expect(zone.formatted_offset).to eq opts[:offset]
-        expect(o.observed_on.month).to eq opts[:month]
-        expect(o.observed_on.day).to eq opts[:day]
-        expect(o.time_observed_at.in_time_zone(o.time_zone).hour).to eq opts[:hour]
-      end
-    end
-  
-    it "should parse a time zone from a code" do
-      @observation.observed_on_string = 'October 30, 2008 10:31PM EST'
-      @observation.save
-      expect(@observation.time_zone).to eq ActiveSupport::TimeZone['Eastern Time (US & Canada)'].name
-    end
-  
-    it "should parse time zone from strings like 2011-12-23T11:52:06-0500" do
-      @observation.observed_on_string = '2011-12-23T11:52:06-0500'
-      @observation.save
-      zone = ActiveSupport::TimeZone[@observation.time_zone]
-      expect(zone).not_to be_blank
-      expect(zone.formatted_offset).to eq "-05:00"
-    end
+        it "should parse time from strings like 2011-12-23T11:52:06.123", time: "2011-12-23T11:52:06.123" do
+          expect(subject.time_observed_at.in_time_zone(subject.time_zone).hour).to eq 11
+        end
 
-    describe "when the user has a time zone" do
-      let(:u_est) { User.make!( time_zone: "Eastern Time (US & Canada)" ) }
-      let(:u_cot) { User.make!( time_zone: "Bogota" ) }
-      let(:u_cst) { User.make!( time_zone: "Central Time (US & Canada)" ) }
+        it "should parse time and zone from July 9, 2012 7:52:39 AM ACST", time: "July 9, 2012 7:52:39 AM ACST" do
+          expect(subject.time_observed_at.in_time_zone(subject.time_zone).hour).to eq 7
+          expect(subject.time_zone).to eq ActiveSupport::TimeZone['Adelaide'].name
+        end
 
-      it "should use the user's time zone if the date string only has an offset and it matches the user's time zone" do
-        observed_on_string = "2019-01-29 9:21:46 a. m. GMT-05:00"
-        o_est = Observation.make!( user: u_est, observed_on_string: observed_on_string )
-        expect( o_est.time_zone ).to eq u_est.time_zone
-        o_cot = Observation.make!( user: u_cot, observed_on_string: observed_on_string )
-        expect( o_cot.time_zone ).to eq u_cot.time_zone
+        it "should handle unparsable times gracefully", time: "2013-03-02, 1430hrs" do
+          expect(subject.observed_on.day).to eq 2
+        end
+
+        it "should not save a time if one wasn't specified", time: "April 2 2008" do
+          expect(subject.time_observed_at).to be_blank
+        end
+
+        it "should not save a time for 'today'", time: "today" do
+          expect(subject.time_observed_at).to be(nil)
+        end
+
+        it "should parse a time zone from a code", time: 'October 30, 2008 10:31PM EST' do
+          expect(subject.time_zone).to eq ActiveSupport::TimeZone['Eastern Time (US & Canada)'].name
+        end
+
+        it "should parse time zone from strings like '2011-12-23T11:52:06-0500'", time: "2011-12-23T11:52:06-0500" do
+          expect(subject.time_zone).not_to be_blank
+          expect(ActiveSupport::TimeZone[subject.time_zone].formatted_offset).to eq "-05:00"
+        end
+
+        it "should not save relative dates/times like 'this morning'", time: "this morning" do
+          expect(subject.observed_on_string.match('this morning')).to be(nil)
+        end
+
+        it "should preserve observed_on_string if it did NOT contain a relative time descriptor", time: "April 22 2008" do
+          expect(subject.observed_on_string).to eq "April 22 2008"
+        end
+
+        it "should parse dates that contain commas", time: "April 22, 2008" do
+          expect(subject.observed_on).not_to be(nil)
+        end
+
+        it "should NOT parse a date like '2004'", time: "2004" do
+          expect(subject).not_to be_valid
+        end
+
+        it "should properly parse relative datetimes like '2 days ago'", time: "2 days ago" do
+          Time.use_zone(subject.user.time_zone) do
+            expect(subject.observed_on).to eq 2.days.ago.to_date
+          end
+        end
+
+        it "should not save relative dates/times like 'yesterday'", time: "yesterday" do
+          expect(subject.observed_on_string.split.include?('yesterday')).to be(false)
+        end
+
+        it "should default to the user's time zone" do
+          expect(subject.time_zone).to eq subject.user.time_zone
+        end
       end
 
-      it "should use the user's time zone if the date string only has an offset and it matches the user's time zone during daylight savings time" do
-        observed_on_string = "2018-06-29 9:21:46 a. m. GMT-05:00"
-        o_est = Observation.make!( user: u_est, observed_on_string: observed_on_string )
-        expect( o_est.time_zone ).to eq u_est.time_zone
-        o_cot = Observation.make!( user: u_cot, observed_on_string: observed_on_string )
-        expect( o_cot.time_zone ).to eq u_cot.time_zone
+      context "when the user has a time zone" do
+        let(:u_est) { build_stubbed :user, time_zone: "Eastern Time (US & Canada)" }
+        let(:u_cot) { build_stubbed :user, time_zone: "Bogota" }
+
+        it "should use the user's time zone if the date string only has an offset and it matches the user's time zone" do
+          o_est = build_stubbed :observation, user: u_est, observed_on_string: "2019-01-29 9:21:46 a. m. GMT-05:00"
+          o_est.run_callbacks :validation
+          expect( o_est.time_zone ).to eq u_est.time_zone
+          o_cot = build_stubbed :observation, user: u_cot, observed_on_string: "2019-01-29 9:21:46 a. m. GMT-05:00"
+          o_cot.run_callbacks :validation
+          expect( o_cot.time_zone ).to eq u_cot.time_zone
+        end
+
+        it "should use the user's time zone if the date string only has an offset and it matches the user's time zone during daylight savings time" do
+          o_est = build_stubbed :observation, user: u_est, observed_on_string: "2018-06-29 9:21:46 a. m. GMT-05:00"
+          o_est.run_callbacks :validation
+          expect( o_est.time_zone ).to eq u_est.time_zone
+          o_cot = build_stubbed :observation, user: u_cot, observed_on_string: "2018-06-29 9:21:46 a. m. GMT-05:00"
+          o_cot.run_callbacks :validation
+          expect( o_cot.time_zone ).to eq u_cot.time_zone
+        end
+
+        it "should parse out a time even if a problem time zone code is in the observed_on_string" do
+          u_cdt = create :user, time_zone: "Central Time (US & Canada)"
+          o_cdt = create :observation, user: u_cdt, observed_on_string: "2019-03-24 2:10 PM CDT"
+
+          expect( o_cdt.time_zone ).to eq u_cdt.time_zone
+          expect( o_cdt.time_observed_at ).not_to be_blank
+        end
       end
 
-      it "should parse out a time even if a problem time zone code is in the observed_on_string" do
-        observed_on_string = "2019-03-24 2:10 PM CDT"
-        o_cdt = Observation.make!( user: u_cst, observed_on_string: observed_on_string )
-        expect( o_cdt.time_zone ).to eq u_cst.time_zone
-        expect( o_cdt.time_observed_at ).not_to be_blank
+      it "should NOT use the user's time zone if another was set" do
+        subject.time_zone = 'Eastern Time (US & Canada)'
+        subject.run_callbacks :validation
+
+        expect(subject.time_zone).not_to eq subject.user.time_zone
+        expect(subject.time_zone).to eq 'Eastern Time (US & Canada)'
+      end
+
+      it "should save the time in the time zone selected" do
+        subject.time_zone = 'Eastern Time (US & Canada)'
+        subject.run_callbacks :validation
+
+        expect(subject.time_observed_at.in_time_zone(subject.time_zone).hour).to eq 12
+      end
+
+      it "should not choke of bad dates" do
+        observation = create :observation
+        observation.observed_on_string = "this is not a date"
+
+        expect { observation.save }.not_to raise_error
+      end
+
+      it "should not be in the future" do
+        expect { create :observation, observed_on_string: '2 weeks from now' }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "should parse a bunch of test date strings" do
+        [
+            ['Fri Apr 06 2012 16:23:35 GMT-0500 (GMT-05:00)', month: 4, day: 6, hour: 16, offset: '-05:00'],
+            ['Sun Nov 03 2013 08:15:25 GMT-0500 (GMT-5)', month: 11, day: 3, hour: 8, offset: '-05:00'],
+
+            # This won't work given our current setup because if we lookup a time
+            # zone by offset like this, it will return the first *named* timezone,
+            # which in this case is Amsterdam, which is the same as CET, which, in
+            # September, observes daylight savings time, so it's actually CEST and
+            # the offset is +2:00. The main problem here is that if the client just
+            # specifies an offset, we can't reliably find the zone
+            # ['September 27, 2012 8:09:50 AM GMT+01:00', :month => 9, :day => 27, :hour => 8, :offset => "+01:00"],
+
+            # This *does* work b/c in December, Amsterdam is in CET, standard time
+            ['December 27, 2012 8:09:50 AM GMT+01:00', month: 12, day: 27, hour: 8, offset: '+01:00'],
+            # Spacy AM, offset w/o named zone
+            ['2019-01-29 9:21:46 a. m. GMT-05:00', month: 1, day: 29, hour: 9, offset: '-05:00'],
+            ['Thu Dec 26 2013 11:18:22 GMT+0530 (GMT+05:30)', month: 12, day: 26, hour: 11, offset: '+05:30'],
+            ['Thu Feb 20 2020 11:46:32 GMT+1030 (GMT+10:30)', month: 2, day: 20, hour: 11, offset: '+10:30'],
+            ['Thu Feb 20 2020 11:46:32 GMT+10:30', month: 2, day: 20, hour: 11, offset: '+10:30'],
+            # ['2010-08-23 13:42:55 +0000', :month => 8, :day => 23, :hour => 13, :offset => "+00:00"],
+            ['2014-06-18 5:18:17 pm CEST', month: 6, day: 18, hour: 17, offset: '+02:00'],
+            ['2017-03-12 12:17:00 pm PDT', month: 3, day: 12, hour: 12, offset: '-07:00'],
+            ['2017/03/12 12:17 PM PDT', month: 3, day: 12, hour: 12, offset: '-07:00'],
+            ['2017/03/12 12:17 P.M. PDT', month: 3, day: 12, hour: 12, offset: '-07:00'],
+            # ["2017/03/12 12:17 AM PDT", month: 3, day: 12, hour: 0, offset: "-07:00"], # this doesn't work.. why...
+            ['2017/04/12 12:17 AM PDT', month: 4, day: 12, hour: 0, offset: '-07:00'],
+            ['2020/09/02 8:28 PM UTC', month: 9, day: 2, hour: 20, offset: '+00:00'],
+            ['2020/09/02 8:28 PM GMT', month: 9, day: 2, hour: 20, offset: '+00:00'],
+            ['2021-03-02T13:00:10.000-06:00', month: 3, day: 2, hour: 13, offset: '-06:00']
+        ].each do |date_string, opts|
+          observation = build :observation, observed_on_string: date_string
+          observation.run_callbacks :validation
+
+          expect(observation.observed_on.day).to eq opts[:day]
+          expect(observation.observed_on.month).to eq opts[:month]
+          time = observation.time_observed_at.in_time_zone(observation.time_zone)
+          expect(time.hour).to eq opts[:hour]
+          expect(time.formatted_offset).to eq opts[:offset]
+        end
+      end
+
+      it "should parse Spanish date strings" do
+        [
+            ['lun nov 04 2013 04:22:34 p.m. GMT-0600 (GMT-6)', month: 11, day: 4, hour: 16, offset: "-06:00"],
+            ['lun dic 09 2013 23:37:08 GMT-0800 (GMT-8)', month: 12, day: 9, hour: 23, offset: "-08:00"],
+            ['jue dic 12 2013 00:54:02 GMT-0800 (GMT-8)', month: 12, day: 12, hour: 0, offset: "-08:00"]
+        ].each do |date_string, opts|
+          observation = build :observation, observed_on_string: date_string
+          observation.run_callbacks :validation
+
+          expect(ActiveSupport::TimeZone[observation.time_zone].formatted_offset).to eq opts[:offset]
+          expect(observation.observed_on.month).to eq opts[:month]
+          expect(observation.observed_on.day).to eq opts[:day]
+          expect(observation.time_observed_at.in_time_zone(observation.time_zone).hour).to eq opts[:hour]
+        end
+      end
+
+      it "should handle a user without a time zone" do
+        observation = build :observation, user: build(:user, time_zone: nil),
+                                          observed_on_string: "2018-06-29 9:21:46 a. m. GMT-05:00"
+        observation.run_callbacks :validation
+
+        expect( observation.observed_on ).not_to be_blank
+      end
+
+      it "should set the time zone to UTC if the user's time zone is blank" do
+        observation = build :observation, observed_on_string: nil, user: build(:user, time_zone: nil)
+        observation.run_callbacks :validation
+
+        expect(observation.time_zone).to eq 'UTC'
       end
     end
 
-    it "should handle a user without a time zone" do
-      u = User.make!( time_zone: nil )
-      expect( u.time_zone ).to be_nil
-      o = Observation.make!( user: u, observed_on_string: "2018-06-29 9:21:46 a. m. GMT-05:00" )
-      expect( o.observed_on ).not_to be_blank
+    it "should have a matching identification if taxon is known" do
+      observation = create :observation
+
+      expect(observation.identifications.empty?).not_to be(true)
+      expect(observation.identifications.first.taxon).to eq observation.taxon
     end
 
-    it "should handle unparsable times gracefully" do
-      @observation.observed_on_string = "2013-03-02, 1430hrs"
-      @observation.save
-      expect(@observation).to be_valid
-      expect(@observation.observed_on.day).to eq 2
-    end
-  
-    it "should not save a time if one wasn't specified" do
-      @observation.observed_on_string = "April 2 2008"
-      @observation.save
-      expect(@observation.time_observed_at).to be_blank
-    end
-  
-    it "should not save a time for 'today' or synonyms" do
-      @observation.observed_on_string = "today"
-      @observation.save
-      expect(@observation.time_observed_at).to be(nil)
-    end
-
-    it "should not choke of bad dates" do
-      @observation.observed_on_string = "this is not a date"
-      expect {
-        @observation.save
-      }.not_to raise_error
-    end
-  
-    it "should have an identification if taxon is known" do
-      @observation.save
-      @observation.reload
-      expect(@observation.identifications.empty?).not_to be(true)
-    end
-  
     it "should not have an identification if taxon is not known" do
-      o = Observation.make!
-      expect(o.identifications.to_a).to be_blank
+      observation = create :observation, taxon: nil
+
+      expect(observation.identifications.to_a).to be_blank
     end
-  
-    it "should have an identification that matches the taxon" do
-      @observation.reload
-      expect(@observation.identifications.first.taxon).to eq @observation.taxon
-    end
-  
+
     it "should not queue a DJ job to refresh lists" do
       Delayed::Job.delete_all
       stamp = Time.now
@@ -268,132 +302,78 @@ describe Observation do
       jobs = Delayed::Job.where("created_at >= ?", stamp)
       expect(jobs.select{|j| j.handler =~ /List.*refresh_with_observation/m}).to be_blank
     end
-  
-    it "should properly parse relative datetimes like '2 days ago'" do
-      Time.use_zone(@observation.user.time_zone) do
-        @observation.observed_on_string = '2 days ago'
-        @observation.save
-        expect(@observation.observed_on).to eq 2.days.ago.to_date
-      end
-    end
-  
-    it "should not save relative dates/times like 'yesterday'" do
-      expect(@observation.observed_on_string.split.include?('yesterday')).to be(false)
-    end
-  
-    it "should not save relative dates/times like 'this morning'" do
-      @observation.observed_on_string = 'this morning'
-      @observation.save
-      @observation.reload
-      expect(@observation.observed_on_string.match('this morning')).to be(nil)
-    end
-  
-    it "should preserve observed_on_string if it did NOT contain a relative " +
-       "time descriptor" do
-      @observation.observed_on_string = "April 22 2008"
-      @observation.save
-      @observation.reload
-      expect(@observation.observed_on_string).to eq "April 22 2008"
-    end
-  
-    it "should parse dates that contain commas" do
-      @observation.observed_on_string = "April 22, 2008"
-      @observation.save
-      expect(@observation.observed_on).not_to be(nil)
-    end
-  
-    it "should NOT parse a date like '2004'" do
-      @observation.observed_on_string = "2004"
-      @observation.save
-      expect(@observation).not_to be_valid
-    end
-  
-    it "should default to the user's time zone" do
-      expect(@observation.time_zone).to eq @observation.user.time_zone
-    end
-  
-    it "should NOT use the user's time zone if another was set" do
-      @observation.time_zone = 'Eastern Time (US & Canada)'
-      @observation.save
-      expect(@observation).to be_valid
-      @observation.reload
-      expect(@observation.time_zone).not_to eq @observation.user.time_zone
-      expect(@observation.time_zone).to eq'Eastern Time (US & Canada)'
-    end
-  
-    it "should save the time in the time zone selected" do
-      @observation.time_zone = 'Eastern Time (US & Canada)'
-      @observation.save
-      expect(@observation).to be_valid
-      expect(@observation.time_observed_at.in_time_zone(@observation.time_zone).hour).to eq 1
-    end
-  
-    it "should set the time zone to UTC if the user's time zone is blank" do
-      u = User.make!
-      u.update_attribute(:time_zone, nil)
-      expect(u.time_zone).to be_blank
-      o = Observation.new(:user => u)
-      o.save
-      expect(o.time_zone).to eq'UTC'
-    end
-  
+
     it "should trim whitespace from species_guess" do
-      @observation.species_guess = " Anna's Hummingbird     "
-      @observation.save
-      expect(@observation.species_guess).to eq "Anna's Hummingbird"
+      observation = create :observation, species_guess: " Anna's Hummingbird     "
+
+      expect(observation.species_guess).to eq "Anna's Hummingbird"
     end
-  
+
     it "should increment the counter cache in users" do
+      observation = create :observation
       Delayed::Worker.new.work_off
-      @observation.reload
-      old_count = @observation.user.observations_count
-      Observation.make!(:user => @observation.user)
+      observation.reload
+      old_count = observation.user.observations_count
+      Observation.make!(:user => observation.user)
       Delayed::Worker.new.work_off
-      @observation.reload
-      expect(@observation.user.observations_count).to eq old_count+1
+      observation.reload
+      expect(observation.user.observations_count).to eq old_count+1
     end
-  
-    it "should allow lots of sigfigs" do
-      lat =  37.91143999
-      lon = -122.2687819
-      @observation.latitude = lat
-      @observation.longitude = lon
-      @observation.save
-      @observation.reload
-      expect(@observation.latitude.to_f).to eq lat
-      expect(@observation.longitude.to_f).to eq lon
-    end
-  
-    it "should set lat/lon if entered in place_guess" do
-      lat =  37.91143999
-      lon = -122.2687819
-      expect(@observation.latitude).to be_blank
-      @observation.place_guess = "#{lat}, #{lon}"
-      @observation.save
-      expect(@observation.latitude.to_f).to eq lat
-      expect(@observation.longitude.to_f).to eq lon
-    end
-  
-    it "should set lat/lon if entered in place_guess as NSEW" do
-      lat =  -37.91143999
-      lon = -122.2687819
-      expect(@observation.latitude).to be_blank
-      @observation.place_guess = "S#{lat * -1}, W#{lon * -1}"
-      @observation.save
-      expect(@observation.latitude.to_f).to eq lat
-      expect(@observation.longitude.to_f).to eq lon
-    end
-  
-    it "should not set lat/lon for addresses with numbers" do
-      o = Observation.make!(:place_guess => "Apt 1, 33 Figueroa Ave., Somewhere, CA")
-      expect(o.latitude).to be_blank
-    end
-  
-    it "should not set lat/lon for addresses with zip codes" do
-      o = Observation.make!(:place_guess => "94618")
-      expect(o.latitude).to be_blank
-      o = Observation.make!(:place_guess => "94618-5555")
-      expect(o.latitude).to be_blank
+
+    describe "setting lat lon" do
+      let(:lat) { 37.91143999 }
+      let(:lon) { -122.2687819 }
+
+
+      it "sets latlon and place guess on save" do
+        observation = create :observation
+
+        expect(observation).to receive(:set_latlon_from_place_guess)
+        expect(observation).to receive(:set_place_guess_from_latlon)
+        observation.save
+      end
+
+      it "should allow lots of sigfigs" do
+        observation = create :observation, latitude: lat, longitude: lon
+
+        expect(observation.latitude.to_f).to eq lat
+        expect(observation.longitude.to_f).to eq lon
+      end
+
+      it "should set lat/lon if entered in place_guess" do
+        observation = build :observation, latitude: nil, longitude: nil, place_guess: "#{lat}, #{lon}"
+        observation.set_latlon_from_place_guess
+
+        expect(observation.latitude.to_f).to eq lat
+        expect(observation.longitude.to_f).to eq lon
+      end
+
+      it "should set lat/lon if entered in place_guess as NSEW" do
+        observation = build :observation, latitude: nil, longitude: nil, place_guess: "S#{lat * -1}, W#{lon * -1}"
+        observation.set_latlon_from_place_guess
+
+        expect(observation.latitude.to_f).to eq lat * -1
+        expect(observation.longitude.to_f).to eq lon
+      end
+
+      it "should not set lat/lon for addresses with numbers" do
+        observation = build :observation, place_guess: "Apt 1, 33 Figueroa Ave., Somewhere, CA"
+        observation.set_latlon_from_place_guess
+
+        expect(observation.latitude).to be_blank
+      end
+
+      it "should not set lat/lon for addresses with zip codes" do
+        observation = build :observation, place_guess: "94618"
+        observation.set_latlon_from_place_guess
+
+        expect(observation.latitude).to be_blank
+
+        observation2 = build :observation, place_guess: "94618-5555"
+        observation.set_latlon_from_place_guess
+
+        expect(observation2.latitude).to be_blank
+      end
     end
 
     describe "place_guess" do
@@ -513,22 +493,25 @@ describe Observation do
     end
   
     describe "quality_grade" do
+      subject { build_stubbed :observation }
+
       it "should default to casual" do
-        o = Observation.make!
-        expect(o.quality_grade).to eq Observation::CASUAL
+        subject.run_callbacks :update
+
+        expect(subject.quality_grade).to eq Observation::CASUAL
       end
     end
 
     it "should trim to the user_agent to 255 char" do
-      user_agent = <<-EOT
+      observation = create :observation, user_agent: <<-EOT
         Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR
         1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; .NET CLR 2.0.50727;
         .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648; .NET CLR 3.0.4506.2152;
         .NET CLR 3.5.30729; PeoplePal 7.0; PeoplePal 7.3; .NET4.0C; .NET4.0E;
         OfficeLiveConnector.1.5; OfficeLivePatch.1.3) w:PACBHO60
       EOT
-      o = Observation.make!(:user_agent => user_agent)
-      expect(o.user_agent.size).to be < 256
+
+      expect(observation.user_agent.size).to be < 256
     end
 
     it "should set the URI" do

--- a/spec/models/project_observation_spec.rb
+++ b/spec/models/project_observation_spec.rb
@@ -6,35 +6,299 @@ describe ProjectObservation do
   it { is_expected.to belong_to :user }
   it { is_expected.to validate_presence_of :project }
   it { is_expected.to validate_presence_of :observation }
+
+  describe '#georeferenced?' do
+    subject { build :project_observation }
+
+    it 'should work' do
+      subject.observation.assign_attributes latitude: 0.5, longitude: 0.5
+      expect(subject).to be_georeferenced
+    end
+
+    it 'should be true if observation coordinates are private' do
+      subject.observation.assign_attributes latitude: 0.5, longitude: 0.5, geoprivacy: Observation::PRIVATE
+      expect(subject).to be_georeferenced
+    end
+  end
+
+  describe 'has photos and sounds' do
+    let(:observation) { build :observation, :research_grade }
+    let(:project) { build :project }
+    let(:project_user) { build :project_user, project: project, user: observation.user }
+    subject { build :project_observation, project: project, observation: observation, user: observation.user }
+
+    before {
+      allow(observation.observation_photos).to receive(:count).and_return observation.observation_photos.length
+      allow(observation.observation_sounds).to receive(:count).and_return observation.observation_sounds.length
+      allow(observation).to receive(:reload).and_return true
+    }
+
+    describe '#has_a_photo?' do
+      context 'with photo present' do
+        let(:observation) { build :observation, :research_grade, :with_photos }
+        it { expect(subject.has_a_photo?).to be true }
+      end
+
+      context 'with photo not present' do
+        it { expect(subject.has_a_photo?).to be false }
+      end
+    end
+
+    describe '#has_a_sound?' do
+      context 'with sound present' do
+        let(:observation) { build :observation, :research_grade, :with_sounds }
+        it { expect(subject.has_a_sound?).to be true }
+      end
+      context 'with sound not present' do
+        it { expect(subject.has_a_sound?).to be false }
+      end
+    end
+
+    describe '#has_media?' do
+      context 'with photo present' do
+        let(:observation) { build :observation, :research_grade, :with_photos }
+        it { expect(subject.has_media?).to be true }
+      end
+      context 'with sound present' do
+        let(:observation) { build :observation, :research_grade, :with_sounds }
+        it { expect(subject.has_media?).to be true }
+      end
+      context 'with photo and sound not present' do
+        it { expect(subject.has_media?).to_not be true }
+      end
+    end
+  end
+
+  describe '#identified?' do
+    subject { build_stubbed :project_observation, observation: build_stubbed(:observation, taxon: nil) }
+    it 'should work' do
+      expect(subject).not_to be_identified
+      subject.observation.assign_attributes taxon: build_stubbed(:taxon), editing_user_id: subject.observation.user_id
+      expect(subject).to be_identified
+    end
+  end
+
+  describe '#in_taxon?' do
+    let(:project_user) { build :project_user }
+    let(:project) { project_user.project }
+    let(:taxon) { build :taxon, :as_species }
+    let(:observation) { build :observation, user: project_user.user, taxon: taxon }
+
+    subject { build :project_observation, observation: observation, project: project, user: observation.user }
+
+    context 'for observations of target taxon' do
+      it { is_expected.to be_in_taxon(observation.taxon) }
+    end
+
+    context 'when taxon is blank' do
+      let(:observation) { build :observation, user: project_user.user, taxon: nil }
+
+      it { is_expected.not_to be_in_taxon(nil) }
+    end
+
+    context 'for observations of descendants if target taxon' do
+      let(:child) { build :taxon, :as_subspecies, parent: observation.taxon }
+      let(:child_obs) { build :observation, taxon: child, user: project_user.user }
+      subject { build :project_observation, observation: child_obs, project: project, user: child_obs.user }
+
+      it { is_expected.to be_in_taxon(observation.taxon) }
+    end
+
+    context 'for observations outside of target taxon' do
+      before { setup_project_and_user }
+      let(:other) { create :taxon }
+      let(:other_obs) { create :observation, taxon: other, user: @project_user.user }
+      subject { build :project_observation, observation: other_obs, project: @project, user: other_obs.user }
+
+      it { is_expected.not_to be_in_taxon @taxon }
+    end
+  end
+
+  describe '#project_allows_observations?' do
+    subject { build_stubbed :project_observation, project: project }
+    context 'for collection project' do
+      let(:project) { build :project, project_type: 'collection' }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'for umbrella project' do
+      let(:project) { build :project, project_type: 'umbrella' }
+
+      it { is_expected.to_not be_valid }
+    end
+  end
+
+  describe '#observed_in_bioblitz_time_range?' do
+    subject { build :project_observation, observation: observation, project: project }
+
+    let(:start_time) { Time.parse "2016-01-01T20:00:00-07:00" }
+    let(:end_time) { Time.parse "2016-01-01T20:00:00-07:00" }
+    let(:observed_on) { start_time.to_s }
+    let(:observation) { build :observation, observed_on_string: observed_on }
+    let(:prefers_range_by_date) { true }
+    let(:project) {
+      build :project,
+            project_type: Project::BIOBLITZ_TYPE,
+            start_time: start_time,
+            end_time: end_time,
+            prefers_range_by_date: prefers_range_by_date
+    }
+
+    it 'validates observed in bioblitz time range' do
+      expect(subject).to receive(:observed_in_bioblitz_time_range?)
+
+      subject.valid?
+    end
+
+    context 'project prefers range by time' do
+      let(:prefers_range_by_date) { false }
+
+      before { subject.observation.run_callbacks :validation }
+
+      context 'equal to start time' do
+        let(:observed_on) { start_time.to_s }
+
+        it { is_expected.to be_valid }
+      end
+      context 'equal to end time' do
+        let(:observed_on) { end_time.to_s }
+
+        it { is_expected.to be_valid }
+      end
+      context 'equal to one minute earlier' do
+        let(:observed_on) { (start_time - 1.minute).to_s }
+
+        it { is_expected.to_not be_valid }
+      end
+      context 'equal to one minute later' do
+        let(:observed_on) { (end_time + 1.minute).to_s }
+
+        it { is_expected.to_not be_valid }
+      end
+    end
+
+    context 'project prefers range by date'do
+      before { subject.observation.run_callbacks :validation }
+
+      context 'equal to start time' do
+        let(:observed_on) { start_time.to_s }
+
+        it { is_expected.to be_valid }
+      end
+      context 'equal to end time' do
+        let(:observed_on) { end_time.to_s }
+
+        it { is_expected.to be_valid }
+      end
+      context 'equal to one minute earlier' do
+        let(:observed_on) { (start_time - 1.minute).to_s }
+
+        it { is_expected.to be_valid }
+      end
+      context 'equal to one minute later' do
+        let(:observed_on) { (end_time + 1.minute).to_s }
+
+        it { is_expected.to be_valid }
+      end
+      context 'equal to one day earlier' do
+        let(:observed_on) { (start_time - 1.day).to_s }
+
+        it { is_expected.to_not be_valid }
+      end
+      context 'equal to one day later' do
+        let(:observed_on) { (end_time + 1.day).to_s }
+
+        it { is_expected.to_not be_valid }
+      end
+    end
+  end
+
+  describe '#set_curator_coordinate_access' do
+    subject { build :project_observation }
+    let(:access) { ProjectUser::CURATOR_COORDINATE_ACCESS_OBSERVER }
+    let(:observation) { build_stubbed :observation, user: project_user.user }
+    let(:project_user) { build_stubbed :project_user, preferred_curator_coordinate_access: access }
+    let(:project) { project_user.project }
+    let(:user) { project_user.user }
+
+    it 'sets curator coordinate access before validation' do
+      expect(subject).to receive(:set_curator_coordinate_access)
+      subject.valid?
+    end
+
+    context 'with no user' do
+      before { subject.run_callbacks :validation }
+
+      it 'should set curator_coordinate_access to false' do
+        expect(subject.prefers_curator_coordinate_access).to be false
+      end
+    end
+
+    context 'preferring access for their own additions' do
+      let(:subject) { build_stubbed :project_observation, project: project, observation: observation, user: user }
+      before do
+        allow(subject).to receive(:project_user).and_return project_user
+        subject.run_callbacks :validation
+      end
+
+      it 'should set curator_coordinate_access to true' do
+        expect(subject.preferred_curator_coordinate_access).to be true
+      end
+    end
+
+    context 'preferring access for their own additions and added by someone else' do
+      let(:subject) { build_stubbed :project_observation, project: project, observation: observation }
+
+      before { subject.run_callbacks :validation }
+
+      it 'should set curator_coordinate_access to false' do
+        expect(subject.preferred_curator_coordinate_access).to be false
+      end
+    end
+
+    context 'preferring access for addition by others' do
+      let(:subject) { build_stubbed :project_observation, project: project, observation: observation }
+      let(:access) { ProjectUser::CURATOR_COORDINATE_ACCESS_ANY }
+
+      before do
+        allow(subject).to receive(:project_user).and_return project_user
+        subject.run_callbacks :validation
+      end
+
+      it 'should set curator_coordinate_access to true' do
+        expect(subject.preferred_curator_coordinate_access).to be true
+      end
+    end
+  end
 end
 
 describe ProjectObservation, "creation" do
   elastic_models( Observation, Place )
-  before(:each) do
-    setup_project_and_user
-  end
-  it "should not queue a DJ job for the list" do
-    stamp = Time.now
-    make_project_observation(:observation => @observation, :project => @project, :user => @observation.user)
-    jobs = Delayed::Job.where("created_at >= ?", stamp)
-    expect(jobs.select{|j| j.handler =~ /\:refresh_project_list\n/}).to be_blank
-  end
-  
+  before(:each) { |example| setup_project_and_user if example.metadata[:with_setup] }
+
+  let(:project_user) { build_stubbed :project_user }
+  let(:project) { project_user.project }
+  let(:taxon) { build_stubbed :taxon, :as_species }
+  let(:observation) { build_stubbed :observation, user: project_user.user, taxon: taxon }
+
+  subject { build_stubbed :project_observation, project: project, observation: observation, user: observation.user }
+
   it "should queue a DJ job to set project user counters" do
     stamp = Time.now
-    make_project_observation(:observation => @observation, :project => @project, :user => @observation.user)
+    subject.run_callbacks :create
     jobs = Delayed::Job.where("created_at >= ?", stamp)
     expect(jobs.select{|j| j.handler =~ /\:update_observations_counter_cache/}).not_to be_blank
     expect(jobs.select{|j| j.handler =~ /\:update_taxa_counter_cache/}).not_to be_blank
   end
 
-  it "should set curator id if observer is a curator" do
+  it "should set curator id if observer is a curator", :with_setup do
     o = Observation.make!(:user => @project.user, :taxon => Taxon.make!)
     po = without_delay {make_project_observation(:observation => o, :project => @project, :user => o.user)}
     expect(po.curator_identification_id).to eq(o.owners_identification.id)
   end
 
-  it "should set curator ID if observer is not a curator but a curator has identified the observation" do
+  it "should set curator ID if observer is not a curator but a curator has identified the observation", :with_setup do
     o = Observation.make!
     i = Identification.make!( observation: o, user: @project.user )
     expect( @project ).to be_curated_by i.user
@@ -44,14 +308,13 @@ describe ProjectObservation, "creation" do
     expect( i.project_observations.first ).to eq po
   end
 
-  it "should touch the observation" do
-    o = Observation.make!(:user => @project_user.user)
-    po = ProjectObservation.create(:observation => o, :project => @project)
-    o.reload
-    expect(o.updated_at).to be > o.created_at
+  it "should touch the observation"  do
+    subject.run_callbacks :create
+
+    expect(subject.observation.updated_at).to be > subject.observation.created_at
   end
 
-  it "should properly touch objects that had projects preloaded" do
+  it "should properly touch objects that had projects preloaded", :with_setup do
     o = Observation.make!(:user => @project_user.user)
     Observation.preload_associations(o, :project_observations)
     expect(Observation.elastic_search(where: { id: o.id }).
@@ -61,123 +324,21 @@ describe ProjectObservation, "creation" do
       results.results.first.project_ids).to eq [ @project.id ]
   end
 
-  it "should set curator_coordinate_access to false by default" do
-    po = ProjectObservation.make!
-    expect( po.project.project_users.where(user_id: po.observation.user_id) ).to be_blank
-    expect( po.prefers_curator_coordinate_access? ).to be false
-  end
-  
-  it "should set curator_coordinate_access to true if project observers prefers access for their own additions" do
-    pu = ProjectUser.make!(preferred_curator_coordinate_access: ProjectUser::CURATOR_COORDINATE_ACCESS_OBSERVER)
-    expect( pu.preferred_curator_coordinate_access ).to eq ProjectUser::CURATOR_COORDINATE_ACCESS_OBSERVER
-    po = ProjectObservation.make!(project: pu.project, observation: Observation.make!(user: pu.user), user: pu.user)
-    expect( po.preferred_curator_coordinate_access ).to be true
-  end
-
-  it "should set curator_coordinate_access to false if project observers prefers access for their own additions and added by someone else" do
-    pu = ProjectUser.make!(preferred_curator_coordinate_access: ProjectUser::CURATOR_COORDINATE_ACCESS_OBSERVER)
-    expect( pu.preferred_curator_coordinate_access ).to eq ProjectUser::CURATOR_COORDINATE_ACCESS_OBSERVER
-    po = ProjectObservation.make!(project: pu.project, observation: Observation.make!(user: pu.user))
-    expect( po.preferred_curator_coordinate_access ).to be false
-  end
-
-  it "should set curator_coordinate_access to true if project observers prefers access for addition by others" do
-    pu = ProjectUser.make!(preferred_curator_coordinate_access: ProjectUser::CURATOR_COORDINATE_ACCESS_ANY)
-    expect( pu.preferred_curator_coordinate_access ).to eq ProjectUser::CURATOR_COORDINATE_ACCESS_ANY
-    po = ProjectObservation.make!(project: pu.project, observation: Observation.make!(user: pu.user))
-    expect( po.preferred_curator_coordinate_access ).to be true
-  end
-
   it "should be possible for any member of the project" do
-    pu = ProjectUser.make!
-    po = ProjectObservation.make(user: pu.user, project: pu.project)
-    expect( po ).to be_valid
-  end
-
-  it "should validates bioblitz time range" do
-    start_time = Time.parse("2016-01-01T20:00:00-07:00")
-    end_time = Time.parse("2016-01-01T20:00:00-07:00")
-    p = Project.make!(
-      project_type: Project::BIOBLITZ_TYPE,
-      start_time: start_time,
-      end_time: end_time,
-      prefers_range_by_date: false
-    )
-    # equal to start time
-    o = Observation.make!(observed_on_string: start_time.to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to be_valid
-    # equal to end time
-    o = Observation.make!(observed_on_string: end_time.to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to be_valid
-    # 1 minute earlier
-    o = Observation.make!(observed_on_string: (start_time - 1.minute).to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to_not be_valid
-    # 1 minute later
-    o = Observation.make!(observed_on_string: (end_time + 1.minute).to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to_not be_valid
-  end
-
-  it "should validates bioblitz date range" do
-    start_time = Time.parse("2016-01-01T20:00:00-07:00")
-    end_time = Time.parse("2016-01-01T20:00:00-07:00")
-    p = Project.make!(
-      project_type: Project::BIOBLITZ_TYPE,
-      start_time: start_time,
-      end_time: end_time,
-      prefers_range_by_date: true
-    )
-    # equal to start time
-    o = Observation.make!(observed_on_string: start_time.to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to be_valid
-    # equal to end time
-    o = Observation.make!(observed_on_string: end_time.to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to be_valid
-    # 1 minute earlier
-    o = Observation.make!(observed_on_string: (start_time - 1.minute).to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to be_valid
-    # 1 minute later
-    o = Observation.make!(observed_on_string: (end_time + 1.minute).to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to be_valid
-    # 1 day earlier
-    o = Observation.make!(observed_on_string: (start_time - 1.day).to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to_not be_valid
-    # 1 day later
-    o = Observation.make!(observed_on_string: (end_time + 1.day).to_s)
-    po = ProjectObservation.make(project: p, observation: o)
-    expect(po).to_not be_valid
-  end
-
-  it "does not allow creation for collection projects" do
-    collection_project = Project.make!(project_type: "collection")
-    pu = ProjectUser.make!(project: collection_project)
-    po = ProjectObservation.make(user: pu.user, project: collection_project)
-    expect( po ).to_not be_valid
-  end
-
-  it "does not allow creation for umbrella projects" do
-    collection_project = Project.make!(project_type: "umbrella")
-    pu = ProjectUser.make!(project: collection_project)
-    po = ProjectObservation.make(user: pu.user, project: collection_project)
-    expect( po ).to_not be_valid
+    expect(build(:project_observation, user: project_user.user, project: project_user.project)).to be_valid
   end
 
   describe "updates" do
-    let(:project_user) { build :project_user, role: ProjectUser::CURATOR }
+    let(:project_user) { build_stubbed :project_user, role: ProjectUser::CURATOR }
+    let(:user) { project_user.user }
+    let(:project) { project_user.project }
+    let(:observer) { build_stubbed :user }
 
     before { enable_has_subscribers }
     after { disable_has_subscribers }
 
     it "should be generated for the observer" do
-      po = without_delay { ProjectObservation.make!(user: project_user.user, project: project_user.project) }
+      po = without_delay { ProjectObservation.make!(user: user, project: project) }
       expect( UpdateAction.unviewed_by_user_from_query(po.observation.user_id, notifier: po) ).to eq true
     end
     it "should not be generated if the observer added to the project" do
@@ -190,16 +351,19 @@ describe ProjectObservation, "creation" do
       end
     end
     it "should generate updates on the project" do
-      po = without_delay { ProjectObservation.make!(user: project_user.user, project: project_user.project) }
+      po = without_delay { ProjectObservation.make!(user: user, project: project) }
       expect( UpdateAction.last.resource ).to eq po.project
     end
 
     it "should not generate more than 15 updates" do
-      observer = create :user
       without_delay do
         16.times do
-          observation = create :observation, user: observer
-          ProjectObservation.make!(user: project_user.user, project: project_user.project, observation: observation)
+          build_stubbed(
+            :project_observation,
+            user: user,
+            project: project,
+            observation: build_stubbed(:observation, user: observer)
+          ).notify_observer(:observation)
         end
       end
       es_response = UpdateAction.elastic_search(
@@ -326,129 +490,6 @@ describe ProjectObservation, "observed_in_place" do
     observation.save
     project_observation.reload
     expect(project_observation).to be_observed_in_place(place)
-  end
-end
-
-describe ProjectObservation, "georeferenced?" do
-  
-  it "should work" do
-    project_observation = make_project_observation
-    o = project_observation.observation
-    o.update_attributes(:latitude => 0.5, :longitude => 0.5)
-    project_observation.reload
-    expect(project_observation).to be_georeferenced
-  end
-
-  it "should be true if observation coordinates are private" do
-    project_observation = make_project_observation
-    o = project_observation.observation
-    o.update_attributes(:latitude => 0.5, :longitude => 0.5, :geoprivacy => Observation::PRIVATE)
-    project_observation.reload
-    expect(project_observation).to be_georeferenced
-  end
-  
-end
-
-describe ProjectObservation, "identified?" do
-  
-  it "should work" do
-    project_observation = make_project_observation
-    observation = project_observation.observation
-    expect(project_observation).not_to be_identified
-    observation.update_attributes( taxon: Taxon.make!, editing_user_id: observation.user_id )
-    expect(project_observation).to be_identified
-  end
-  
-end
-
-describe ProjectObservation, "in_taxon?" do
-  before(:each) do
-    setup_project_and_user
-  end
-  
-  it "should be true for observations of target taxon" do
-    po = make_project_observation(:observation => @observation, :project => @project, :user => @observation.user)
-    expect(po).to be_in_taxon(@observation.taxon)
-  end
-  
-  it "should be true for observations of descendants if target taxon" do
-    child = Taxon.make!(parent: @taxon, rank: Taxon::SUBSPECIES)
-    o = Observation.make!(:taxon => child, :user => @project_user.user)
-    po = make_project_observation(:observation => o, :project => @project, :user => o.user)
-    expect(po).to be_in_taxon(@taxon)
-  end
-  
-  it "should not be true for observations outside of target taxon" do
-    other = Taxon.make!
-    o = Observation.make!(:taxon => other, :user => @project_user.user)
-    po = make_project_observation(:observation => o, :project => @project, :user => o.user)
-    expect(po).not_to be_in_taxon(@taxon)
-  end
-  
-  it "should be false if taxon is blank" do
-    o = Observation.make!(:user => @project_user.user)
-    po = make_project_observation(:observation => o, :project => @project, :user => o.user)
-    expect(po).not_to be_in_taxon(nil)
-  end
-end
-
-describe ProjectObservation, "has_a_photo?" do
-  let(:p) { Project.make! }
-  elastic_models( Observation )
-  it "should be true if photo present" do
-    o = make_research_grade_observation
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o, :user => o.user)
-    expect(po.has_a_photo?).to be true
-  end
-  it "should be false if photo not present" do
-    o = Observation.make!
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o, :user => o.user)
-    expect(po.has_a_photo?).to_not be true
-  end
-end
-
-describe ProjectObservation, "has_a_sound?" do
-  let(:p) { Project.make! }
-  elastic_models( Observation )
-  it "should be true if sound present" do
-    os = ObservationSound.make!
-    o = os.observation
-    o.reload
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o)
-    expect(po.has_a_sound?).to be true
-  end
-  it "should be false if sound not present" do
-    o = Observation.make!
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o)
-    expect(po.has_a_sound?).to_not be true
-  end
-end
-
-describe ProjectObservation, "has_media?" do
-  let(:p) { Project.make! }
-  elastic_models( Observation )
-  it "should be true if photo present" do
-    o = make_research_grade_observation
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o)
-    expect(po.has_media?).to be true
-  end
-  it "should be true if sound present" do
-    os = ObservationSound.make!
-    o = os.observation
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o)
-    expect(po.has_media?).to be true
-  end
-  it "should be false if photo and sound not present" do
-    o = Observation.make!
-    pu = ProjectUser.make!(:project => p, :user => o.user)
-    po = ProjectObservation.make(:project => p, :observation => o)
-    expect(po.has_media?).to_not be true
   end
 end
 


### PR DESCRIPTION
More factories added (using existing machinist blueprints as... blueprints), more work on the slowest examples:

`spec/models/project_observation_spec.rb`
`9 minutes 28 seconds` -> `4 minutes 38.2`

`spec/models/observation_spec.rb:58`
`4 minutes 43.9 seconds` -> `2 minutes 2.7 seconds`