### PR TITLE
Suspend as moderator action

### DIFF
--- a/app/controllers/moderator_actions_controller.rb
+++ b/app/controllers/moderator_actions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ModeratorActionsController < ApplicationController
   before_action :authenticate_user!
   before_action :curator_required
@@ -5,14 +7,34 @@ class ModeratorActionsController < ApplicationController
   def create
     @moderator_action = ModeratorAction.new( approved_params )
     @moderator_action.user = current_user
-    respond_to do |format|
+    respond_to do | format |
       if @moderator_action.save
         format.json { render json: @moderator_action }
         format.html do
-          if @moderator_action == ModeratorAction::HIDE
-            flash[:notice] = "comment hidden"
+          default_notice = "#{@moderator_action.resource_type.humanize}: #{@moderator_action.action}"
+          flash[:notice] = case @moderator_action.resource_type
+          when "Comment"
+            case @moderator_action.action
+            when ModeratorAction::HIDE then t( :comment_hidden )
+            when ModeratorAction::UNHIDE then t( :comment_unhidden )
+            else default_notice
+            end
+          when "Identification"
+            case @moderator_action.action
+            when ModeratorAction::HIDE then t( :identification_text_hidden )
+            when ModeratorAction::UNHIDE then t( :identification_text_unhidden )
+            else default_notice
+            end
+          when "User"
+            case @moderator_action.action
+            when ModeratorAction::SUSPEND
+              t( :the_user_x_has_been_suspended, user: @moderator_action.resource.login )
+            when ModeratorAction::UNSUSPEND
+              t( :the_user_x_has_been_unsuspended, user: @moderator_action.resource.login )
+            else default_notice
+            end
           else
-            flash[:notice] = "comment unhidden"
+            default_notice
           end
           redirect_back_or_default @moderator_action.resource
         end
@@ -21,7 +43,8 @@ class ModeratorActionsController < ApplicationController
           render status: :unprocessable_entity, json: { errors: @moderator_action.errors }
         end
         format.html do
-          flash[:error] = "Couldn't hide resource: #{@moderator_action.errors.full_messages.to_sentence}"
+          flash[:error] =
+            t( :failed_to_save_record_with_errors, errors: @moderator_action.errors.full_messages.to_sentence )
           redirect_back_or_default @moderator_action.resource
         end
       end
@@ -31,7 +54,7 @@ class ModeratorActionsController < ApplicationController
   protected
 
   def approved_params
