### PR TITLE
Observose thresholds

### DIFF
--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -321,7 +321,7 @@ class TaxaController < ApplicationController
     @descendants_exist = @taxon.descendants.exists?
     @taxon_range = TaxonRange.without_geom.where(taxon_id: @taxon).first
     unless @protected_attributes_editable = @taxon.protected_attributes_editable_by?( current_user )
-      flash.now[:notice] ||= "This active taxon has more than #{Taxon::OBSERVOSE_THRESHOLD} downstream observations or is covered by a taxon framework, so some taxonomic attributes can only be editable by iNaturalist staff or taxon curators associated with that taxon framework."
+      flash.now[:notice] ||= "This active taxon has more than #{Taxon::OBSERVOSE_THRESHOLD} downstream observations or is covered by a taxon framework, so some taxonomic attributes can only be editable by staff or taxon curators associated with that taxon framework."
     end
   end
 

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -321,7 +321,7 @@ class TaxaController < ApplicationController
     @descendants_exist = @taxon.descendants.exists?
     @taxon_range = TaxonRange.without_geom.where(taxon_id: @taxon).first
     unless @protected_attributes_editable = @taxon.protected_attributes_editable_by?( current_user )
-      flash.now[:notice] ||= "This active taxon is covered by a taxon framework, so some taxonomic attributes can only be editable by taxon curators associated with that taxon framework."
+      flash.now[:notice] ||= "This active taxon has more than #{Taxon::OBSERVOSE_THRESHOLD} downstream observations or is covered by a taxon framework, so some taxonomic attributes can only be editable by iNaturalist staff or taxon curators associated with that taxon framework."
     end
   end
 

--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -87,10 +87,10 @@ class TaxonChangesController < ApplicationController
       if current_user && @upstream_taxon_framework && @upstream_taxon_framework.taxon_curators.count > 0 && @upstream_taxon_framework.taxon_curators.select{|tc| tc.user_id != current_user}
         @curated_upstream_taxon_framework = @upstream_taxon_framework
       end
-      @observose_taxon = @taxon_change.input_taxa.detect{|t| t.observose_branch?}.try(:observose_branch?)
-      @observose_taxon_threshold = @taxon_change.input_taxa.detect{|t| t.get_observose_threshold}.try(:get_observose_threshold)
-      @observose_taxon_warning = @taxon_change.input_taxa.detect{|t| t.observose_warning_branch?}.try(:observose_warning_branch?)
-      @observose_taxon_warning_threshold = @taxon_change.input_taxa.detect{|t| t.get_observose_warning_threshold}.try(:get_observose_warning_threshold)
+      @observose_taxon = @taxon_change.input_taxa.detect{|t| t.observose_branch?}.try( :observose_branch? )
+      @observose_taxon_threshold = @taxon_change.input_taxa.detect{|t| t.get_observose_threshold}.try( :get_observose_threshold )
+      @observose_taxon_warning = @taxon_change.input_taxa.detect{|t| t.observose_warning_branch?}.try( :observose_warning_branch? )
+      @observose_taxon_warning_threshold = @taxon_change.input_taxa.detect{|t| t.get_observose_warning_threshold}.try( :get_observose_warning_threshold )
     end
     respond_to do |format|
       format.html

--- a/app/controllers/taxon_changes_controller.rb
+++ b/app/controllers/taxon_changes_controller.rb
@@ -87,6 +87,10 @@ class TaxonChangesController < ApplicationController
       if current_user && @upstream_taxon_framework && @upstream_taxon_framework.taxon_curators.count > 0 && @upstream_taxon_framework.taxon_curators.select{|tc| tc.user_id != current_user}
         @curated_upstream_taxon_framework = @upstream_taxon_framework
       end
+      @observose_taxon = @taxon_change.input_taxa.detect{|t| t.observose_branch?}.try(:observose_branch?)
+      @observose_taxon_threshold = @taxon_change.input_taxa.detect{|t| t.get_observose_threshold}.try(:get_observose_threshold)
+      @observose_taxon_warning = @taxon_change.input_taxa.detect{|t| t.observose_warning_branch?}.try(:observose_warning_branch?)
+      @observose_taxon_warning_threshold = @taxon_change.input_taxa.detect{|t| t.get_observose_warning_threshold}.try(:get_observose_warning_threshold)
     end
     respond_to do |format|
       format.html

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -135,7 +135,7 @@ class Taxon < ApplicationRecord
     :observations => {:notification => "new_observations", :include_owner => false}
   }
   
