### PR TITLE
Added "Created Using" to Observation Modal

### DIFF
--- a/app/assets/stylesheets/observations/identify/observation_modal.scss
+++ b/app/assets/stylesheets/observations/identify/observation_modal.scss
@@ -550,14 +550,14 @@ body > [role="dialog"] .ObservationModal {
           text-align: center;
           display: block;
           line-height: 16px;
-          &.fa-globe {
+          &.fa-globe, &.fa-cloud-upload {
             top: 1px;
           }
         }
         img.app-thumbnail {
           position: absolute;
           left: 0;
-          top: 0;
+          top: 1px;
           width: 15px;
           text-align: center;
           display: block;

--- a/app/views/observations/identify.html.haml
+++ b/app/views/observations/identify.html.haml
@@ -3,7 +3,7 @@
   = I18n.t :identify_title
 - content_for :extrajs do
   :javascript
-    var DISPLAYABLE_APP_IDS = #{ [OauthApplication.inaturalist_android_app&.id, OauthApplication.inaturalist_iphone_app&.id, OauthApplication.seek_app&.id] };
+    var OFFICIAL_APP_IDS = #{ [OauthApplication.inaturalist_android_app&.id, OauthApplication.inaturalist_iphone_app&.id, OauthApplication.seek_app&.id].compact.to_json };
     var RECENT_OBSERVATION_FIELDS = #{ logged_in? ? current_user.recent_observation_fields.to_json(
       only: [:id, :name, :description, :datatype, :allowed_values, :values_count]).html_safe : "[]" };
     if ( typeof( CURRENT_USER ) !== undefined ) {

--- a/app/webpack/.eslintrc
+++ b/app/webpack/.eslintrc
@@ -18,7 +18,8 @@
     google: true,
     iNaturalist: true,
     SITE: true,
-    iNatModels: true
+    iNatModels: true,
+    OFFICIAL_APP_IDS: true
   },
   // To give you an idea how to override rule options:
   // "rules": {

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -738,6 +738,17 @@ class ObservationModal extends React.Component {
                                 I18n.t( `places_name.${_.snakeCase( country.name )}`, { defaultValue: country.name } ) || I18n.t( "somewhere_on_earth" )
                               ) : I18n.t( "somewhere_on_earth" ) }
                             </li>
+                            { observation.application && observation.application.name && (
+                                <li>
+                                  <a href={observation.application.url}>
+                                    <i className="fa fa-square bullet-icon" />
+                                    <span className="name">
+                                      { observation.application.name }
+                                    </span>
+                                  </a>
+                                </li>
+                              )
+                            }
                             { blind ? null : (
                               <li className="view-follow">
                                 <a

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -142,7 +142,8 @@ class ObservationModal extends React.Component {
       mapZoomLevel,
       onMapZoomChanged,
       mapZoomLevelLocked,
-      setMapZoomLevelLocked
+      setMapZoomLevelLocked,
+      officialAppIds
     } = this.props;
     if ( !observation ) {
       return <div />;
@@ -741,7 +742,7 @@ class ObservationModal extends React.Component {
                             { observation.application && observation.application.name && (
                               <li>
                                 <a href={observation.application.url}>
-                                  { DISPLAYABLE_APP_IDS.includes( observation.application.id ) ? (
+                                  { officialAppIds.includes( observation.application.id ) ? (
                                     <img
                                       className="app-thumbnail"
                                       src={observation.application.icon}

--- a/app/webpack/observations/identify/containers/observation_modal_container.js
+++ b/app/webpack/observations/identify/containers/observation_modal_container.js
@@ -54,7 +54,10 @@ function mapStateToProps( state ) {
     mapZoomLevel: state.config.mapZoomLevel,
     mapZoomLevelLocked: state.config.mapZoomLevelLocked === undefined
       ? false
-      : state.config.mapZoomLevelLocked
+      : state.config.mapZoomLevelLocked,
+    officialAppIds: state.config.officialAppIds === undefined 
+      ? [] 
+      : state.config.officialAppIds
   }, state.currentObservation );
 }
 

--- a/app/webpack/observations/identify/webpack-entry.js
+++ b/app/webpack/observations/identify/webpack-entry.js
@@ -60,6 +60,13 @@ if ( PREFERRED_SEARCH_PLACE !== undefined && PREFERRED_SEARCH_PLACE !== null ) {
   } ) );
 }
 
+if ( OFFICIAL_APP_IDS !== undefined && OFFICIAL_APP_IDS !== null ) {
+  // set apps that will display icons in the observation modal
+  store.dispatch( setConfig( {
+    officialAppIds: OFFICIAL_APP_IDS
+  } ) );
+}
+
 setupKeyboardShortcuts( store.dispatch );
 
 window.onpopstate = e => {


### PR DESCRIPTION
Issue: https://github.com/inaturalist/inaturalist/issues/3304

I decided against using the icon within the modal as I felt it would ruin the styling pattern that comes from the fa icons and the name is definitely enough to identify the application. But I can change that if the icon is a must. 

<img width="1359" alt="Screen Shot 2021-12-09 at 9 19 58 AM" src="https://user-images.githubusercontent.com/16074833/145415915-95ba00b0-ce81-4a69-ad95-edd2382a03cd.png">