-    params.require(:moderator_action).permit(
+    params.require( :moderator_action ).permit(
       :reason,
       :action,
       :resource_type,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -343,6 +343,8 @@ module ApplicationHelper
     end
     # Ensure all tags are closed
     text = Nokogiri::HTML::DocumentFragment.parse( text ).to_s
+    # Remove empty paragraphs
+    text = text.gsub( "<p></p>", "" )
     text.html_safe
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,7 @@ class Comment < ApplicationRecord
   acts_as_spammable fields: [ :body ],
                     comment_type: "comment"
   acts_as_votable
-  has_moderator_actions
+  has_moderator_actions %w(hide unhide)
   SUBSCRIBABLE = false
 
   # Uncomment to require speech privilege to make comments on anything other

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -6,7 +6,7 @@ class Identification < ApplicationRecord
                     automated: false
 
   blockable_by lambda {|identification| identification.observation.try(:user_id) }
-  has_moderator_actions
+  has_moderator_actions %w(hide unhide)
   belongs_to_with_uuid :observation
   belongs_to :user
   belongs_to_with_uuid :taxon

--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -1,19 +1,48 @@
+# frozen_string_literal: true
+
 class ModeratorAction < ApplicationRecord
   HIDE = "hide"
   UNHIDE = "unhide"
-  ACTIONS = [HIDE, UNHIDE]
+  SUSPEND = "suspend"
+  UNSUSPEND = "unsuspend"
+  ACTIONS = [
+    HIDE,
+    SUSPEND,
+    UNHIDE,
+    UNSUSPEND
+  ].freeze
+  MINIMUM_REASON_LENGTH = 10
+  MAXIMUM_REASON_LENGTH = 2048
 
   belongs_to :user, inverse_of: :moderator_actions
   belongs_to :resource, polymorphic: true, inverse_of: :moderator_actions
   validates :action, inclusion: ACTIONS
-  validates :reason, length: { minimum: 10 }
+  validates :reason, length: { minimum: MINIMUM_REASON_LENGTH, maximum: MAXIMUM_REASON_LENGTH }
   validate :only_staff_can_unhide, on: :create
+  validate :check_accepted_actions, on: :create
+  validate :cannot_suspend_staff
 
   after_save :touch_resource
+  after_save :notify_resource
 
   def only_staff_can_unhide
-    if user && action == UNHIDE && !user.is_admin?
-      errors.add( :base, :only_staff_can_unhide )
+    return unless user && action == UNHIDE && !user.is_admin?
+
+    errors.add( :base, :only_staff_can_unhide )
+  end
+
+  def cannot_suspend_staff
+    return unless resource.is_a?( User ) && resource.is_admin? && action == SUSPEND
+
+    errors.add( :base, :staff_cannot_be_suspended )
+  end
+
+  def check_accepted_actions
+    if resource &&
+        resource.class.respond_to?( :accepted_moderator_actions ) &&
+        !resource.class.accepted_moderator_actions.blank? &&
+        !resource.class.accepted_moderator_actions.include?( action )
+      errors.add( :action, :not_supported_for_this_kind_of_content )
     end
   end
 
@@ -31,5 +60,11 @@ class ModeratorAction < ApplicationRecord
   def touch_resource
     resource.touch
     true
+  end
+
+  def notify_resource
+    return unless resource.respond_to?( :moderated_with )
+
+    resource.moderated_with( self )
   end
 end

--- a/app/views/users/moderation.html.haml
+++ b/app/views/users/moderation.html.haml
@@ -67,7 +67,8 @@
             = @site.site_name_short
           - else
             = link_to_user( record.user )
-        %td= record.try_methods( :body, :flag, :description )
+        %td
+          = truncate_with_more formatted_user_text( record.try_methods( :body, :flag, :description, :reason ) ), length: 512
         %td.nobr
           - if record.is_a?( ModeratorNote )
             - if record.editable_by?( current_user )

--- a/app/views/users/suspend.html.haml
+++ b/app/views/users/suspend.html.haml
@@ -3,7 +3,7 @@
     .col-md-6.col-md-offset-3
       %h1=t :suspend_user_html, user: link_to_user( @user )
       = form_for @moderator_action, builder: BootstrapFormBuilder do | f |
-        = f.text_area :reason, description: t( :suspend_user_reason_instructions_html, link_start_tag: "<a href=\"/pages/community-guidelines\">".html_safe, link_end_tag: "</a>".html_safe ), required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH
+        = f.text_area :reason, description: t( :suspend_user_reason_instructions_html, link_start_tag: "<a href=\"/pages/community+guidelines\">".html_safe, link_end_tag: "</a>".html_safe ), required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH
         = f.hidden_field :user_id
         = f.hidden_field :resource_type
         = f.hidden_field :resource_id

--- a/app/views/users/suspend.html.haml
+++ b/app/views/users/suspend.html.haml
@@ -1,0 +1,12 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      %h1=t :suspend_user_html, user: link_to_user( @user )
+      = form_for @moderator_action, builder: BootstrapFormBuilder do | f |
+        = f.text_area :reason, description: t( :suspend_user_reason_instructions_html, link_start_tag: "<a href=\"/pages/community-guidelines\">".html_safe, link_end_tag: "</a>".html_safe ), required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH
+        = f.hidden_field :user_id
+        = f.hidden_field :resource_type
+        = f.hidden_field :resource_id
+        = f.hidden_field :action
+        = f.submit t(:suspend_user), class: "btn btn-primary"
+        = link_to t(:cancel), :back, class: "btn btn-default"

--- a/app/views/users/unsuspend.html.haml
+++ b/app/views/users/unsuspend.html.haml
@@ -1,0 +1,12 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      %h1=t :unsuspend_user_html, user: link_to_user( @user )
+      = form_for @moderator_action, builder: BootstrapFormBuilder do | f |
+        = f.text_area :reason, description: t( :unsuspend_user_reason_instructions ), required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH - 5
+        = f.hidden_field :user_id
+        = f.hidden_field :resource_type
+        = f.hidden_field :resource_id
+        = f.hidden_field :action
+        = f.submit t(:unsuspend_user), class: "btn btn-primary"
+        = link_to t(:cancel), :back, class: "btn btn-default"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/config/initializers/has_moderator_actions.rb
+++ b/config/initializers/has_moderator_actions.rb
@@ -1,20 +1,28 @@
+# frozen_string_literal: true
+
 module HasModeratorActions
-  def self.included(base)
+  def self.included( base )
     base.extend ClassMethods
     include InstanceMethods
   end
-  
+
   module ClassMethods
-    def has_moderator_actions
+    # rubocop:disable Naming/PredicateName
+    def has_moderator_actions( accepted_actions = nil )
       has_many :moderator_actions, as: :resource, dependent: :destroy
       include HasModeratorActions::InstanceMethods
+      return unless accepted_actions
+
+      cattr_accessor :accepted_moderator_actions
+      self.accepted_moderator_actions = accepted_actions
     end
+    # rubocop:enable Naming/PredicateName
   end
 
   module InstanceMethods
     def hidden?
-      moderator_actions.sort_by(&:id).last.try(:action) == ModeratorAction::HIDE
+      moderator_actions.sort_by( &:id ).last.try( :action ) == ModeratorAction::HIDE
     end
   end
 end
-ActiveRecord::Base.send(:include, HasModeratorActions)
+ActiveRecord::Base.include HasModeratorActions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3901,8 +3901,8 @@ en:
   please_complete_the_following_to_add_project: |
     Please complete the following to add this observation to the project:
   please_confirm_your_inat_username: "Please confirm your %{site_name} username"
-  please_explain_why_you_want_to_hide_this: Please explain why you want to hide this
-  please_explain_why_you_want_to_unhide_this: Please explain why you want to unhide this
+  please_explain_why_you_want_to_hide_this: Please explain why you are hiding this
+  please_explain_why_you_want_to_unhide_this: Please explain why are unhiding this
   please_fix_your_csv_and_try_again: Please fix your CSV and try again.
   please_hold_on_while_the_file: Please hold on while the file is generated. It can take a couple minutes if you have a lot of observations.
   please_hold_on_while_the_file_is_generated: Please hold on while the file is generated.  It can take a couple minutes for large lists.
@@ -4747,8 +4747,8 @@ en:
   suspend_user: Suspend user
   suspend_user_html: Suspend %{user}
   suspend_user_reason_instructions_html: |
-    Explain why this user should be suspended by citing the
-    %{link_start_tag}Community Guideline(s)%{link_end_tag} the user violated.
+    Explain why you are suspending this user by citing the
+    %{link_start_tag}Community Guideline(s)%{link_end_tag} that the user violated.
     Please refrain from adding personal opinions.
   sw_lat: SW Lat.
   sw_lon: SW Lon.
@@ -5174,7 +5174,7 @@ en:
   unsuspend_user: Unsuspend user
   unsuspend_user_html: Unsuspend %{user}
   unsuspend_user_reason_instructions: |
-    Please explain why this user should be unsuspended.
+    Please explain why you are unsuspending this user.
   upcoming_bioblitzes: Upcoming bioblitzes
   update: Update
   update_existing_observations_with_new_license: Update existing observations with new license choices

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1024,6 +1024,10 @@ en:
   # Verb, generally a label on a button that allows the user to add a comment
   comment_: Comment
   comment_deleted: Comment deleted
+  # Notice when a comment has been hidden by moderators
+  comment_hidden: Comment hidden
+  # Notice when a comment has been unhidden by moderators
+  comment_unhidden: Comment unhidden
   comments: Comments
   comments_by_me: Comments by me
   comments_have_been_disabled: Comments have been disabled
@@ -2169,6 +2173,10 @@ en:
   identification_by_user: Identification by %{user}
   identification_deleted: Identification deleted.
   identification_saved: "Identification saved!"
+  # Notice when the text content of an identification has been hidden by moderators
+  identification_text_hidden: Identification text hidden
+  # Notice when the text content of an identification has been unhidden by moderators
+  identification_text_hidden: Identification text unhidden
   identification_updated: Identification updated!
   identification_user_short: Ident. user
   identification_withdrawn: Identification withdrawn.
@@ -4737,6 +4745,11 @@ en:
   summary: Summary
   supporting: Supporting
   suspend_user: Suspend user
+  suspend_user_html: Suspend %{user}
+  suspend_user_reason_instructions_html: |
+    Explain why this user should be suspended by citing the
+    %{link_start_tag}Community Guideline(s)%{link_end_tag} the user violated.
+    Please refrain from adding personal opinions.
   sw_lat: SW Lat.
   sw_lon: SW Lon.
   sync: Sync?
@@ -5159,6 +5172,9 @@ en:
   unsubscribe: Unsubscribe
   unsubscribe_from_emails_like_this: Unsubscribe from emails like this
   unsuspend_user: Unsuspend user
+  unsuspend_user_html: Unsuspend %{user}
+  unsuspend_user_reason_instructions: |
+    Please explain why this user should be unsuspended.
   upcoming_bioblitzes: Upcoming bioblitzes
   update: Update
   update_existing_observations_with_new_license: Update existing observations with new license choices
@@ -8361,6 +8377,10 @@ en:
       message:
         subject: Subject
         body: Body
+      moderator_action:
+        # The reason a moderator action was taken, e.g. an explanation for why
+        # someone thought a comment should be hidden
+        reason: Reason
       observation:
         description: Notes
         geo_x: Easting
@@ -8479,6 +8499,11 @@ en:
               guide_has_too_many_taxa: "guide can only have 500 taxa"
         moderator_action:
           attributes:
+            action:
+              not_supported_for_this_kind_of_content: is not supported for this kind of content
+            base:
+              only_staff_can_unhide: Only staff can unhide hidden content
+              staff_cannot_be_suspended: Staff cannot be suspended
             user_id:
               must_be_a_curator: must be a curator
         mushroom_observer_import_flow_task:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4747,9 +4747,9 @@ en:
   suspend_user: Suspend user
   suspend_user_html: Suspend %{user}
   suspend_user_reason_instructions_html: |
-    Explain why you are suspending this user by citing the
-    %{link_start_tag}Community Guideline(s)%{link_end_tag} that the user violated.
-    Please refrain from adding personal opinions.
+    Explain why you are suspending this account and cite any violations of the
+    %{link_start_tag}Community Guidelines%{link_end_tag}. Please refrain
+     from adding personal opinions.
   sw_lat: SW Lat.
   sw_lon: SW Lon.
   sync: Sync?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -311,46 +311,6 @@ describe UsersController, "remove_role" do
   end
 end
 
-describe UsersController, "suspend" do
-  let( :user ) { User.make! }
-  let( :curator_user ) { make_curator }
-  it "suspends the user" do
-    expect( user.suspended_at ).to be_nil
-    sign_in curator_user
-    get :suspend, params: { id: user.id }
-    user.reload
-    expect( user.suspended_at ).not_to be_nil
-  end
-
-  it "sets the suspending user" do
-    expect( user.suspended_at ).to be_nil
-    sign_in curator_user
-    get :suspend, params: { id: user.id }
-    user.reload
-    expect( user.suspended_by_user ).to eq curator_user
-  end
-end
-
-describe UsersController, "unsuspend" do
-  let( :user ) { User.make!( suspended_at: Time.now ) }
-  let( :curator_user ) { make_curator }
-  it "unsuspends the user" do
-    expect( user.suspended_at ).not_to be_nil
-    sign_in curator_user
-    get :unsuspend, params: { id: user.id }
-    user.reload
-    expect( user.suspended_at ).to be_nil
-  end
-
-  it "unsets the suspending user" do
-    expect( user.suspended_at ).not_to be_nil
-    sign_in curator_user
-    get :unsuspend, params: { id: user.id }
-    user.reload
-    expect( user.suspended_by_user ).to be_nil
-  end
-end
-
 describe UsersController, "show" do
   it "should with a login" do
     u = User.make!

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :comment do
     user
     body { Faker::Lorem.paragraph }
-    parent { build :observation }
+    parent { create :observation }
   end
 end

--- a/spec/factories/moderator_actions.rb
+++ b/spec/factories/moderator_actions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :moderator_action do
+    user
+    reason { Faker::Lorem.paragraph }
+    action { ModeratorAction::HIDE }
+    resource { build :comment }
+  end
+end

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -1,9 +1,70 @@
-require "spec_helper.rb"
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe ModeratorAction do
-  it { is_expected.to belong_to(:user).inverse_of :moderator_actions }
-  it { is_expected.to belong_to(:resource).inverse_of :moderator_actions }
+  it { is_expected.to belong_to( :user ).inverse_of :moderator_actions }
+  it { is_expected.to belong_to( :resource ).inverse_of :moderator_actions }
 
-  it { is_expected.to validate_inclusion_of(:action).in_array ModeratorAction::ACTIONS }
-  it { is_expected.to validate_length_of(:reason).is_at_least 10 }
+  it { is_expected.to validate_inclusion_of( :action ).in_array ModeratorAction::ACTIONS }
+  it { is_expected.to validate_length_of( :reason ).is_at_least 10 }
+
+  describe "create" do
+    describe "HIDE" do
+      it "should be possible for a comment" do
+        expect(
+          create( :moderator_action, action: ModeratorAction::HIDE, resource: create( :comment ) )
+        ).to be_persisted
+      end
+      it "should not be possible for a user" do
+        expect(
+          build( :moderator_action, action: ModeratorAction::HIDE, resource: create( :user ) )
+        ).not_to be_valid
+      end
+    end
+
+    describe "SUSPEND" do
+      it "should not be possible for a comment" do
+        expect(
+          build( :moderator_action, action: ModeratorAction::SUSPEND, resource: create( :comment ) )
+        ).not_to be_valid
+      end
+      it "should be possible for a user" do
+        expect(
+          create( :moderator_action, action: ModeratorAction::SUSPEND, resource: create( :user ) )
+        ).to be_persisted
+      end
+      it "should suspend a user" do
+        u = create :user
+        expect( u ).not_to be_suspended
+        create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        u.reload
+        expect( u ).to be_suspended
+      end
+      it "should not suspend staff" do
+        u = create :user, :as_admin
+        expect( u ).not_to be_suspended
+        expect( build( :moderator_action, action: ModeratorAction::SUSPEND, resource: u ) ).not_to be_valid
+        u.reload
+        expect( u ).not_to be_suspended
+      end
+      it "sets suspended_by_user" do
+        u = create :user
+        expect( u ).not_to be_suspended
+        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        u.reload
+        expect( u.suspended_by_user ).to eq ma.user
+      end
+    end
+    describe "UNSUSPEND" do
+      it "should unsuspend a user" do
+        u = create :user
+        u.suspend!
+        expect( u ).to be_suspended
+        create( :moderator_action, action: ModeratorAction::UNSUSPEND, resource: u )
+        u.reload
+        expect( u ).not_to be_suspended
+      end
+    end
+  end
 end


### PR DESCRIPTION
Alters account suspension so it happens via Moderator Actions. This means each suspension and unsuspension will be recorded, along with who performed the action and with an explanation for why they did it.

Closes #3050