### PR TITLE
Exclude showing project user rules without users

### DIFF
--- a/app/webpack/projects/show/components/requirements.jsx
+++ b/app/webpack/projects/show/components/requirements.jsx
@@ -56,17 +56,19 @@ const Requirements = ( {
       </a>
     ) );
   let userRules;
-  if ( _.isEmpty( project.userRules ) ) {
+  const projectUserRules = _.filter( project.userRules, "user" );
+  if ( _.isEmpty( projectUserRules ) ) {
     userRules = project.rule_members_only ? I18n.t( "project_members_only" ) : I18n.t( "any_user" );
   } else {
-    userRules = _.map( _.sortBy( project.userRules, r => r.user.login ), r => (
+    userRules = _.map( _.sortBy( projectUserRules, r => r.user.login ), r => (
       <a key={`project-user-rules-${r.id}`} href={`/people/${r.user.login}`}>
         { r.user.login }
       </a>
     ) );
   }
-  const exceptUserRules = !_.isEmpty( project.notUserRules )
-    && _.map( _.sortBy( project.notUserRules, r => r.user.login ), r => (
+  const projectNotUserRules = _.filter( project.notUserRules, "user" );
+  const exceptUserRules = !_.isEmpty( projectNotUserRules )
+    && _.map( _.sortBy( projectNotUserRules, r => r.user.login ), r => (
       <a key={`project-user-rules-${r.id}`} href={`/people/${r.user.login}`}>
         { r.user.login }
       </a>


### PR DESCRIPTION
Fixes #3318

It's possible to have project user rules for deleted users.
When displaying project user rules, filter out the rules where the user is missing to avoid an error.

I thought about filtering this further up in `/app/webpack/projects/shared/models/project.js`, but as it was a shared, and the API can return rules without users by not passing `rule_details=true` in the request, I thought it best to fix it close to where the error was occurring.