### PR TITLE
Atlas improvements

### DIFF
--- a/app/controllers/atlases_controller.rb
+++ b/app/controllers/atlases_controller.rb
@@ -23,12 +23,10 @@ class AtlasesController < ApplicationController
     @exploded_places_json = @exploded_places.to_json
     
     #any obs outside of the atlas
-    @observations_not_in_atlas_places_params = { 
+    @observations_not_in_atlas_places_params = Atlas::NOT_IN_ATLAS_PARAMS.merge( { 
       taxon_id: @atlas.taxon_id, 
-      quality_grade: ["research","needs_id"].join( "," ),
-      geoprivacy: ["open,obscured"].join( "," ),
       not_in_place: @atlas_presence_places_with_establishment_means.map{|p| p[:id] }.join( "," )
-    }
+    } )
     @num_obs_not_in_atlas_places = INatAPIService.observations( @observations_not_in_atlas_places_params.merge( per_page: 0 ) ).total_results
     respond_to do |format|
       format.html do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -727,7 +727,7 @@ module ApplicationHelper
       "taxon-range-layer-label" => I18n.t("maps.overlays.range"),
       "taxon-places-layer-label" => I18n.t("maps.overlays.checklist_places"),
       "taxon-places-layer-hover" => I18n.t("maps.overlays.checklist_places_description"),
-      "taxon-observations-layer-label" => I18n.t("maps.overlays.observations"),
+      "taxon-observations-layer-label" => I18n.t( options[:taxon_observations_layer_label] ? options[:taxon_observations_layer_label] : "maps.overlays.observations" ),
       "all-layer-label" => I18n.t("maps.overlays.all_observations"),
       "all-layer-description" => I18n.t("maps.overlays.every_publicly_visible_observation"),
       "gbif-layer-label" => I18n.t("maps.overlays.gbif_network"),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -727,7 +727,7 @@ module ApplicationHelper
       "taxon-range-layer-label" => I18n.t("maps.overlays.range"),
       "taxon-places-layer-label" => I18n.t("maps.overlays.checklist_places"),
       "taxon-places-layer-hover" => I18n.t("maps.overlays.checklist_places_description"),
-      "taxon-observations-layer-label" => I18n.t( options[:taxon_observations_layer_label] ? options[:taxon_observations_layer_label] : "maps.overlays.observations" ),
+      "taxon-observations-layer-label" => options[:taxon_observations_layer_label].blank? ? I18n.t( "maps.overlays.observations" ) : options[:taxon_observations_layer_label],
       "all-layer-label" => I18n.t("maps.overlays.all_observations"),
       "all-layer-description" => I18n.t("maps.overlays.every_publicly_visible_observation"),
       "gbif-layer-label" => I18n.t("maps.overlays.gbif_network"),

--- a/app/models/atlas.rb
+++ b/app/models/atlas.rb
@@ -10,6 +10,8 @@ class Atlas < ApplicationRecord
   after_save :index_taxon
   after_destroy :index_taxon
   
+  NOT_IN_ATLAS_PARAMS = { acc_below: 5000, verifiable: true, geoprivacy: ["open","obscured"].join(",")}
+
   TAXON_JOINS = [
     "LEFT OUTER JOIN taxa t ON t.id = atlases.taxon_id"
   ]
@@ -54,10 +56,14 @@ class Atlas < ApplicationRecord
   # All of the atlas places where there is a ListedTaxon demonstrating presence
   def presence_places
     exploded_place_ids_to_include, exploded_place_ids_to_exclude = get_exploded_place_ids_to_include_and_exclude
-    descendant_listed_taxa = ListedTaxon.joins( list: :check_list_place ).
-      where( "lists.type = 'CheckList'" ).
-      where( "listed_taxa.taxon_id IN ( ? )", taxon.subtree_ids )
-    descendant_place_ids = descendant_listed_taxa.select( "listed_taxa.place_id" ).distinct.pluck( :place_id )
+    scope = ListedTaxon.joins( list: :check_list_place ).
+      where( "lists.type = 'CheckList'" )
+    if taxon.rank_level <= 10
+      listed_taxa = scope.where( "listed_taxa.taxon_id IN ( ? )", taxon.subtree_ids )
+    else
+      listed_taxa = scope.where( "listed_taxa.taxon_id = ?", taxon_id )
+    end
+    descendant_place_ids = listed_taxa.select( "listed_taxa.place_id" ).distinct.pluck( :place_id )
     descendants_places = Place.where( id: descendant_place_ids ).
       where( "admin_level IN (?)", [Place::COUNTRY_LEVEL, Place::STATE_LEVEL, Place::COUNTY_LEVEL] )
     place_ancestor_ids = descendants_places.map{ |p| p.ancestor_place_ids || p.id }.
@@ -116,8 +122,13 @@ class Atlas < ApplicationRecord
   # est. means data
   def presence_places_with_establishment_means
     scope = ListedTaxon.joins( { list: :check_list_place } ).
-      where( "lists.type = 'CheckList'" ).
-      where( "listed_taxa.taxon_id IN ( ? )", taxon.subtree_ids )
+      where( "lists.type = 'CheckList'" )
+
+    if taxon.rank_level <= 10
+      scope = scope.where( "listed_taxa.taxon_id IN ( ? )", taxon.subtree_ids )
+    else
+      scope = scope.where( "listed_taxa.taxon_id = ?", taxon_id )
+    end
 
     exploded_place_ids_to_include, exploded_place_ids_to_exclude = get_exploded_place_ids_to_include_and_exclude
     native_place_ids = scope.select( "listed_taxa.place_id" ).
