### PR TITLE
Bugfix: uploader not correctly interpreting time zone from the server

### DIFF
--- a/app/models/local_photo.rb
+++ b/app/models/local_photo.rb
@@ -345,7 +345,10 @@ class LocalPhoto < Photo
       if capture_time = (metadata[:date_time_original] || metadata[:date_time_digitized])
         o.set_time_zone
         o.time_observed_at = capture_time
-        # Force the time to be in the time zone
+        # Force the time to be in the time zone, b/c the value from EXIFR will
+        # be in the system time zone, regardless of what time zone info might
+        # be in the photo metadata. See
+        # https://github.com/MikeKovarik/exifr/issues/84#issuecomment-1004691190
         o.set_time_in_time_zone
         if o.time_observed_at
           o.observed_on_string = o.time_observed_at.in_time_zone( o.time_zone || user.time_zone ).strftime("%Y-%m-%d %H:%M:%S")

--- a/app/webpack/observations/uploader/models/dropped_file.js
+++ b/app/webpack/observations/uploader/models/dropped_file.js
@@ -25,7 +25,15 @@ const DroppedFile = class DroppedFile {
     const updates = { };
     const obs = photo.to_observation;
     if ( obs.time_observed_at ) {
-      updates.date = moment( obs.time_observed_at ).format( parsableDatetimeFormat( ) );
+      // to_observation should come back with a time zone set based on
+      // coordinates, and we need to use that here to tell moment that we
+      // want to use that timezone when formatting an output date, otherwise
+      // moment will parse the date with the offset in time_observed at
+      // correctly, but then *output* a datetime in the local time zone when
+      // we call format()
+      updates.date = moment
+        .tz( obs.time_observed_at, obs.zic_time_zone )
+        .format( parsableDatetimeFormat( ) );
       updates.selected_date = updates.date;
     }
     if ( obs.latitude && obs.longitude ) {


### PR DESCRIPTION
Most of the time the uploader will correctly interpret the datetime from the EXIF and populate that value in the obs card immediately. However, if it fails, it will fall back on the `time_observed_at` provided by the server. The bug was occurring when the latter occurred and the uploader was correctly interpreting that value with its specified offset, but then incorrectly formatting that in the *local* time zone for display. This change makes sure that when the client interprets `time_observed_at`, it also sets the moment object to use the correct time zone before formatting the datetime for display.