### PR TITLE
Use parsable date format for EXIF date in Uploader (#3437)

### DIFF
--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -554,8 +554,14 @@ a.UserImage,
     }
   }
   .edit-button {
+    display: flex;
+    justify-content: flex-end;
     .btn-group {
-      float: right;
+      display: flex;
+      a {
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
       .dropdown-menu > li > a {
         padding: 3px 10px;
       }

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1055,6 +1055,10 @@ class Observation < ApplicationRecord
       date_string.gsub!( /( 12:(\d\d)(:\d\d)?)\s+?a\.?m\.?/i, '\\1')
       date_string.gsub!( / 12:/, " 00:" )
     end
+
+    # Translate am/pm into English for parsing
+    date_string.sub!( /\s#{I18n.t( "time.am")}/, " AM" )
+    date_string.sub!( /\s#{I18n.t( "time.pm")}/, " PM" )
     
     # Set the time zone appropriately
     old_time_zone = Time.zone

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1056,9 +1056,13 @@ class Observation < ApplicationRecord
       date_string.gsub!( / 12:/, " 00:" )
     end
 
-    # Translate am/pm into English for parsing
-    date_string.sub!( /\s#{I18n.t( "time.am")}/, " AM" )
-    date_string.sub!( /\s#{I18n.t( "time.pm")}/, " PM" )
+    # Translate am/pm into English for parsing. This is a pretty conservative
+    # solution to a complicated problem. Assumes AM/PM is at the end of the
+    # string and preceeded by a space, or in the middle but followed by a space
+    date_string.sub!( /\s#{I18n.t( "time.am" )}$/i, " AM" )
+    date_string.sub!( /\s#{I18n.t( "time.am" )}\s/i, " AM " )
+    date_string.sub!( /\s#{I18n.t( "time.pm" )}$/i, " PM" )
+    date_string.sub!( /\s#{I18n.t( "time.pm" )}\s/i, " PM " )
     
     # Set the time zone appropriately
     old_time_zone = Time.zone

--- a/app/webpack/observations/uploader/models/dropped_file.js
+++ b/app/webpack/observations/uploader/models/dropped_file.js
@@ -94,7 +94,7 @@ const DroppedFile = class DroppedFile {
           // reformat YYYY:MM:DD into YYYY/MM/DD for moment
           const dt = ( exif.DateTimeOriginal || exif.DateTimeDigitized )
             .replace( /(\d{4}):(\d{2}):(\d{2})/, "$1/$2/$3" );
-          metadata.date = moment( dt ).format( "YYYY/MM/DD h:mm A" );
+          metadata.date = moment( dt ).format( parsableDatetimeFormat( ) );
           metadata.selected_date = metadata.date;
         }
         if ( Math.abs( metadata.latitude ) > 90 || Math.abs( metadata.longitude ) > 180 ) {

--- a/app/webpack/observations/uploader/models/util.js
+++ b/app/webpack/observations/uploader/models/util.js
@@ -20,7 +20,7 @@ export const MAX_FILE_SIZE = 20971520; // 20 MB in bytes
 export const DATETIME_WITH_TIMEZONE = "YYYY/MM/DD h:mm A z";
 export const DATETIME_WITH_TIMEZONE_OFFSET = "YYYY/MM/DD h:mm A ZZ";
 export const DATETIME_12_HOUR = "YYYY/MM/DD h:mm A";
-export const DATETIME_24_HOUR = "YYYY/MM/DD hh:mm";
+export const DATETIME_24_HOUR = "YYYY/MM/DD HH:mm";
 
 // Datetime format without a time zone that is both ok to parse and ok to
 // display. Intentionally not internationalized b/c translators shouldn't be

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -151,6 +151,14 @@ describe Observation do
         it "should default to the user's time zone" do
           expect(subject.time_zone).to eq subject.user.time_zone
         end
+
+        it "should parse translated AM/PM" do
+          I18n.with_locale( :ru ) do
+            o = build :observation, observed_on_string: "2022-01-01 11 вечера"
+            o.munge_observed_on_with_chronic
+            expect( o.time_observed_at_in_zone.hour ).to eq 23
+          end
+        end
       end
 
       context "when the user has a time zone" do

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -159,6 +159,14 @@ describe Observation do
             expect( o.time_observed_at_in_zone.hour ).to eq 23
           end
         end
+
+        it "should parse translated AM/PM regardless of case" do
+          I18n.with_locale( :ru ) do
+            o = build :observation, observed_on_string: "2022-01-01 11 ВЕЧЕРА"
+            o.munge_observed_on_with_chronic
+            expect( o.time_observed_at_in_zone.hour ).to eq 23
+          end
+        end
       end
 
       context "when the user has a time zone" do


### PR DESCRIPTION
Also attempts to replace AM / PM translated into other languages with the literal English values when parsing a date with Chronic.

Closes #3437 