@@ -168,9 +179,10 @@ class Atlas < ApplicationRecord
   
   def self.still_is_marked( atlas )
     return false if atlas.is_marked = false
-    observation_search_url_params = { 
-      verifiable: true, taxon_id: atlas.taxon_id, not_in_place: atlas.presence_places.pluck(:id).join( "," ), geoprivacy: ["open","obscured"].join(",")
-    }
+    observation_search_url_params = NOT_IN_ATLAS_PARAMS.merge( {
+      taxon_id: atlas.taxon_id,
+      not_in_place: atlas_presence_places.pluck(:id).join( "," )
+    } )
     total_res = INatAPIService.observations( observation_search_url_params.merge( per_page: 0 ) ).total_results
     if total_res > 0
       return true
@@ -195,9 +207,9 @@ class Atlas < ApplicationRecord
       checked_count += 1
       change = false
       atlas_presence_places = atlas.presence_places
-      observation_search_url_params = { 
-        verifiable: true, taxon_id: atlas.taxon_id, not_in_place: atlas_presence_places.pluck(:id).join( "," ), geoprivacy: ["open","obscured"].join(",")
-      }
+      observation_search_url_params = NOT_IN_ATLAS_PARAMS.merge( {
+        taxon_id: atlas.taxon_id, not_in_place: atlas_presence_places.pluck(:id).join( "," )
+      } )
       total_res = INatAPIService.observations( observation_search_url_params.merge( per_page: 0 ) ).total_results
       if total_res == 0
         change = true if atlas.is_marked == true

--- a/app/models/atlas.rb
+++ b/app/models/atlas.rb
@@ -10,7 +10,7 @@ class Atlas < ApplicationRecord
   after_save :index_taxon
   after_destroy :index_taxon
   
-  NOT_IN_ATLAS_PARAMS = { acc_below: 5000, verifiable: true, geoprivacy: ["open","obscured"].join(",")}
+  NOT_IN_ATLAS_PARAMS = { verifiable: true, geoprivacy: ["open","obscured"].join(",")}
 
   TAXON_JOINS = [
     "LEFT OUTER JOIN taxa t ON t.id = atlases.taxon_id"

--- a/app/models/atlas.rb
+++ b/app/models/atlas.rb
@@ -181,7 +181,7 @@ class Atlas < ApplicationRecord
     return false if atlas.is_marked = false
     observation_search_url_params = NOT_IN_ATLAS_PARAMS.merge( {
       taxon_id: atlas.taxon_id,
-      not_in_place: atlas_presence_places.pluck(:id).join( "," )
+      not_in_place: atlas.presence_places.pluck(:id).join( "," )
     } )
     total_res = INatAPIService.observations( observation_search_url_params.merge( per_page: 0 ) ).total_results
     if total_res > 0

--- a/app/views/atlases/show.html.haml
+++ b/app/views/atlases/show.html.haml
@@ -41,11 +41,12 @@
         map_attributes = setup_map_tag_attrs(
           min_zoom: 1,
           show_all_layer: false,
+          taxon_observations_layer_label: "verifiable_observations",
           taxon_layers: [ {
             taxon: @atlas.taxon,
             places: false,
             ranges: true,
-            observations: true,
+            observations: {verifiable: true},
             gbif: { disabled: true },
           } ]
         )

--- a/app/views/atlases/show.html.haml
+++ b/app/views/atlases/show.html.haml
@@ -41,12 +41,12 @@
         map_attributes = setup_map_tag_attrs(
           min_zoom: 1,
           show_all_layer: false,
-          taxon_observations_layer_label: "verifiable_observations",
+          taxon_observations_layer_label: t( :verifiable_observations ),
           taxon_layers: [ {
             taxon: @atlas.taxon,
             places: false,
             ranges: true,
-            observations: {verifiable: true},
+            observations: { verifiable: true },
             gbif: { disabled: true },
           } ]
         )


### PR DESCRIPTION
### 1. Made it so that atlases for taxa coarser than species don't roll up listed taxa for taxon descendants
Atlases roll up listed taxa for taxon descendants. The idea is that if a species has no listed_taxa for place X but it has sub-species that do, place X should still be calculated as an atlas presence_place.

While atlases were mostly conceived for species, they are our only means of reassigning input_taxon IDs to unambiguous output_taxa as part of a taxon_split which sometimes needs to be done for taxa coarser than species (e.g. families etc.). This method of rolling up listed taxa for taxon descendants for taxa with many many descendants (e.g. large families) isn't scaling well and times out. 

This change makes it so that atlases for taxa coarser than species only calculate presence places based on listed_taxa associated with the taxon itself, ignoring listed_taxa associated with the taxon's descendants.

### 2. Made atlases show verifiable observations only
Previously taxon maps only showed verifiable observations. This was appropriate for atlases which are meant to convey biogeography complicated by observations of captive observations. When the React maps were extended to allow users to toggle verifiable observations, observations without media, and captive/cultivated observations, the jquery maps that persist on atlases and taxon changes changed to display all observations including casual observations.

This change stops short of adding the 3 options in the Reach maps, but makes it so that the maps on atlases show Verifiable observations _instead of_ all observations. To accomodate this, I added a parameter to the `setup_map_tag_attrs` application helper.

~~3. Made it so that atlases only flag observations with <5k accuracy~~
The utility of using atlases to mark out of atlas observations is being diminished by observations with really large accuracies. I'd like to exclude these from the existing atlas marking functionality. But I forgot that the acc_below parameter will also exclude acc=nil observations which we don't want to exclude. so I removed this piece until we can add new API params that act as acc_below OR acc=nil