### PR TITLE
Fix taxon photo term filter

### DIFF
--- a/app/webpack/taxa/photos/ducks/photos.js
+++ b/app/webpack/taxa/photos/ducks/photos.js
@@ -404,23 +404,19 @@ export function hydrateFromUrlParams( params ) {
     if ( params.quality_grade ) {
       newObservationParams.quality_grade = params.quality_grade;
     }
-    if ( taxon ) {
+    if ( taxon && params.term_id && params.term_value_id ) {
       const controlledAttrIDs = _.keys( taxon.fieldValues ).map( k => parseInt( k, 0 ) );
       const controlledValueIDs = _.flatten( _.values( taxon.fieldValues ) )
         .map( v => v.controlled_value.id );
-      _.forEach( params, ( value, key ) => {
-        if ( !key.match( /^term(_value)?_id$/ ) ) {
-          return;
-        }
-        const attrRelevant = key === "term_id" && controlledAttrIDs.includes( parseInt( value, 0 ) );
-        const valueRelevant = key === "term_value_id" && controlledValueIDs.includes( parseInt( value, 0 ) );
-        if ( attrRelevant || valueRelevant ) {
-          newObservationParams[key] = value;
-        }
-      } );
-      if ( !_.isEmpty( newObservationParams ) ) {
-        dispatch( setObservationParams( newObservationParams ) );
+      const attrRelevant = controlledAttrIDs.includes( parseInt( params.term_id, 0 ) );
+      const valueRelevant = controlledValueIDs.includes( parseInt( params.term_value_id, 0 ) );
+      if ( attrRelevant && valueRelevant ) {
+        newObservationParams.term_id = params.term_id;
+        newObservationParams.term_value_id = params.term_value_id;
       }
+    }
+    if ( !_.isEmpty( newObservationParams ) ) {
+      dispatch( setObservationParams( newObservationParams ) );
     }
   };
 }


### PR DESCRIPTION
Fix taxon photo term filter so both term_value_id AND term_id need to be relevant for the taxon for both of them to be included. 

Fixes #3250

Beforehand, if the term_id was valid, but the term_value_id not used, then only the term_id was included in the filter which would filter out all observations that didn't include some value for that term_id. This clashed with what the UI was showing as it indicatied that no filtering was occurring.

I also moved the setObservationParams function call to the bottom of the function (outside the `if ( taxon )` block) as it looked like a more correct location for it.

Note: I've reproduced and tested the fix locally, but as my local dev environment is lacking much data it might be worth putting it through its paces in a test environment.