### PR TITLE
Small performance improvements

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js
+++ b/app/assets/javascripts/ang/controllers/observation_search.js
@@ -608,8 +608,10 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
         return;
       }
       $scope.observations = ObservationsFactory.responseToInstances( response );
-      ObservationsFactory.speciesCounts( { ...statsParams, per_page: $scope.speciesPagination.perPage } )
-        .then( function( response ) {
+      var speciesParams = _.extend( { }, statsParams, {
+        per_page: $scope.speciesPagination.perPage
+      } );
+      ObservationsFactory.speciesCounts( speciesParams ).then( function( response ) {
         if( $scope.lastSearchTime != thisSearchTime ) { return; }
         $scope.totalSpecies = response.data.total_results;
         $scope.taxa = _.map( response.data.results, function( r ) {
@@ -618,7 +620,7 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
           return t;
         });
         $scope.speciesPagination.searching = false;
-      });
+      } );
       ObservationsFactory.identifiers( statsParams ).then( function( response ) {
         if( $scope.lastSearchTime != thisSearchTime ) { return; }
         $scope.totalIdentifiers = response.data.total_results;

--- a/app/assets/javascripts/ang/inaturalist_angular.js
+++ b/app/assets/javascripts/ang/inaturalist_angular.js
@@ -9,7 +9,7 @@ function( $http, $rootScope, $filter ) {
     if( options.cache !== true ) { options.cache = false; }
     var config = {
       cache: options.cache,
-      timeout: 20000 // 20 second timeout
+      timeout: 60000 // 60 second timeout
     };
     var apiURL = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
     if ( apiURL && url.indexOf( apiURL ) >= 0 ) {

--- a/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
@@ -1,6 +1,6 @@
-#taxa-grid.container.bootstrap-10{ "infinite-scroll": "showMoreTaxa( )", "infinite-scroll-disabled": "!viewing('species')", "infinite-scroll-distance": 1 }
+#taxa-grid.container.bootstrap-10{ "infinite-scroll": "showMoreTaxa( )", "infinite-scroll-disabled": "!viewing('species') || speciesPagination.searching || speciesPagination.stopped", "infinite-scroll-distance": 1 }
   .row.grid
-    .col-xs-2.cell{ "ng-repeat": "t in taxa | limitTo: numberTaxaShown" }
+    .col-xs-2.cell{ "ng-repeat": "t in taxa" }
       .thumbnail.borderless
         %a{ :class => "photo {{ t.photo( ) ? '' : 'iconic'}}", href: "/taxa/{{ t.id }}", "ng-style": "shared.backgroundIf( t.photo( ) )", target: "_self" }
           %i{ :class => "icon icon-iconic-{{ t.iconicTaxonName( ) | lowercase }}" }
@@ -16,7 +16,7 @@
               {{ t.photoLicenseShort( ) }}
         .caption
           %inat-taxon.title.split-taxon{ taxon: "t", url: "/taxa/{{ t.id }}" }
-  .spinner.ng-cloak{ "ng-show": "pagination.searching" }
+  .spinner.ng-cloak{ "ng-show": "speciesPagination.searching" }
     %span.fa.fa-spin.fa-refresh
   .noresults.text-muted.ng-cloak{ "ng-show": "noTaxa( )" }
     {{ shared.t( 'no_results_found' ) }}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -224,32 +224,7 @@ class ApplicationController < ActionController::Base
     @footless = true
     @no_footer_gap = true
     @responsive = true
-    es_query = {
-      has: ["photos"],
-      per_page: 100,
-      order_by: "votes",
-      order: "desc",
-      place_id: @site.try(:place_id).blank? ? nil : @site.place_id,
-      projects: ["log-in-photos"]
-    }
-    @observations = Observation.includes( :photos ).elastic_query( es_query ).to_a
-    if @observations.blank?
-      es_query.delete(:projects)
-      @observations = Observation.includes( :photos ).elastic_query( es_query ).to_a
-    end
-    if @observations.blank?
-      es_query.delete(:place_id)
-      @observations = Observation.includes( :photos ).elastic_query( es_query ).to_a
-    end
-    if es_query[:projects].blank?
-      ratio = params[:ratio].to_f
-      ratio = 1 if ratio <= 0
-      @observations = @observations.select do |o|
-        photo = o.observation_photos.sort_by{ |op| op.position || op.id }.first.photo
-        r = photo.original_dimensions[:width].to_f / photo.original_dimensions[:height].to_f
-        r < ratio
-      end
-    end
+    @observations = @site.login_featured_observations
   end
 
   def get_flickraw

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -147,7 +147,7 @@ class TaxaController < ApplicationController
   def show
     if params[:id]
       begin
-        @taxon ||= Taxon.where(id: params[:id]).includes(:taxon_names).first
+        @taxon ||= Taxon.where(id: params[:id]).includes({ taxon_names: :place_taxon_names }).first
       rescue RangeError => e
         Logstasher.write_exception(e, request: request, session: session, user: current_user)
         nil

--- a/app/controllers/taxon_names_controller.rb
+++ b/app/controllers/taxon_names_controller.rb
@@ -17,7 +17,7 @@ class TaxonNamesController < ApplicationController
     per_page = params[:per_page].to_i
     per_page = 30 if per_page <= 0
     per_page = 200 if per_page > 200
-    @taxon_names = TaxonName.page( params[:page] ).per_page( per_page )
+    @taxon_names = TaxonName.page( params[:page] ).per_page( per_page ).includes( :place_taxon_names )
 
     if params[:q]
       @taxon_names = @taxon_names.where( "name LIKE ?", "%#{params[:q].split.join( '%' )}%" )

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -32,6 +32,8 @@ class VotesController < ApplicationController
 
   def unvote
     @record.unvote voter: current_user, vote: params[:vote], vote_scope: params[:scope]
+    # ActsAsVotable uses delete_all, which bypasses after_destroy :run_votable_callback
+    @record.votable_callback if @record.respond_to?( :votable_callback )
     respond_to do |format|
       format.html do
         redirect_to @record

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -399,17 +399,21 @@ class Observation < ApplicationRecord
       o.taxon_native ||= false
       o.taxon_endemic ||= false
     }
-    observations_by_id = Hash[ observations.map{ |o| [ o.id, o ] } ]
-    batch_ids_string = observations_by_id.keys.join(",")
+    batch_ids_string = observations.map(&:id).join(",")
     return if batch_ids_string.blank?
     # fetch all place_ids store them in `indexed_place_ids`
     if options.blank? || options[:places]
+      observation_private_place_ids = { }
       connection.execute("
         SELECT observation_id, place_id
         FROM observations_places
         WHERE observation_id IN (#{ batch_ids_string })").to_a.each do |r|
-        if o = observations_by_id[ r["observation_id"].to_i ]
-          o.indexed_private_place_ids << r["place_id"].to_i
+        observation_private_place_ids[r["observation_id"]] ||= []
+        observation_private_place_ids[r["observation_id"]] << r["place_id"]
+      end
+      observations.each do |o|
+        if observation_private_place_ids[o.id]
+          o.indexed_private_place_ids = observation_private_place_ids[o.id]
         end
       end
       private_place_ids = observations.map(&:indexed_private_place_ids).flatten.uniq.compact
@@ -444,14 +448,14 @@ class Observation < ApplicationRecord
       uniq_obs_place_ids = observations.map{ |o|o.indexed_private_places.map(&:path_ids) }.flatten.compact.uniq.join(',')
       return if uniq_obs_place_ids.empty? || taxon_ids.empty?
       Observation.connection.execute("
-        SELECT taxon_id, establishment_means, string_agg(place_id::text,',') as place_ids
+        SELECT taxon_id, establishment_means, place_id
         FROM listed_taxa
         WHERE taxon_id IN (#{ taxon_ids.join(',') })
         AND place_id IN (#{ uniq_obs_place_ids })
-        AND establishment_means IS NOT NULL
-        GROUP BY taxon_id, establishment_means").to_a.each do |r|
-        taxon_establishment_places[r["taxon_id"].to_s] ||= {}
-        taxon_establishment_places[r["taxon_id"].to_s][r["establishment_means"]] = r["place_ids"].split( "," )
+        AND establishment_means IS NOT NULL").to_a.each do |r|
+        taxon_establishment_places[r["taxon_id"]] ||= {}
+        taxon_establishment_places[r["taxon_id"]][r["establishment_means"]] ||= []
+        taxon_establishment_places[r["taxon_id"]][r["establishment_means"]] << r["place_id"]
       end
       place_ids = taxon_establishment_places.values.map(&:values).flatten.uniq.map(&:to_i)
       return if place_ids.empty?
@@ -459,8 +463,8 @@ class Observation < ApplicationRecord
       Place.connection.execute("
         SELECT id, bbox_area
         FROM places WHERE id IN (#{ place_ids.join(',') })").to_a.each do |r|
-        places[r["id"].to_s] = {
-          id: r["id"].to_i,
+        places[r["id"]] = {
+          id: r["id"],
           bbox_area: r["bbox_area"].to_f
         }
       end
@@ -482,15 +486,15 @@ class Observation < ApplicationRecord
         end
       end
       observations.each do |o|
-        if o.taxon && taxon_places[o.taxon.id.to_s]
-          closest = taxon_places[o.taxon.id.to_s].
-            slice(*o.indexed_private_places.map(&:path_ids).flatten.compact.uniq.map(&:to_s)).
+        if o.taxon && taxon_places[o.taxon.id]
+          closest = taxon_places[o.taxon.id].
+            slice(*o.indexed_private_places.map(&:path_ids).flatten.compact.uniq).
             values.sort_by{ |p| p[:bbox_area] || 0 }.first
           o.taxon_introduced = !!(closest &&
             closest.values_at(*ListedTaxon::INTRODUCED_EQUIVALENTS).compact.any?)
           o.taxon_native = !!(closest &&
             closest.values_at(*ListedTaxon::NATIVE_EQUIVALENTS).compact.any?)
-          o.taxon_endemic = (o.indexed_private_place_ids & taxon_endemic_place_ids[o.taxon.id.to_s]).any?
+          o.taxon_endemic = (o.indexed_private_place_ids & taxon_endemic_place_ids[o.taxon.id]).any?
         end
       end
     end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2573,7 +2573,11 @@ class Observation < ApplicationRecord
         29625, # City Nature Challenge 2019
         40364  # City Nature Challenge 2020
       ].map {|umbrella_project_id|
-        if umbrella = Project.find_by_id( umbrella_project_id )
+        if umbrella = Project.includes( {
+          project_observation_rules: {
+            operand: :project_observation_rules
+          }
+        } ).find_by_id( umbrella_project_id )
           umbrella.project_observation_rules.select{|por| por.operator == "in_project?"}.map {|por|
             por.operand.project_observation_rules.
               select{|sub_por| sub_por.operator == "observed_in_place?" }.

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -542,12 +542,8 @@ class Site < ApplicationRecord
         taxon: :taxon_names,
       }] )
       if es_query[:projects].blank?
-        ratio = params[:ratio].to_f
-        ratio = 1 if ratio <= 0
         observations = observations.select do |o|
           photo = o.observation_photos.sort_by{ |op| op.position || op.id }.first.photo
-          r = photo.original_dimensions[:width].to_f / photo.original_dimensions[:height].to_f
-          r < ratio
         end
       end
       observations

--- a/app/webpack/projects/show/components/species_tab.jsx
+++ b/app/webpack/projects/show/components/species_tab.jsx
@@ -2,10 +2,15 @@ import _ from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { Grid, Row, Col } from "react-bootstrap";
-import TaxonThumbnail from "../../../taxa/show/components/taxon_thumbnail";
 import InfiniteScroll from "react-infinite-scroller";
+import TaxonThumbnail from "../../../taxa/show/components/taxon_thumbnail";
 
-const SpeciesTab = ( { project, config, species, setConfig } ) => {
+const SpeciesTab = function ( {
+  project,
+  config,
+  species,
+  infiniteScrollSpecies
+} ) {
   if ( _.isEmpty( species ) ) { return ( <span /> ); }
   const loader = <div key="species-tab-loading-spinner" className="loading_spinner huge" />;
   const scrollIndex = config.speciesScrollIndex || 30;
@@ -13,24 +18,26 @@ const SpeciesTab = ( { project, config, species, setConfig } ) => {
     <div className="TopSpecies">
       <Grid>
         <Row>
-          <Col xs={ 12 }>
+          <Col xs={12}>
             <InfiniteScroll
-              loadMore={ ( ) => { setConfig( { speciesScrollIndex: scrollIndex + 30 } ); } }
-              hasMore={ species.length >= scrollIndex }
-              loader={ loader }
+              loadMore={( ) => {
+                infiniteScrollSpecies( scrollIndex + 30 );
+              }}
+              hasMore={species.length >= scrollIndex}
+              loader={loader}
               className="results"
             >
               { _.map( species.slice( 0, scrollIndex ), s => (
-                <div className="result" key={ `grid_taxon_${s.taxon.id}` }>
+                <div className="result" key={`grid_taxon_${s.taxon.id}`}>
                   <TaxonThumbnail
-                    taxon={ s.taxon }
-                    config={ config }
-                    truncate={ null }
-                    height={ 210 }
+                    taxon={s.taxon}
+                    config={config}
+                    truncate={null}
+                    height={210}
                     noInactive
-                    overlay={ (
+                    overlay={(
                       <div>
-                        <a href={ `/observations?project_id=${project.id}&taxon_id=${s.taxon.id}&place_id=any&verifiable=any` }>
+                        <a href={`/observations?project_id=${project.id}&taxon_id=${s.taxon.id}&place_id=any&verifiable=any`}>
                           { I18n.t( "x_observations", { count: s.count } ) }
                         </a>
                       </div>
@@ -49,7 +56,7 @@ const SpeciesTab = ( { project, config, species, setConfig } ) => {
 SpeciesTab.propTypes = {
   project: PropTypes.object,
   config: PropTypes.object,
-  setConfig: PropTypes.func,
+  infiniteScrollSpecies: PropTypes.func,
   species: PropTypes.array
 };
 

--- a/app/webpack/projects/show/containers/species_tab_container.js
+++ b/app/webpack/projects/show/containers/species_tab_container.js
@@ -1,19 +1,22 @@
 import { connect } from "react-redux";
 import SpeciesTab from "../components/species_tab";
 import { setConfig } from "../../../shared/ducks/config";
+import { infiniteScrollSpecies } from "../ducks/project";
 
 function mapStateToProps( state ) {
   return {
     config: state.config,
     project: state.project,
-    species: state.project && state.project.species_loaded ?
-      state.project.species.results : null
+    species: state.project && state.project.species_loaded
+      ? state.project.species.results : null
   };
 }
 
 function mapDispatchToProps( dispatch ) {
   return {
-    setConfig: attributes => { dispatch( setConfig( attributes ) ); }
+    setConfig: attributes => { dispatch( setConfig( attributes ) ); },
+    infiniteScrollSpecies: nextScrollIndex => dispatch(
+      infiniteScrollSpecies( nextScrollIndex ) )
   };
 }
 

--- a/app/webpack/projects/show/ducks/project.js
+++ b/app/webpack/projects/show/ducks/project.js
@@ -154,7 +154,7 @@ export function infiniteScrollObservations( nextScrollIndex ) {
   return ( dispatch, getState ) => {
     const { project, config } = getState( );
     if ( !project || !project.filtered_observations_loaded ) { return null; }
-    const total = project.filtered_observations_loaded.total_results;
+    const total = project.filtered_observations.total_results;
     const loaded = project.filtered_observations.results.length;
     if ( nextScrollIndex > total || nextScrollIndex <= loaded || nextScrollIndex > 500 ) {
       dispatch( setConfig( { observationsScrollIndex: nextScrollIndex } ) );
@@ -179,14 +179,44 @@ export function infiniteScrollObservations( nextScrollIndex ) {
   };
 }
 
+export function infiniteScrollSpecies( nextScrollIndex ) {
+  return ( dispatch, getState ) => {
+    const { project, config } = getState( );
+    if ( !project || !project.species_loaded ) { return null; }
+    const total = project.species.total_results;
+    const loaded = project.species.results.length;
+    if ( nextScrollIndex > total || nextScrollIndex <= loaded || nextScrollIndex > 500 ) {
+      dispatch( setConfig( { speciesScrollIndex: nextScrollIndex } ) );
+      return null;
+    }
+    let params = Object.assign( { }, project.search_params, {
+      per_page: 50,
+      page: project.species_page + 1
+    } );
+    return inatjs.observations.speciesCounts( params ).then( response => {
+      project.species.results = project
+        .species.results.concat( response.results );
+      dispatch( setAttributes( {
+        species: project.species,
+        species_page: project.species_page + 1
+      } ) );
+      dispatch( setConfig( { speciesScrollIndex: nextScrollIndex } ) );
+    } ).catch( e => console.log( e ) );
+  };
+}
+
 export function fetchSpecies( ) {
   return ( dispatch, getState ) => {
     const { project } = getState( );
     if ( !project ) { return null; }
-    return inatjs.observations.speciesCounts( project.search_params ).then( response => {
+    let params = Object.assign( { }, project.search_params, {
+      per_page: 50
+    } );
+    return inatjs.observations.speciesCounts( params ).then( response => {
       dispatch( setAttributes( {
         species_loaded: true,
-        species: response
+        species: response,
+        species_page: 1
       } ) );
     } ).catch( e => console.log( e ) );
   };

--- a/app/webpack/taxa/show/ducks/leaders.js
+++ b/app/webpack/taxa/show/ducks/leaders.js
@@ -42,16 +42,19 @@ export function setLeader( key, leader ) {
 
 export function fetchTopObserver( ) {
   return function ( dispatch, getState ) {
-    return inatjs.observations.observers( defaultObservationParams( getState( ) ) )
+    const params = { ...defaultObservationParams( getState( ) ), per_page: 1 };
+    return inatjs.observations.observers( params )
       .then( response => dispatch( setLeader( "topObserver", response.results[0] ) ) );
   };
 }
 
 export function fetchTopIdentifier( ) {
   return function ( dispatch, getState ) {
-    const params = Object.assign( { }, defaultObservationParams( getState( ) ), {
-      own_observation: false
-    } );
+    const params = {
+      ...defaultObservationParams( getState( ) ),
+      own_observation: false,
+      per_page: 1
+    };
     return inatjs.identifications.identifiers( params )
       .then( response => dispatch( setLeader( "topIdentifier", response.results[0] ) ) );
   };

--- a/db/migrate/20220317205240_add_unique_index_on_uuid_to_annotations.rb
+++ b/db/migrate/20220317205240_add_unique_index_on_uuid_to_annotations.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnUuidToAnnotations < ActiveRecord::Migration[6.1]
+  def change
+    add_index :annotations, :uuid, unique: true
+  end
+end

--- a/db/migrate/20220317210522_add_index_on_ruler_id_and_ruler_type_to_rules.rb
+++ b/db/migrate/20220317210522_add_index_on_ruler_id_and_ruler_type_to_rules.rb
@@ -1,0 +1,5 @@
+class AddIndexOnRulerIdAndRulerTypeToRules < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rules, [:ruler_id, :ruler_type]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7249,6 +7249,13 @@ CREATE INDEX index_annotations_on_resource_id_and_resource_type ON public.annota
 
 
 --
+-- Name: index_annotations_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_annotations_on_uuid ON public.annotations USING btree (uuid);
+
+
+--
 -- Name: index_annotations_on_unique_resource_and_attribute; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8943,6 +8950,13 @@ CREATE INDEX index_roles_users_on_user_id ON public.roles_users USING btree (use
 
 
 --
+-- Name: index_rules_on_ruler_id_and_ruler_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rules_on_ruler_id_and_ruler_type ON public.rules USING btree (ruler_id, ruler_type);
+
+
+--
 -- Name: index_saved_locations_on_title; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10147,6 +10161,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220217224804'),
 ('20220224012321'),
 ('20220225054243'),
-('20220308015748');
+('20220308015748'),
+('20220317205240'),
+('20220317210522');
 
 


### PR DESCRIPTION
A handful of smaller changes:

- Use "infinite scrolling" on species tabs of explore and projects pages. Results in a initial species_counts request that is smaller and a little faster
- Limit data fetched for top observer and IDer for taxon page
- Add indices to annotations and rules. Makes deleting annotations much faster; rules lookups are faster
- Increase query timeout on explore. Explore had a lower timeout than the API
- Cache results of API query from login page
- Change ListedTaxon query for observation bulk indexing to be more performant
- Added various preloading to reduce number of DB queries