### PR TITLE
Several minor fixes

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -175,7 +175,7 @@ class CheckListsController < ApplicationController
   end
   
   def lock_down_default_check_lists
-    return true unless @list.is_default?
+    return true unless @list.is_default? && @list.place.prefers_check_lists?
     if logged_in? && current_user.is_admin?
       flash[:notice] = t(:you_can_edit_this_default_check_list_because)
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -147,6 +147,13 @@ class UsersController < ApplicationController
     @helpers_count = INatAPIService.get( "/observations/identifiers",
       user_id: current_user.id, per_page: 0 ).total_results
     @comments_count = current_user.comments.count
+    projects_with_managers_count = ProjectUser.
+      joins(:project).
+      where( "projects.user_id = ?", current_user ).
+      where( role: ProjectUser::MANAGER ).
+      where( "project_users.user_id != ?", current_user ).
+      count( "DISTINCT project_id" )
+    @projects_count = current_user.projects.count - projects_with_managers_count
     ident_response = Identification.elastic_search(
       size: 0,
       filters: [

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -196,13 +196,9 @@ class ListedTaxon < ApplicationRecord
     end
   end
   PRESENT_EQUIVALENTS = [PRESENT, COMMON, UNCOMMON]
-  
+
   ESTABLISHMENT_MEANS = %w(native endemic introduced)
-  ESTABLISHMENT_MEANS_DESCRIPTIONS = ActiveSupport::OrderedHash.new
-  ESTABLISHMENT_MEANS_DESCRIPTIONS["native"] = "evolved in this region or arrived by non-anthropogenic means"
-  ESTABLISHMENT_MEANS_DESCRIPTIONS["endemic"] = "native and occurs nowhere else"
-  ESTABLISHMENT_MEANS_DESCRIPTIONS["introduced"] = "arrived in the region via anthropogenic means"
-  
+
   ESTABLISHMENT_MEANS.each do |means|
     const_set means.upcase, means
     define_method "#{means}?" do
@@ -960,9 +956,11 @@ class ListedTaxon < ApplicationRecord
   end
 
   def establishment_means_description
-    default = ListedTaxon::ESTABLISHMENT_MEANS_DESCRIPTIONS[establishment_means]
     key = default.gsub( "-", "_" ).gsub( " ", "_" ).downcase
-    I18n.t( "establishment_means_descriptions.#{ key }", default: default )
+    # I18n.t( "establishment_means_descriptions.native" )
+    # I18n.t( "establishment_means_descriptions.endemic" )
+    # I18n.t( "establishment_means_descriptions.introduced" )
+    I18n.t( "establishment_means_descriptions.#{key}" )
   end
 
   def reindex_observations_later

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -950,16 +950,11 @@ class User < ApplicationRecord
     end
 
     # transition ownership of projects with observations, delete the rest
-    Project.where(:user_id => id).find_each do |p|
-      if p.observations.exists?
-        if manager = p.project_users.managers.where("user_id != ?", id).first
-          p.user = manager.user
-          manager.role_will_change!
-          manager.save
-        else
-          pu = ProjectUser.create(:user => User.admins.first, :project => p)
-          p.user = pu.user
-        end
+    Project.where( user_id: id ).find_each do | p |
+      if p.observations.exists? && ( manager = p.project_users.managers.where( "user_id != ?", id ).first )
+        p.user = manager.user
+        manager.role_will_change!
+        manager.save
         p.save
       else
         p.destroy

--- a/app/views/listed_taxa/_establishment_field.html.erb
+++ b/app/views/listed_taxa/_establishment_field.html.erb
@@ -49,9 +49,9 @@
       <%= raw t(:establishment_means_describes_how) %> 
     </p>
     <dl>
-      <% for identifier, description in ListedTaxon::ESTABLISHMENT_MEANS_DESCRIPTIONS %>
+      <% for identifier in ListedTaxon::ESTABLISHMENT_MEANS %>
         <dt><%=t "establishment.#{ identifier }", default: identifier %></dt>
-        <dd><%=t "establishment_means_descriptions.#{description.parameterize.underscore}", default: description %></dd>
+        <dd><%=t "establishment_means_descriptions.#{identifier}" %></dd>
       <% end %>
     </dl>
   </div>

--- a/app/views/users/delete.html.haml
+++ b/app/views/users/delete.html.haml
@@ -5,7 +5,7 @@
   .row
     .col-md-6.col-md-offset-3.col-xs-12
       %h1=t :are_you_sure?
-      - if @observations_count > 0 || @identifications_count > 0 || @comments_count > 0
+      - if @observations_count > 0 || @identifications_count > 0 || @comments_count > 0 || @projects_count > 0
         %p=t "views.users.delete.by_deleting_your_account_you_will_remove"
         %ul
           - if @observations_count > 0
@@ -14,6 +14,8 @@
             %li=t "views.users.delete.x_identifications_html", count: number_with_delimiter( @identifications_count ), helpees_count: number_with_delimiter( @helpees_count )
           - if @comments_count > 0
             %li=t "views.users.delete.x_comments_html", count: number_with_delimiter( @comments_count )
+          - if @projects_count > 0
+            %li=t "views.users.delete.x_projects_html", count: number_with_delimiter( @projects_count )
         %p=t "views.users.delete.furthermore_cannot_undo_html"
       %p=t "views.users.delete.settings_and_mute_html"
       %p=t "views.users.delete.still_want_to_delete_html", confirmation_code: confirmation_code

--- a/app/webpack/shared/ducks/config.js
+++ b/app/webpack/shared/ducks/config.js
@@ -15,6 +15,7 @@ export default function reducer( state = {}, action ) {
       return Object.assign( {}, state, { [action.key]: !state[action.key] } );
     case UPDATE_CURRENT_USER: {
       if ( !state.currentUser ) return state;
+      if ( !state.currentUser.id ) return state;
       const prefUpdates = _.pickBy( action.updates, ( v, k ) => ( k.match( /prefers_/ ) || k.match( /preferred_/ ) ) );
       if ( _.keys( prefUpdates ).length > 0 ) {
         const body = new FormData( );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7552,6 +7552,13 @@ en:
             including the work of the
             <strong class="count">%{helpers_count} people</strong> who have
             helped you out with identifications
+        x_projects_html:
+            one: |
+              <strong class="count">%{count} project</strong> that does not
+              have another manager or admin that can become the new owner
+            other: |
+              <strong class="count">%{count} projects</strong> that do not
+              have other managers or admins that can become the new owner
         x_identifications_html:
           one: |
             <strong class="count">your %{count} identification</strong>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1727,6 +1727,10 @@ en:
   establishment_means_describes_how: |
     Establishment means describes how the taxon came to be established in an area.  
     See DarwinCore for <a href="http://rs.tdwg.org/dwc/terms/history/index.htm#establishmentMeans-2009-04-24">more information on terminology</a>.
+  establishment_means_descriptions:
+    native: evolved in this region or arrived by non-anthropogenic means
+    endemic: native and occurs nowhere else
+    introduced: arrived in the region via anthropogenic means
   estimate_which_input: |
     Estimate which input taxon ids will be replaced with which output taxa and which will be coarsened to a common ancestor once the split is comitted. This may take
     a moment to calculate. Links to observations are truncated to subsets of 200.

--- a/spec/controllers/check_list_controller_spec.rb
+++ b/spec/controllers/check_list_controller_spec.rb
@@ -45,7 +45,7 @@ describe CheckListsController, "destroy" do
     place.update( prefers_check_lists: false )
     curator = create :user, :as_curator
     sign_in curator
-    delete :destroy, id: list.id
+    delete :destroy, params: { id: list.id }
     expect( List.find_by_id( list.id ) ).to be_blank
   end
 
@@ -54,7 +54,7 @@ describe CheckListsController, "destroy" do
     list = place.check_list
     curator = create :user, :as_curator
     sign_in curator
-    delete :destroy, id: list.id
+    delete :destroy, params: { id: list.id }
     expect( List.find_by_id( list.id ) ).not_to be_blank
   end
 end

--- a/spec/controllers/check_list_controller_spec.rb
+++ b/spec/controllers/check_list_controller_spec.rb
@@ -37,3 +37,24 @@ describe CheckListsController, "show" do
     end
   end
 end
+
+describe CheckListsController, "destroy" do
+  it "should be allowed for curators if list is the default but place does not allow checklists" do
+    place = create :place, :with_geom, prefers_check_lists: true
+    list = place.check_list
+    place.update( prefers_check_lists: false )
+    curator = create :user, :as_curator
+    sign_in curator
+    delete :destroy, id: list.id
+    expect( List.find_by_id( list.id ) ).to be_blank
+  end
+
+  it "should not be allowed for curators if list is the default and the place allows checklists" do
+    place = create :place, :with_geom, prefers_check_lists: true
+    list = place.check_list
+    curator = create :user, :as_curator
+    sign_in curator
+    delete :destroy, id: list.id
+    expect( List.find_by_id( list.id ) ).not_to be_blank
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -708,13 +708,12 @@ describe User do
 
         it "should generate for new project owners even if they're new members" do
           p = Project.make!( user: user )
-          po = make_project_observation( project: p )
-          a = without_delay do
-            make_admin
-          end
-          expect( UpdateAction.unviewed_by_user_from_query( a.id, { } ) ).to eq false
+          make_project_observation( project: p )
+          pu = create( :project_user, project: p, role: ProjectUser::MANAGER )
+          expect( UpdateAction.unviewed_by_user_from_query( pu.user_id, {} ) ).to eq false
           without_delay { user.sane_destroy }
-          expect( UpdateAction.unviewed_by_user_from_query( a.id, resource: p ) ).to eq true
+          expect( Project.find_by_id( p.id ) ).not_to be_blank
+          expect( UpdateAction.unviewed_by_user_from_query( pu.user_id, resource: p ) ).to eq true
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -680,40 +680,12 @@ describe User do
         expect(jobs.select{|j| j.handler =~ /'ProjectList'.*\:refresh/m}).to be_blank
       end
 
-      it "should destroy projects with no observations" do
-        expect( project.observations ).to be_blank
-        user.sane_destroy
-        expect( Project.find_by_id( project.id ) ).to be_blank
-      end
-
-      it "should not destroy projects with observations" do
-        po = make_project_observation( project: project )
-        user.sane_destroy
-        expect( Project.find_by_id( project.id ) ).not_to be_blank
-      end
-
       it "should assign projects to a manager" do
         po = make_project_observation( project: project )
         m = ProjectUser.make!( role: ProjectUser::MANAGER, project: project )
         user.sane_destroy
         project.reload
         expect( project.user_id ).to eq( m.user_id )
-      end
-
-      it "should assign projects to a site admin if no manager" do
-        a = make_admin
-        expect( User.admins.count ).to eq 1
-        po = make_project_observation( project: project )
-        user.sane_destroy
-        project.reload
-        expect( project.user_id ).to eq a.id
-      end
-
-      it "should not destroy project journal posts" do
-        po = make_project_observation( project: project )
-        pjp = Post.make!( parent: project, user: user )
-        user.sane_destroy
-        expect( Post.find_by_id( pjp.id ) ).not_to be_blank
       end
 
       describe "notifications" do


### PR DESCRIPTION
* Allow default check list deletion when place no longer allows check lists
* Fixed bugs with translatable establishment means descriptions
* When user deletes their account and they made a project that has observations
  but no other managers, stop assigning the project to the first admin and just
  delete it