### PR TITLE
26675 updown keyboardshortcut dialog

### DIFF
--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -392,6 +392,8 @@ class ObservationModal extends React.Component {
       { keys: ["z"], label: I18n.t( "zoom_photo" ) },
       { keys: ["&larr;"], label: I18n.t( "previous_observation" ) },
       { keys: ["&rarr;"], label: I18n.t( "next_observation" ) },
+      { keys: ["&uarr;"], label: I18n.t( "scroll_up" ) },
+      { keys: ["&darr;"], label: I18n.t( "scroll_down" ) },
       { keys: ["SHIFT", "&larr;"], label: I18n.t( "previous_tab" ) },
       { keys: ["SHIFT", "&rarr;"], label: I18n.t( "next_tab" ) },
       { keys: ["ALT/CMD", "&larr;"], label: I18n.t( "previous_photo" ) },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4246,6 +4246,8 @@ en:
     other: Saving %{num} of %{count} observations...
   saving_verb: Saving
   scale_colon: "Scale:"
+  scroll_down: Scroll Down
+  scroll_up: Scroll Up
   schemes: Schemes
   schemes_including: Schemes including
   # E.g. "Homo sapiens" instead of "human"


### PR DESCRIPTION
Adding scroll up/down to the Identify Modal  Keyboard shortcut popup.  

Untested. Just thought I'd take a stab at it. 
https://forum.inaturalist.org/t/add-up-down-arrows-in-identify-modal-keyboard-shortcut-popup/26675