### PR TITLE
Changes to assertion oauth flow error states

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Layout/SpaceAroundBlockParameters:
 Layout/SpaceInsideParens:
   EnforcedStyle: space
 
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -1,23 +1,35 @@
+# frozen_string_literal: true
+
 class ProviderOauthController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   layout "bootstrap"
 
-  def self.controller_path
-    "oauth"
-  end
+  class SuspendedError < StandardError; end
+
+  class ChildWithoutPermissionError < StandardError; end
+
+  class BadAssertionTypeError < StandardError; end
 
   # OAuth2 assertion flow: http://tools.ietf.org/html/draft-ietf-oauth-assertions-01#section-6.3
   # Accepts Facebook and Google access tokens and returns an iNat access token
   def assertion
     assertion_type = params[:assertion_type] || params[:grant_type]
-    client = Doorkeeper::Application.find_by_uid(params[:client_id])
-    if assertion_type.blank? || client.blank?
-      render :status => :unauthorized, :json => { :error => t( "doorkeeper.errors.messages.access_denied" ) }
-      return
+    client = Doorkeeper::Application.find_by_uid( params[:client_id] )
+    if client.blank?
+      return render status: :bad_request, json: {
+        error: "invalid_client",
+        error_description: t( "doorkeeper.errors.messages.access_denied" )
+      }
+    end
+    unless client.trusted?
+      return render status: :bad_request, json: {
+        error: "unauthorized_client",
+        error_description: t( "doorkeeper.errors.messages.access_denied" )
+      }
     end
     access_token = begin
-      Timeout::timeout( 10 ) do
+      Timeout.timeout( 10 ) do
         case assertion_type
         when /facebook/
           oauth_access_token_from_facebook_token( params[:client_id], params[:assertion] )
@@ -25,10 +37,32 @@ class ProviderOauthController < ApplicationController
           oauth_access_token_from_google_token( params[:client_id], params[:assertion] )
         when /apple/
           oauth_access_token_from_apple_assertion( params[:client_id], params[:assertion] )
+        else
+          raise BadAssertionTypeError
         end
       end
     rescue Timeout::Error
-      render status: :gateway_timeout, json: { error: t( "doorkeeper.errors.messages.temporarily_unavailable" ) }
+      # Not a part of the oauth spec: https://datatracker.ietf.org/doc/html/rfc6749
+      render status: :gateway_timeout, json: {
+        error: "timeout",
+        error_description: t( "doorkeeper.errors.messages.temporarily_unavailable" )
+      }
+      return
+    rescue BadAssertionTypeError
+      return render status: :bad_request, json: {
+        error: "unsupported_grant_type",
+        error_description: t( "doorkeeper.errors.messages.access_denied" )
+      }
+    rescue SuspendedError
+      return render status: :bad_request, json: {
+        error: "invalid_grant",
+        error_description: t( :this_user_has_been_suspended )
+      }
+    rescue ChildWithoutPermissionError
+      render status: :bad_request, json: {
+        error: "invalid_grant",
+        error_description: t( "please_ask_your_parents_for_permission" )
+      }
       return
     end
 
@@ -41,69 +75,75 @@ class ProviderOauthController < ApplicationController
       else
         uri = URI.parse( access_token.application.redirect_uri )
         uri.query = Rack::Utils.build_query(
-          :access_token => auth.token.token,
-          :token_type   => auth.token.token_type,
-          :expires_in   => auth.token.expires_in
+          access_token: auth.token.token,
+          token_type: auth.token.token_type,
+          expires_in: auth.token.expires_in
         )
         redirect_to uri.to_s
       end
     else
-      render :status => :unauthorized, :json => { :error => t( "doorkeeper.errors.messages.access_denied" ) }
+      render status: :bad_request, json: {
+        error: "invalid_grant",
+        error_description: t( "doorkeeper.errors.messages.access_denied" )
+      }
     end
   end
 
   private
