### PR TITLE
Fix project slugs that begin with a number and contain unicode

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -72,11 +72,12 @@ class Project < ApplicationRecord
     super_candidate = super( string )
     candidate = title.parameterize
     candidate = super_candidate if candidate.blank? || candidate == super_candidate
-    if candidate.to_i > 0
-      candidate = string.gsub( /[^\p{Word}0-9\-_]+/, "-" ).downcase
-    end
     if candidate =~ /^\d+$/
-      candidate = ["project", id, candidate].compact.join( "-" )
+      candidate = string.gsub( /[^\p{Word}0-9\-_]+/, "-" ).downcase
+    
+      if candidate =~ /^\d+$/
+        candidate = ["project", id, candidate].compact.join( "-" )
+      end
     end
     candidate
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -121,6 +121,12 @@ describe Project do
       expect( p.slug ).to eq "foo"
     end
 
+    it "should transliterate slugs when the title starts with a number" do
+      p = Project.make!( title: "1000 Föö" )
+      p.save
+      expect( p.slug ).to eq "1000-foo"
+    end
+
     describe "for bioblitzes" do
       let(:p) do
         Project.make(


### PR DESCRIPTION
Prevents unicode from getting into slugs in this situation, which can break searches. Tried to retain existing slug calculation otherwise.
Related issue #2842

Also looked at changing the `normalize_friendly_id` for `place`, as that has the same logic, but I found when trying to reproduce the same issue in places, [there is validation to prevent places from starting with a number](https://github.com/inaturalist/inaturalist/blob/main/app/models/place.rb#L305), so it shouldn't be possible for this bug to appear in places.
I can make it consistent if you think it worthwhile?

I can also add a db migration for projects with names that start with a number if needed.