### PR TITLE
Fix react-bootstrap-datetimepicker internationalization 

### DIFF
--- a/app/webpack/computer_vision/webpack-entry.js
+++ b/app/webpack/computer_vision/webpack-entry.js
@@ -2,11 +2,14 @@ import "@babel/polyfill";
 import thunkMiddleware from "redux-thunk";
 import { createStore, compose, applyMiddleware, combineReducers } from "redux";
 import React from "react";
+import moment from "moment";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
 
 import computerVisionDemoReducer from "./ducks/computer_vision_demo";
 import ComputerVisionDemo from "./containers/computer_vision_demo";
+
+moment.locale( I18n.locale );
 
 const rootReducer = combineReducers( {
   computerVisionDemo: computerVisionDemoReducer

--- a/app/webpack/observations/uploader/webpack-entry.js
+++ b/app/webpack/observations/uploader/webpack-entry.js
@@ -5,11 +5,14 @@ import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
 import _ from "lodash";
+import moment from "moment";
 
 import reducer from "./reducers";
 import Uploader from "./containers/uploader";
 import { setConfig } from "../../shared/ducks/config";
 import { fetchSavedLocations } from "./ducks/saved_locations";
+
+moment.locale( I18n.locale );
 
 const store = createStore(
   reducer,

--- a/app/webpack/projects/form/webpack-entry.js
+++ b/app/webpack/projects/form/webpack-entry.js
@@ -2,6 +2,7 @@ import _ from "lodash";
 import "@babel/polyfill";
 import thunkMiddleware from "redux-thunk";
 import React from "react";
+import moment from "moment";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
 import {
@@ -15,6 +16,8 @@ import controlledTermsReducer, { fetchAllControlledTerms }
   from "../../observations/show/ducks/controlled_terms";
 /* global CURRENT_PROJECT */
 /* global COPY_PROJECT */
+
+moment.locale( I18n.locale );
 
 const rootReducer = combineReducers( {
   confirmModal: confirmModalReducer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7213,8 +7213,8 @@
       }
     },
     "react-bootstrap-datetimepicker": {
-      "version": "github:inaturalist/react-bootstrap-datetimepicker#9aaf38da211fa3da208b2994bf7e72864afefa3f",
-      "from": "github:inaturalist/react-bootstrap-datetimepicker#9aaf38da211fa3da208b2994bf7e72864afefa3f",
+      "version": "github:inaturalist/react-bootstrap-datetimepicker#4db2cd10e716270956237bc6b700248a64101cda",
+      "from": "github:inaturalist/react-bootstrap-datetimepicker#4db2cd10e716270956237bc6b700248a64101cda",
       "requires": {
         "classnames": "^2.1.2",
         "moment": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rc-pagination": "^1.17.3",
     "react": "^16.6.0",
     "react-bootstrap": "^0.33.1",
-    "react-bootstrap-datetimepicker": "github:inaturalist/react-bootstrap-datetimepicker#9aaf38da211fa3da208b2994bf7e72864afefa3f",
+    "react-bootstrap-datetimepicker": "github:inaturalist/react-bootstrap-datetimepicker#4db2cd10e716270956237bc6b700248a64101cda",
     "react-color": "^2.14.1",
     "react-csv": "^2.0.3",
     "react-dnd": "^5.0.0",


### PR DESCRIPTION
Fixes issue #3276

Coming at this again after a failed attempt in #3324.

Fix was reasonably straight forward. Some react entry points didn't set the moment locale before the react-datetime control was rendered, so ended up rendering the days of the week in the wrong positions for the locale.

It might be possible to move this to some shared initialization? Not sure where though.

Fixes datetime controls in:
- project create
- uploader (just the left menu was broken)
- computer vision demo

Other areas that use the control already had moment locale initialized on webpack-entry:
- identify filters
- observation show (observation fields)

I also changed the react-bootstrap-datetimepicker git hash in `package.json` to point to the head of main rather than the head of a branch in case that branch is ever deleted. No functional change expected there.