### PR TITLE
don't reassess obs on global non-obscuring status creation/deletion

### DIFF
--- a/app/models/conservation_status.rb
+++ b/app/models/conservation_status.rb
@@ -125,7 +125,7 @@ class ConservationStatus < ApplicationRecord
   def update_observation_geoprivacies
     return true if skip_update_observation_geoprivacies
     # Don't reassess obs for newly created or destroyed non-obscuring global statuses
-    return true if ( saved_change_to_id? || destroyed? ) && geoprivacy == Observation::OPEN && place_id.nil?
+    return true if ( saved_change_to_id? || destroyed? ) && ( geoprivacy.nil? || geoprivacy == Observation::OPEN ) && place_id.nil?
     Observation.delay(priority: USER_INTEGRITY_PRIORITY,
       queue: "throttled",
       unique_hash: {

--- a/app/models/conservation_status.rb
+++ b/app/models/conservation_status.rb
@@ -124,6 +124,8 @@ class ConservationStatus < ApplicationRecord
 
   def update_observation_geoprivacies
     return true if skip_update_observation_geoprivacies
+    # Don't reassess obs for newly created or destroyed non-obscuring global statuses
+    return true if ( saved_change_to_id? || destroyed? ) && geoprivacy == Observation::OPEN && place_id.nil?
     Observation.delay(priority: USER_INTEGRITY_PRIORITY,
       queue: "throttled",
       unique_hash: {


### PR DESCRIPTION
when global non-obscuring conservation statuses are created or destroyed, no need to reassess observation geoprivacies