### PR TITLE
Fix paragraphs not being applied in journal posts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -361,7 +361,7 @@ module ApplicationHelper
 
   def simple_format_with_structure( text, options )
     new_text = ""
-    chunks = text.split( /(<table.*table>|<ul.*ul>|<ol.*ol>|<pre.*pre>)/m )
+    chunks = text.split( /(<table.*?table>|<ul.*?ul>|<ol.*?ol>|<pre.*?pre>)/m )
     chunks.each do |chunk|
       if chunk =~ /<(table|ul|ol)>/
         html = Nokogiri::HTML::DocumentFragment.parse( chunk )


### PR DESCRIPTION
Fixes #3204

Paragraphs were not being applied when in between 2 sections of tables, lists or preformatted text.
This was because the regex used was greedy, and would include everything between the first and last of one of those tags, rather than stop matching after the first end tag it finds.

Fix was to apply the non-greedy `?` modifier to the `*`s.

Issue was also visible on messages as well as journal posts.