### PR TITLE
Use changed coordinates when assigning a time zone for an obscured obs

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1278,8 +1278,8 @@ class Observation < ApplicationRecord
     # changes to the time zone if the coordinates have not changed
     if georeferenced?
       if coordinates_changed?
-        lat = private_latitude.blank? ? latitude : private_latitude
-        lng = private_longitude.blank? ? longitude : private_longitude
+        lat = ( latitude_changed? || private_latitude.blank? ) ? latitude : private_latitude
+        lng = ( longitude_changed? || private_longitude.blank? ) ? longitude : private_longitude
         self.time_zone = TimeZoneGeometry.time_zone_from_lat_lng( lat, lng ).try(:name)
         self.zic_time_zone = ActiveSupport::TimeZone::MAPPING[time_zone] unless time_zone.blank?
       elsif time_zone_changed?

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -4487,6 +4487,13 @@ describe Observation, "set_time_zone" do
     expect( o.zic_time_zone ).to eq "America/Denver"
   end
 
+  it "should change the time zone when the coordinates change when geoprivacy is obscured" do
+    o = Observation.make!( latitude: oakland[:lat], longitude: oakland[:lng], geoprivacy: Observation::OBSCURED )
+    expect( o.zic_time_zone ).to eq "America/Los_Angeles"
+    o.update( latitude: denver[:lat], longitude: denver[:lng] )
+    expect( o.zic_time_zone ).to eq "America/Denver"
+  end
+
   it "should work in the middle of the ocean" do
     o = Observation.make!(
       latitude: pacific_ocean[:lat],


### PR DESCRIPTION
Setting the time zone happens before validation, because it needs to precede setting the datetime, and the datetime needs to be validated to make sure it's not in the future or too far in the past. However, setting the time zone now relies on the coordinates, and for obscured obs, the coordinates are generally in the private_* attributes... except when an observation is getting updated, in which case the client is supposed to just submit new `latitude` and `longitude` values, and we assume a change in those attributes mean they are now the true values and should subsequently be obscured.

Long story short, this change uses those `latitude` and `longitude` to set the time zone if they have changed, but if they haven't it continues to use `private_latitude` and `private_longitude` if they're available, which seems to fix the bug. We'll see what other bugs in causes.

Closes #3446