-  OBSERVOSE_THRESHOLD = 1
+  OBSERVOSE_THRESHOLD = 200000
   OBSERVOSE_WARNING_THRESHOLD = 1000
 
   NAME_PROVIDER_TITLES = {
@@ -1224,7 +1224,7 @@ class Taxon < ApplicationRecord
 
   def curated_taxon_framework?( taxon_framework )
     return false unless taxon_framework
-    return false unless taxon_framework.taxon_curators.any?
+    return taxon_framework.taxon_curators.any?
   end
 
   def current_user_curates_taxon?( user, taxon_framework )
@@ -1259,8 +1259,7 @@ class Taxon < ApplicationRecord
   def protected_attributes_editable_by?( user )
     return true unless is_active
     return true if user && user.is_admin?
-    upstream_taxon_framework = upstream_taxon_framework
-
+    upstream_taxon_framework = get_upstream_taxon_framework
     if observose_branch?
       return false unless curated_taxon_framework?( upstream_taxon_framework )
       return current_user_curates_taxon?( user, upstream_taxon_framework )
@@ -1272,7 +1271,7 @@ class Taxon < ApplicationRecord
   
   def activated_protected_attributes_editable_by?( user )
     return true if user && user.is_admin?
-    upstream_taxon_framework = upstream_taxon_framework
+    upstream_taxon_framework = get_upstream_taxon_framework
     return true unless curated_taxon_framework?( upstream_taxon_framework )
     return current_user_curates_taxon?( user, upstream_taxon_framework )
   end

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -18,7 +18,6 @@ class TaxonChange < ApplicationRecord
   validates_presence_of :taxon_id
   validate :uniqueness_of_taxa
   validate :uniqueness_of_output_taxa
-  validate :taxa_below_order
   accepts_nested_attributes_for :source
   accepts_nested_attributes_for :taxon_change_taxa, :allow_destroy => true,
     :reject_if => lambda { |attrs| attrs[:taxon_id].blank? }
@@ -433,14 +432,6 @@ class TaxonChange < ApplicationRecord
     if taxon_ids.size != taxon_ids.uniq.size
       errors.add(:base, "output taxa must be unique")
     end
-  end
-
-  def taxa_below_order
-    return true if user && user.is_admin?
-    if [taxon, taxon_change_taxa.map(&:taxon)].flatten.compact.detect{|t| t.rank_level.to_i >= Taxon::ORDER_LEVEL }
-      errors.add(:base, "only admins can move around taxa at order-level and above")
-    end
-    true
   end
 
   def move_input_children_to_output( target_input_taxon )

--- a/app/views/taxa/_form.html.erb
+++ b/app/views/taxa/_form.html.erb
@@ -37,15 +37,15 @@
       <div class="column span-12">
         <%= f.text_field :parent_id, value: taxon.parent_id, class: "text", disabled: !@protected_attributes_editable %><br/>
 
-        <%= label_tag t(:parent_name) %><br/>
-        <%= text_field_tag :parent_name, ( parent = taxon.parent rescue nil ) ? parent.name : "", id: "parent_name", class: "text", disabled: !@protected_attributes_editable %>
         <% if @protected_attributes_editable %>
+          <%= label_tag t(:parent_name) %><br/>
+          <%= text_field_tag :parent_name, ( parent = taxon.parent rescue nil ) ? parent.name : "", id: "parent_name", class: "text", disabled: !@protected_attributes_editable %>
           <%= link_to_function t(:browse_all_species), "$('#taxonchooser').jqmShow();" %>
+          <div class="description">
+            <%= t(:this_is_more_convenient_way_find_parent) %>
+          </div>
         <% end %>
-        <div class="description">
-          <%= t(:this_is_more_convenient_way_find_parent) %>
-        </div>
-
+        
       </div>
       <% if !taxon.new_record? && @protected_attributes_editable -%>
         <div class="column span-5">
@@ -234,7 +234,11 @@
   </fieldset>
   
   <div class="clear buttonrow">
-    <%= f.submit t(:save_changes), :class => 'default button', data: { loading_click: t(:saving) } %>
+    <% if @taxon.observose_warning_branch? -%>
+      <%= f.submit t(:save_changes), :class => 'default button', data: { loading_click: t(:saving), confirm: t( :this_taxon_has_more_than, observation_warning_threshold: @taxon.get_observose_warning_threshold ) } %>
+    <% else %>
+      <%= f.submit t(:save_changes), :class => 'default button', data: { loading_click: t(:saving) } %>
+    <% end -%>
     <%= link_to t(:cancel), taxon, :class => 'button' %>
     <% if taxon.persisted? %>
       <%-

--- a/app/views/taxon_changes/_show_change_taxon.html.haml
+++ b/app/views/taxon_changes/_show_change_taxon.html.haml
@@ -4,6 +4,7 @@
   hide_title ||= false
   show_change_links ||= false
   show_commit_button ||= false
+  confirm_msg = @observose_taxon_warning ? t( :one_or_more_input_taxa_have_more_than, observation_warning_threshold: @observose_taxon_warning_threshold ) : t( :are_you_sure_you_want_to_commit_this_change )
 .taxon_change
   - unless hide_buttons
     .pull-right.inline.buttonrow
@@ -14,7 +15,7 @@
         - if show_commit_button && !taxon_change.committed? && taxon_change.committable_by?( current_user )
           = link_to t(:commit), taxon_change_commit_path(taxon_change),    |
             :data => {                                                     |
-              :confirm => t(:are_you_sure_you_want_to_commit_this_change), |
+              :confirm => confirm_msg, |
               :loading_click => t(:committing)                             |
             },                                                             |
             :method => :put,                                               |

--- a/app/views/taxon_changes/show.html.haml
+++ b/app/views/taxon_changes/show.html.haml
@@ -63,12 +63,17 @@
             = link_to_taxon @taxon_change.output_ancestor, sciname: true
           This happens when we can't automatically assign an identification to one of the output taxa.
           = link_to "Review identifications of <span class='sciname'>#{@taxon_change.input_taxon.name}</span> #{@taxon_change.input_taxon.id}".html_safe, identifications_path( taxon_id: @taxon_change.input_taxon.id, current: "any" ), class: "viewmore taxon #{@taxon_change.input_taxon.rank}"
+      -if @observose_taxon
+        .alert.alert-warning
+          %strong= "#{t(:heads_up)}:"
+          One or more of the input taxa involved in this change has more than #{@observose_taxon_threshold} downstream observations.
+          Only admins or any curators of that taxon framework can commit this change.
       - if @curated_upstream_taxon_framework && !current_user.is_admin?
         .alert.alert-warning
           %strong= "#{t(:heads_up)}:"
-          One or both of the input taxa involved in this change are within a
+          One or more of the input taxa involved in this change are within a
           = link_to "taxon framework", taxonomy_details_for_taxon_path( @curated_upstream_taxon_framework.taxon )
-          Only site admins or curators of that taxon framework can commit changes affecting covered taxa.
+          Only admins or curators of that taxon framework can commit changes affecting covered taxa.
           Contact one of that taxon's curators to commit this change:
           %ul
             - @curated_upstream_taxon_framework.taxon_curators.each do |tc|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3106,6 +3106,7 @@ en:
         </ul>
   one_by_one: "One-by-one"
   one_of_your_lists: "one of your lists..."
+  one_or_more_input_taxa_have_more_than: One or more input taxa have <b>more than %{observation_warning_threshold} downstream observations</b>. Committing may take some time to process, are you sure this taxon change is necessary? Also, taxon changes cannot be undone.
   only_a_project_manager_can_add: Only a project manager can add project curator status
   only_administrators_may_access_that_page: Only administrators may access that page
   only_an_admin_can_remove_project_users: Only an admin can remove project users
@@ -4735,6 +4736,7 @@ en:
     <strong>This taxon change has been committed!</strong>
     Please don't edit the taxa.  Editing other fields is ok.
   this_taxon_concept_is_inactive: this taxon concept is inactive
+  this_taxon_has_more_than: This taxon has more than %{observation_warning_threshold} downstream observations. Editing may take some time to process, are you sure it's necessary?
   this_taxon_has_no_default_photo: This taxon has no default photo!
   this_taxon_is_inactive_this_means: |
     This taxon is <strong>inactive</strong>. This means %{site_name}'s curators have replaced

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3106,7 +3106,7 @@ en:
         </ul>
   one_by_one: "One-by-one"
   one_of_your_lists: "one of your lists..."
-  one_or_more_input_taxa_have_more_than: One or more input taxa have <b>more than %{observation_warning_threshold} downstream observations</b>. Committing may take some time to process, are you sure this taxon change is necessary? Also, taxon changes cannot be undone.
+  one_or_more_input_taxa_have_more_than: One or more input taxa have more than %{observation_warning_threshold} downstream observations. Committing may take some time to process, are you sure this taxon change is necessary? Also, taxon changes cannot be undone.
   only_a_project_manager_can_add: Only a project manager can add project curator status
   only_administrators_may_access_that_page: Only administrators may access that page
   only_an_admin_can_remove_project_users: Only an admin can remove project users

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -1360,17 +1360,62 @@ describe Taxon, "leading_name" do
 end
 
 describe Taxon, "editable_by?" do
+  def stub_api_response_for_taxon_over_threshold( t )
+    response_json = <<-JSON
+      {
+        "total_results": 1,
+        "page": 1,
+        "per_page": 30, 
+        "results": [
+          {
+            "observations_count": #{Taxon::OBSERVOSE_THRESHOLD + 10},
+            "id": #{t.id}
+          }
+        ]
+      }
+    JSON
+    stub_request(:get, /#{INatAPIService::ENDPOINT}/).to_return(
+      status: 200,
+      body: response_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+  def stub_api_response_for_taxon_under_thershold( t )
+    response_json = <<-JSON
+      {
+        "total_results": 1,
+        "page": 1,
+        "per_page": 30, 
+        "results": [
+          {
+            "observations_count": #{Taxon::OBSERVOSE_THRESHOLD - 10},
+            "id": #{t.id}
+          }
+        ]
+      }
+    JSON
+    stub_request(:get, /#{INatAPIService::ENDPOINT}/).to_return(
+      status: 200,
+      body: response_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
   let(:admin) { make_admin }
   let(:curator) { make_curator }
+  let(:t) do
+    Taxon.make!
+  end
   it "should be editable by admins if class" do
-    expect( Taxon.make!( rank: Taxon::CLASS ) ).to be_editable_by( admin )
+    stub_api_response_for_taxon_over_threshold( t )
+    expect( t ).to be_protected_attributes_editable_by( admin )
   end
-  it "should be editable by curators if below order" do
-    taxon = Taxon.make!( rank: Taxon::FAMILY )
-    expect( taxon ).to be_editable_by( curator )
+  it "should be editable by curators if below threshold" do
+    stub_api_response_for_taxon_under_thershold( t )
+    expect( t ).to be_protected_attributes_editable_by( curator )
   end
-  it "should not be editable by curators if order or above" do
-    expect( Taxon.make!( rank: Taxon::CLASS ) ).not_to be_editable_by( curator )
+  it "should not be editable by curators if above threshold" do
+    stub_api_response_for_taxon_over_threshold( t )
+    expect( t ).not_to be_protected_attributes_editable_by( curator )
   end
   describe "when taxon framework" do
     let(:second_curator) { make_curator }

--- a/spec/models/taxon_swap_spec.rb
+++ b/spec/models/taxon_swap_spec.rb
@@ -375,7 +375,7 @@ describe TaxonSwap, "commit" do
     }.to raise_error TaxonChange::RankLevelError
   end
 
-  it "should raise an error if commiter is not a taxon curator of a taxon framework of the input taxon" do
+  it "should raise an error if commiter is not a taxon curator of a taxon framework of the input taxon" do 
     superfamily = Taxon.make!( rank: Taxon::SUPERFAMILY )
     tf = TaxonFramework.make!( taxon: superfamily, rank_level: 5 )
     tc = TaxonCurator.make!( taxon_framework: tf )


### PR DESCRIPTION
This pull request makes the changes described here https://forum.inaturalist.org/t/limiting-and-scheduling-large-taxonomy-ancestry-changes/25486
specifically:
1) Establishes an OBSERVOSE_THRESHOLD = 200000 and OBSERVOSE_WARNING_THRESHOLD = 1000
2) Only staff or taxon curators can edit taxa passing the OBSERVOSE_THRESHOLD
3) Only staff or taxon curators can commit taxon changes with input taxa passing the OBSERVOSE_THRESHOLD
4) Warning on taxon save on taxa passing the OBSERVOSE_WARNING_THRESHOLD
5) Warning on taxon change commit with input taxa passing the OBSERVOSE_WARNING_THRESHOLD