-  def oauth_access_token_from_facebook_token(client_id, provider_token)
-    client = Doorkeeper::Application.find_by_uid(client_id)
+
+  def oauth_access_token_from_facebook_token( client_id, provider_token )
+    client = Doorkeeper::Application.find_by_uid( client_id )
     return nil unless client
-    user = if (pa = ProviderAuthorization.where(:provider_name => "facebook", :token => provider_token).first)
+
+    user = if ( pa = ProviderAuthorization.where( provider_name: "facebook", token: provider_token ).first )
       pa.user
     end
     user ||= begin
-      fb = Koala::Facebook::API.new(provider_token)
+      fb = Koala::Facebook::API.new( provider_token )
       r = fb.get_object( "me", fields: "id,email,name,first_name,last_name,about,link,website,location,verified" )
-      user = User.joins(:provider_authorizations).
-        where("provider_authorizations.provider_uid = ?", r['id']).
-        where("provider_authorizations.provider_name = 'facebook'").
+      user = User.joins( :provider_authorizations ).
+        where( "provider_authorizations.provider_uid = ?", r["id"] ).
+        where( "provider_authorizations.provider_name = 'facebook'" ).
         first
-      user ||= User.where("email = ?", r['email']).first
+      user ||= User.where( "email = ?", r["email"] ).first
       if user.blank?
