### PR TITLE
Include scopes in JWT payload

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -833,8 +833,13 @@ class UsersController < ApplicationController
     # not sure why current_user would be nil here, but sometimes it is
     return redirect_to login_path if !current_user
     payload = { user_id: current_user.id }
-    if doorkeeper_token && (a = doorkeeper_token.application)
-      payload[:oauth_application_id] = a.becomes( OauthApplication ).id
+    if doorkeeper_token
+      payload[:scopes] = doorkeeper_token.scopes
+      if a = doorkeeper_token.application
+        payload[:oauth_application_id] = a.becomes( OauthApplication ).id
+      end
+    else
+      payload[:scopes] = [:login, :write]
     end
     render json: { api_token: JsonWebToken.encode( payload ) }
   end


### PR DESCRIPTION
Hi there! This is my first contribution to the iNat repository, so please let me know if there's anything I've missed.

The context for this change is that I'm working on an app ([iNaturalist Bingo](https://forum.inaturalist.org/t/inaturalist-bingo-a-monthly-observation-quest/29046)) that users can sign in to through iNaturalist. The app doesn't need write access to the user's iNaturalist account—it only needs the user's ID. At present, the only way to get a user ID on a cross-origin domain through the OAuth flow seems to be to request a JWT token and fetch `/v1/users/me` from the API server. This requires the _write_ scope, because of these two lines in users_controller.rb:

https://github.com/inaturalist/inaturalist/blob/fc8218f329abbb5462015e723a2756031d8834b1/app/controllers/users_controller.rb#L6-L7

i.e., an access_token with only the `login` scope cannot actually fetch any details about the logged-in user.


My proposal here is that we extend the JWT to include details about the granted scopes, which the API server can then read and apply.

Thoughts? Have I missed some way to implement this "Sign in with iNaturalist"-type flow more simply?