### PR TITLE
Add View More links to bottom of Project observations pages

### DIFF
--- a/app/assets/stylesheets/projects/show2.scss
+++ b/app/assets/stylesheets/projects/show2.scss
@@ -1479,6 +1479,10 @@ $nav-btn-dim: 40px;
   margin-top: 10px;
 }
 
+.ViewMoreFooter {
+  margin-top: 15px;
+}
+
 .FlagAnItem {
   margin-top: 35px;
 }

--- a/app/webpack/projects/show/components/observations_flex_grid_view.jsx
+++ b/app/webpack/projects/show/components/observations_flex_grid_view.jsx
@@ -4,9 +4,10 @@ import PropTypes from "prop-types";
 import { Grid, Row, Col } from "react-bootstrap";
 import InfiniteScroll from "react-infinite-scroller";
 import Observation from "./observation";
+import ViewMoreFooter from "./view_more_footer";
 
 const ObservationsFlexGridView = ( {
-  config, observations, hasMore, loadMore, scrollIndex, maxWidth
+  config, observations, hasMore, loadMore, scrollIndex, maxWidth, showViewMoreLink, viewMoreUrl
 } ) => {
   if ( _.isEmpty( observations ) ) { return ( <span /> ); }
   const index = scrollIndex || 30;
@@ -47,6 +48,10 @@ const ObservationsFlexGridView = ( {
           </Col>
         </Row>
       </Grid>
+      <ViewMoreFooter
+          showViewMoreLink={showViewMoreLink}
+          viewMoreUrl={viewMoreUrl}
+      />
     </div>
   );
 };
@@ -57,7 +62,9 @@ ObservationsFlexGridView.propTypes = {
   hasMore: PropTypes.bool,
   loadMore: PropTypes.func,
   scrollIndex: PropTypes.number,
-  observations: PropTypes.array
+  observations: PropTypes.array,
+  showViewMoreLink: PropTypes.bool,
+  viewMoreUrl: PropTypes.string
 };
 
 export default ObservationsFlexGridView;

--- a/app/webpack/projects/show/components/observations_list_view.jsx
+++ b/app/webpack/projects/show/components/observations_list_view.jsx
@@ -7,9 +7,10 @@ import SplitTaxon from "../../../shared/components/split_taxon";
 import UserImage from "../../../shared/components/user_image";
 import UserLink from "../../../shared/components/user_link";
 import FormattedDate from "../../shared/formatted_date";
+import ViewMoreFooter from "./view_more_footer";
 
 const ObservationsListView = ( {
-  config, observations, hasMore, loadMore, setObservationFilters
+  config, observations, hasMore, loadMore, setObservationFilters, showViewMoreLink, viewMoreUrl
 } ) => {
   const scrollIndex = config.observationsScrollIndex || 30;
   const filters = config.observationFilters;
@@ -176,6 +177,10 @@ const ObservationsListView = ( {
           </Col>
         </Row>
       </Grid>
+      <ViewMoreFooter
+          showViewMoreLink={showViewMoreLink}
+          viewMoreUrl={viewMoreUrl}
+      />
     </div>
   );
 };
@@ -185,7 +190,9 @@ ObservationsListView.propTypes = {
   setObservationFilters: PropTypes.func,
   hasMore: PropTypes.bool,
   loadMore: PropTypes.func,
-  observations: PropTypes.array
+  observations: PropTypes.array,
+  showViewMoreLink: PropTypes.bool,
+  viewMoreUrl: PropTypes.string
 };
 
 export default ObservationsListView;

--- a/app/webpack/projects/show/components/observations_tab.jsx
+++ b/app/webpack/projects/show/components/observations_tab.jsx
@@ -46,6 +46,8 @@ const ObservationsTab = ( {
           infiniteScrollObservations( scrollIndex + 30 );
         }}
         hasMore={observations && observations.length >= scrollIndex && scrollIndex < 200}
+        showViewMoreLink={observations && observations.length >= scrollIndex && scrollIndex >= 200}
+        viewMoreUrl={`/observations?project_id=${project.slug}&verifiable=any&place_id=any&subview=table`}
       />
     );
   } else {
@@ -58,6 +60,8 @@ const ObservationsTab = ( {
           infiniteScrollObservations( scrollIndex + 30 );
         }}
         hasMore={observations && observations.length >= scrollIndex && scrollIndex < 200}
+        showViewMoreLink={observations && observations.length >= scrollIndex && scrollIndex >= 200}
+        viewMoreUrl={`/observations?project_id=${project.slug}&verifiable=any&place_id=any&subview=grid`}
       />
     );
   }

--- a/app/webpack/projects/show/components/view_more_footer.jsx
+++ b/app/webpack/projects/show/components/view_more_footer.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Grid, Row, Col } from "react-bootstrap";
+
+/**
+ * Renders a button-styled link with the text "View More"
+ * if the prop showViewMoreLink is true.
+ *
+ * Otherwise, renders nothing.
+ *
+ * Spacing around the link is appropriate for use as a footer.
+ *
+ */
+
+const ViewMoreFooter = ( { showViewMoreLink, viewMoreUrl } ) => {
+    return (showViewMoreLink
+        ?
+        <div className="ViewMoreFooter">
+            <Grid>
+                <Row>
+                    <Col xs={12} className="text-center">
+                        <a href={viewMoreUrl} className={"btn btn-primary btn-inat btn-green"}>{ I18n.t( "view_more" ) }</a>
+                    </Col>
+                </Row>
+            </Grid>
+        </div>
+        : null);
+};
+
+ViewMoreFooter.propTypes = {
+    showViewMoreLink: PropTypes.bool,
+    viewMoreUrl: PropTypes.string
+};
+
+export default ViewMoreFooter;


### PR DESCRIPTION
Issue: https://github.com/inaturalist/inaturalist/issues/2332

Added View More link buttons to the bottoms of both the Grid and List views of Project observations.

Links will only be visible when there are more observations than are shown on the page and the infinite scroller has reached its limit.

<img width="613" alt="Screen Shot 2021-11-05 at 11 15 11 PM" src="https://user-images.githubusercontent.com/1562005/140596171-324b003b-dfce-4be3-a6db-70b868ddd9b1.png">
<img width="673" alt="Screen Shot 2021-11-05 at 11 12 37 PM" src="https://user-images.githubusercontent.com/1562005/140596172-d2537da3-09d1-454c-8530-2bd956746d7a.png">