-        uid = r['id']
+        uid = r["id"]
         auth_info = {
-          'provider' => 'facebook',
-          'uid' => uid,
-          'info' => {
-            'email' => r['email'],
-            'name' => r['name'],
-            'first_name' => r['first_name'],
-            'last_name' => r['last_name'],
-            'image' => "http://graph.facebook.com/#{uid}/picture?type=square",
-            'description' => r['about'],
-            'urls' => {
-              'Facebook' => r['link'],
-              'Website' => r['website']
+          "provider" => "facebook",
+          "uid" => uid,
+          "info" => {
+            "email" => r["email"],
+            "name" => r["name"],
+            "first_name" => r["first_name"],
+            "last_name" => r["last_name"],
+            "image" => "http://graph.facebook.com/#{uid}/picture?type=square",
+            "description" => r["about"],
+            "urls" => {
+              "Facebook" => r["link"],
+              "Website" => r["website"]
             },
-            'location' => (r['location'] || {})['name'],
-            'verified' => r['verified']
+            "location" => ( r["location"] || {} )["name"],
+            "verified" => r["verified"]
           },
-          'credentials' => {
-            'token' => provider_token
+          "credentials" => {
+            "token" => provider_token
           }
         }
-        user = User.create_from_omniauth(auth_info)
+        user = User.create_from_omniauth( auth_info )
       end
       user
     rescue Koala::Facebook::AuthenticationError => e
       Rails.logger.debug "[DEBUG] Failed to get fb user info from token: #{e}"
       nil
     end
-    return nil unless user
+    return nil unless user&.persisted?
+
     assertion_access_token_for_client_and_user( client, user )
   end
 
-  def oauth_access_token_from_google_token(client_id, provider_token)
-    client = Doorkeeper::Application.find_by_uid(client_id)
-    user = if (pa = ProviderAuthorization.where(:provider_name => "google_oauth2", :token => provider_token).first)
+  def oauth_access_token_from_google_token( client_id, provider_token )
+    client = Doorkeeper::Application.find_by_uid( client_id )
+    user = if ( pa = ProviderAuthorization.where( provider_name: "google_oauth2", token: provider_token ).first )
       pa.user
     end
     user ||= begin
@@ -111,32 +151,32 @@ class ProviderOauthController < ApplicationController
         Authorization: "Bearer #{provider_token}",
         "User-Agent" => "iNaturalist/Google"
       } )
-      json = JSON.parse(r.body)
-      unless uid = json['id']
+      json = JSON.parse( r.body )
+      unless ( uid = json["id"] )
         Rails.logger.debug "[DEBUG] Google auth failed: #{json.inspect}"
         return nil
       end
-      user = User.joins(:provider_authorizations).
-        where("provider_authorizations.provider_uid = ?", uid).
-        where("provider_authorizations.provider_name = 'google_oauth2'").
+      user = User.joins( :provider_authorizations ).
+        where( "provider_authorizations.provider_uid = ?", uid ).
+        where( "provider_authorizations.provider_name = 'google_oauth2'" ).
         first
       if user.blank?
         auth_info = {
-          'provider' => 'google_oauth2',
-          'uid' => uid,
-          'info' => {
-            'email' => json['email'],
-            'name' => json['name'],
-            'first_name' => json['given_name'],
-            'last_name' => json['family_name'],
-            'image' => json['picture'],
-            'urls' => {
-              'Google Plus' => json['link']
+          "provider" => "google_oauth2",
+          "uid" => uid,
+          "info" => {
+            "email" => json["email"],
+            "name" => json["name"],
+            "first_name" => json["given_name"],
+            "last_name" => json["family_name"],
+            "image" => json["picture"],
+            "urls" => {
+              "Google Plus" => json["link"]
             },
-            'verified' => json['verified_email']
+            "verified" => json["verified_email"]
           },
-          'credentials' => {
-            'token' => provider_token
+          "credentials" => {
+            "token" => provider_token
           }
         }
         user = User.create_from_omniauth( auth_info )
@@ -146,8 +186,8 @@ class ProviderOauthController < ApplicationController
       Rails.logger.debug "[DEBUG] Failed to make a Google API call: #{e}"
       nil
     end
+    return nil unless user&.persisted?
 
-    return nil unless user && user.persisted?
     assertion_access_token_for_client_and_user( client, user )
   end
 
@@ -201,7 +241,7 @@ class ProviderOauthController < ApplicationController
       iss: "https://appleid.apple.com",
       verify_iat: true,
       verify_aud: true,
-      aud: [iphone_app_id], #.concat(options.authorized_client_ids),
+      aud: [iphone_app_id], # .concat(options.authorized_client_ids),
       algorithms: ["RS256"],
       jwks: jwks
     } )
@@ -209,8 +249,11 @@ class ProviderOauthController < ApplicationController
     issuer_is_apple = id_token_conents["iss"] == "https://appleid.apple.com"
     audience_is_inat = id_token_conents["aud"] == iphone_app_id
     token_is_current = Time.now < Time.at( id_token_conents["exp"] )
-    if !( issuer_is_apple && audience_is_inat && token_is_current )
-      error_message = "Invalid identity token. iss: #{id_token_conents["iss"]}, aud: #{id_token_conents["aud"]}, exp: #{id_token_conents["exp"]} "
+    unless issuer_is_apple && audience_is_inat && token_is_current
+      error_message = <<~MSG
+        Invalid identity token. iss: #{id_token_conents['iss']},
+        aud: #{id_token_conents['aud']}, exp: #{id_token_conents['exp']}
+      MSG
       Rails.logger.error = error_message
       LogStasher.write_hash(
         error_message: error_message,
@@ -248,8 +291,9 @@ class ProviderOauthController < ApplicationController
       }
       user = User.create_from_omniauth( auth_info )
     end
-    return nil unless user && user.persisted?
-    if access_token = assertion_access_token_for_client_and_user( client, user )
+    return nil unless user&.persisted?
+
+    if ( access_token = assertion_access_token_for_client_and_user( client, user ) )
       # We could get into a situation where the token was created but no
       # ProviderAuthorization records was created if an existing user was found
       # via email and User.create_from_omniauth wasn't called, so we make
@@ -258,7 +302,7 @@ class ProviderOauthController < ApplicationController
         provider_name: "apple",
         provider_uid: provider_uid
       ).first
-      if !existing_pa
+      unless existing_pa
         ProviderAuthorization.create!(
           provider_name: "apple",
           provider_uid: provider_uid,
@@ -270,6 +314,10 @@ class ProviderOauthController < ApplicationController
   end
 
   def assertion_access_token_for_client_and_user( client, user )
+    unless user.active_for_authentication?
+      raise SuspendedError if user.suspended?
+      raise ChildWithoutPermissionError if user.child_without_permission?
+    end
     access_token = Doorkeeper::AccessToken.
       where( application_id: client.id, resource_owner_id: user.id, revoked_at: nil ).
       order( "created_at desc" ).
@@ -292,7 +340,7 @@ class ProviderOauthController < ApplicationController
   end
 
   def scopes_from_params( params, client )
-    allowed_scopes = client.scopes.try(:to_a) || []
+    allowed_scopes = client.scopes.try( :to_a ) || []
     requested_scopes = params[:scope].to_s.split( /\s/ ).compact.uniq
     scopes = allowed_scopes & requested_scopes
     scopes = Doorkeeper.configuration.default_scopes.to_a if scopes.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -386,12 +386,22 @@ class User < ApplicationRecord
     !suspended?
   end
 
+  def child_without_permission?
+    !birthday.blank? &&
+      birthday > 13.years.ago &&
+      UserParent.where( "user_id = ? AND donorbox_donor_id IS NULL", id ).exists?
+  end
+
   # This is a dangerous override in that it doesn't call super, thereby
   # ignoring the results of all the devise modules like confirmable. We do
   # this b/c we want all users to be able to sign in, even if unconfirmed, but
   # not if suspended.
   def active_for_authentication?
-    active? && ( birthday.blank? || birthday < 13.years.ago || !UserParent.where( "user_id = ? AND donorbox_donor_id IS NULL", id ).exists? )
+    return false if suspended?
+
+    return false if child_without_permission?
+
+    super
   end
 
   def download_remote_icon

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -401,7 +401,7 @@ class User < ApplicationRecord
 
     return false if child_without_permission?
 
-    super
+    true
   end
 
   def download_remote_icon

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3910,6 +3910,8 @@ en:
   please_add_a_citation_for_this_change: Please add a citation for this change.
   please_allow_a_few_weeks_for_external_sites:
     Please allow a few weeks for external sites to sync changes from this observation
+  # Request that a known child ask their parents for permission to use this service
+  please_ask_your_parents_for_permission: Please ask your parents for permission
   # Title to a section warning a user to exercise caution
   please_be_careful!: Please Be Careful!
   please_complete_the_following_to_add_project: |

--- a/lib/privileges.rb
+++ b/lib/privileges.rb
@@ -32,7 +32,7 @@ module Privileges
     end
     def earns_privilege( privilege, options = { on: [:create, :destroy]} )
       return if self.included_modules.include?( Privileges::InstanceMethods )
-      include HasSubscribers::InstanceMethods
+      include Privileges::InstanceMethods
 
       options[:on].each do |phase|
         send( "after_#{phase}", lambda {

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "#{File.dirname( __FILE__ )}/../spec_helper"
+
+describe ProviderOauthController do
+  describe "from google" do
+    let( :client ) { create :oauth_application, trusted: true }
+    let( :assertion_params ) do
+      {
+        assertion_type: "google",
+        client_id: client.uid,
+        assertion: "foo"
+      }
+    end
+
+    before do
+      stub_request( :get, "https://www.googleapis.com/userinfo/v2/me" ).to_return(
+        status: 200,
+        body: google_response.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+    end
+
+    describe "with an email address" do
+      let( :google_response ) do
+        {
+          id: Faker::Number.number.to_s,
+          email: Faker::Internet.email
+        }
+      end
+
+      it "should create a user" do
+        expect( User.find_by_email( google_response[:email] ) ).to be_blank
+        post :assertion, format: :json, params: assertion_params
+        expect( User.find_by_email( google_response[:email] ) ).not_to be_blank
+      end
+
+      it "should return a token for a confirmed user" do
+        u = create :user, email: google_response[:email], confirmed_at: Time.now
+        expect( u ).to be_confirmed
+        post :assertion, format: :json, params: assertion_params
+        expect( response ).to be_successful
+        expect( JSON.parse( response.body )["access_token"] ).not_to be_blank
+      end
+
+      it "should return a token for an unconfirmed user who never received a confirmation email" do
+        u = create :user, email: google_response[:email], confirmed_at: nil
+        User.where( id: u.id ).update_all( confirmation_sent_at: nil )
+        u.reload
+        expect( u ).not_to be_confirmed
+        expect( u.confirmation_sent_at ).to be_blank
+        post :assertion, format: :json, params: assertion_params
+        expect( response ).to be_successful
+        expect( JSON.parse( response.body )["access_token"] ).not_to be_blank
+      end
+
+      it "should not return a token for a confirmed suspended user" do
+        u = create :user, email: google_response[:email], confirmed_at: Time.now
+        u.suspend!
+        expect( u ).to be_confirmed
+        expect( u ).to be_suspended
+        post :assertion, format: :json, params: assertion_params
+        expect( response ).not_to be_successful
+        response_json = JSON.parse( response.body )
+        expect( response_json["access_token"] ).to be_blank
+        expect( response_json["error"] ).to eq "invalid_grant"
+        expect( response_json["error_description"] ).not_to be_blank
+      end
+
+      it "should not return a token for a confirmed child without permission" do
+        u = create :user, email: google_response[:email], confirmed_at: Time.now, birthday: 5.years.ago.to_date
+        up = create( :user_parent, user: u )
+        u.reload
+        expect( up ).not_to be_donor
+        expect( u.birthday ).to be > 13.years.ago
+        expect( u ).to be_confirmed
+        expect( u ).to be_child_without_permission
+        post :assertion, format: :json, params: assertion_params
+        expect( response ).not_to be_successful
+        response_json = JSON.parse( response.body )
+        expect( response_json["access_token"] ).to be_blank
+        expect( response_json["error"] ).to eq "invalid_grant"
+        expect( response_json["error_description"] ).not_to be_blank
+      end
+
+      describe "with a bad assertion_type" do
+        let( :assertion_params ) do
+          {
+            assertion_type: "fragglerock",
+            client_id: client.uid,
+            assertion: "foo"
+          }
+        end
+        it "should return unsupported_grant_type error" do
+          post :assertion, format: :json, params: assertion_params
+          expect( response ).not_to be_successful
+          response_json = JSON.parse( response.body )
+          expect( response_json["error"] ).to eq "unsupported_grant_type"
+        end
+      end
+      describe "with a bad client_id" do
+        let( :assertion_params ) do
+          {
+            assertion_type: "google",
+            client_id: "#{client.uid}sdgsdg",
+            assertion: "foo"
+          }
+        end
+        it "should return invalid_client error" do
+          post :assertion, format: :json, params: assertion_params
+          expect( response ).not_to be_successful
+          response_json = JSON.parse( response.body )
+          expect( response_json["error"] ).to eq "invalid_client"
+        end
+      end
+      describe "with an untrusted client" do
+        let( :client ) { create :oauth_application, trusted: false }
+        it "should return unauthorized_client error" do
+          post :assertion, format: :json, params: assertion_params
+          expect( response ).not_to be_successful
+          response_json = JSON.parse( response.body )
+          expect( response_json["error"] ).to eq "unauthorized_client"
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -91,6 +91,22 @@ describe ProviderOauthController do
             assertion: "foo"
           }
         end
+        # As the OAuth spec says
+        it "should return 400" do
+          post :assertion, format: :json, params: assertion_params
+          expect( response.status ).to eq 400
+        end
+        it "should return a localized error_description" do
+          locale = "es"
+          post :assertion, format: :json, params: assertion_params.merge( locale: locale )
+          response_json = JSON.parse( response.body )
+          expect(
+            response_json["error_description"]
+          ).to eq I18n.t( "doorkeeper.errors.messages.access_denied", locale: locale )
+          expect(
+            response_json["error_description"]
+          ).not_to eq I18n.t( "doorkeeper.errors.messages.access_denied", locale: "en" )
+        end
         it "should return unsupported_grant_type error" do
           post :assertion, format: :json, params: assertion_params
           expect( response ).not_to be_successful

--- a/spec/factories/oauth_applications.rb
+++ b/spec/factories/oauth_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :oauth_application do
+    name { Faker::Name.name }
+    redirect_uri { Faker::Internet.url }
+    owner { build :user }
+  end
+end

--- a/spec/factories/user_parents.rb
+++ b/spec/factories/user_parents.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_parent do
+    user { build :user, birthday: 5.years.ago.to_date.to_s }
+    parent_user { build :user }
+    name { Faker::Name.name }
+    child_name { Faker::Name.name }
+    email { Faker::Internet.email }
+
+    trait :as_donor do
+      donorbox_donor_id { Faker::Number.number }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,22 +1,30 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
-    sequence(:login) { |n| "user#{n}" }
+    sequence( :login ) {| n | "user#{n}" }
     email { Faker::Internet.email }
     name { Faker::Name.name }
     password { "monkey" }
-    created_at { 5.days.ago.to_s(:db) }
+    created_at { 5.days.ago.to_s( :db ) }
     state { "active" }
     time_zone { "Pacific Time (US & Canada)" }
+    confirmed_at { 4.days.ago.to_s( :db ) }
+    confirmation_token { Faker::Alphanumeric.alphanumeric }
 
     factory :admin do
-      roles { [association(:role, name: 'admin')] }
+      roles { [association( :role, name: "admin" )] }
     end
 
     factory :curator do
-      roles { [association(:role, name: 'curator')] }
+      roles { [association( :role, name: "curator" )] }
     end
   end
 
-  trait(:as_admin) { roles { [association(:role, name: 'admin')] } }
-  trait(:as_curator) { roles { [association(:role, name: 'curator')] } }
+  trait( :as_admin ) { roles { [association( :role, name: "admin" )] } }
+  trait( :as_curator ) { roles { [association( :role, name: "curator" )] } }
+  trait( :as_unconfirmed ) do
+    confirmed_at { nil }
+    confirmation_token { nil }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,22 +101,12 @@ describe User do
   end
 
   describe "creation" do
-    before do
-      @user = nil
-      @creating_user = lambda do
-        @user = create_user
-        puts "[ERROR] #{@user.errors.full_messages.to_sentence}" if @user.new_record?
-      end
+    it "increments User#count" do
+      expect { create( :user ) }.to change( User, :count ).by( 1 )
     end
 
-    it 'increments User#count' do
-      expect(@creating_user).to change(User, :count).by(1)
-    end
-
-    it 'initializes confirmation_token' do
-      @creating_user.call
-      @user.reload
-      expect(@user.confirmation_token).not_to be_blank
+    it "initializes confirmation_token" do
+      expect( create( :user, :as_unconfirmed ).confirmation_token ).not_to be_blank
     end
 
     it "should require email under normal circumstances" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,10 +93,17 @@ RSpec.configure do | config |
       end
       # ensure spatial_ref_sys has a vanilla WGS84 "projection"
       begin
-        ActiveRecord::Base.connection.execute( <<-SQL
-          INSERT INTO spatial_ref_sys VALUES (4326,'EPSG',4326,'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]', '+proj=longlat +datum=WGS84 +no_defs')
-        SQL
-                                             )
+        ActiveRecord::Base.connection.execute(
+          <<~SQL
+            INSERT INTO spatial_ref_sys
+            VALUES (
+              4326,
+              'EPSG',
+              4326,
+              'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]', '+proj=longlat +datum=WGS84 +no_defs'
+            )
+          SQL
+        )
       rescue PG::Error, ActiveRecord::RecordNotUnique => e
         raise e unless e.message =~ /duplicate key/
       end


### PR DESCRIPTION
Pulled in a few changes to oauth assertion flow error states from the email confirmation branch so mobile developers can build against them in production. These get our responses to the assertion auth flow in line with the oauth spec, namely that we reply with 400 responses that contain JSON in a standardized format. In theory the iPhone app will handle them, but Android will have to make [some changes](https://github.com/inaturalist/iNaturalistAndroid/issues/1188), and maybe Seek.