### PR TITLE
Truncate Projects by_login title and description with css

### DIFF
--- a/app/assets/stylesheets/projects.css
+++ b/app/assets/stylesheets/projects.css
@@ -25,3 +25,15 @@
 	margin-bottom: 20px;
 	margin-top: 20px;	
 }
+.truncate {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.truncate-2 {
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical; 
+	text-overflow: ellipsis;
+	overflow: hidden;
+}

--- a/app/views/projects/_project_by_login.html.haml
+++ b/app/views/projects/_project_by_login.html.haml
@@ -4,6 +4,8 @@
 .project_element
   = link_to project_path( project ), class: "float left" do
     = image_tag( project.icon.url( :span2 ), alt: "#{h( project.title )} icon", width: 70, height: 70 )
-  %h4= link_to truncate( strip_tags( project.title ), length: 20 ) , project
+  %h4.truncate
+    = link_to strip_tags( project.title ), project
   - unless project.description.blank?
-    = h truncate( strip_tags( project.description ), length: 60 )
+    .truncate-2
+      = h truncate( strip_tags( project.description ), length: 120 )


### PR DESCRIPTION
Instead of truncating at the server.

This allows the full width to be used to display text.

No accepted issue #, but see this forum post for an example of the issue:
https://forum.inaturalist.org/t/projects-titles-are-cut-off-in-user-profile/20749

I used `-webkit-line-clamp` etc. for the 2 line truncation as it was being used elsewhere in the codebase.