### PR TITLE
Support multiple values for user_id and ident_user_id in observations/export

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -636,8 +636,9 @@ class Observation < ApplicationRecord
 
     # Place searches require special handling if the user is asking for their
     # own observations
+    params_user_ids = [p[:user_id]].flatten.map(&:to_i)
     unless p[:place_id].blank? || p[:place_id] == "any"
-      if p[:viewer] && p[:user_id] && p[:viewer].id == p[:user_id].to_i
+      if p[:viewer] && params_user_ids.size == 1 && p[:viewer].id == params_user_ids[0]
         search_filters << { terms: { "private_place_ids.keyword" => [ p[:place_id] ].flatten.map{ |v|
           ElasticModel.id_or_object(v)
         } } }
@@ -650,7 +651,7 @@ class Observation < ApplicationRecord
 
     unless p[:not_in_place].blank?
       place_ids = [p[:not_in_place]].flatten.map {| v | ElasticModel.id_or_object( v ) }
-      inverse_filters << if p[:viewer]&.id == p[:user_id].to_i
+      inverse_filters << if ( params_user_ids.size == 1 && p[:viewer]&.id == params_user_ids[0] )
         { terms: { "private_place_ids.keyword" => place_ids } }
       else
         { terms: { "place_ids.keyword" => place_ids } }

--- a/lib/observation_search.rb
+++ b/lib/observation_search.rb
@@ -375,6 +375,14 @@ module ObservationSearch
       end
 
       p[:user_id] = p[:user_id] || p[:user]
+
+      # Handle multiple users in user_id
+      users = [p[:user_id].to_s.split( "," )].flatten.map do | user_id |
+        candidate = user_id.to_s.strip
+        User.find_by_id( candidate ) || User.find_by_login( candidate )
+      end
+      p[:user_id] = users.blank? ? nil : users.map(&:id)
+
       unless p[:user_id].blank? || p[:user_id].is_a?(Array)
         p[:user] = User.find_by_id(p[:user_id])
         p[:user] ||= User.find_by_login(p[:user_id])
@@ -387,9 +395,10 @@ module ObservationSearch
         ident_users = p[:ident_user_id].is_a?( Array ) ?
           p[:ident_user_id] : [p[:ident_user_id].to_s.split( "," )].flatten
         ident_user_ids = []
-        ident_users.each do |id_or_login|
-          ident_user = User.find_by_id(p[:ident_user_id])
-          ident_user ||= User.find_by_login(p[:ident_user_id])
+        ident_users.each do | id_or_login |
+          id_or_login = id_or_login.strip
+          ident_user = User.find_by_id( id_or_login )
+          ident_user ||= User.find_by_login( id_or_login )
           ident_user_ids << ident_user.id if ident_user
         end
         p[:ident_user_id] = ident_user_ids.join( "," )

--- a/lib/observation_search.rb
+++ b/lib/observation_search.rb
@@ -380,8 +380,9 @@ module ObservationSearch
       users = [p[:user_id].to_s.split( "," )].flatten.map do | user_id |
         candidate = user_id.to_s.strip
         User.find_by_id( candidate ) || User.find_by_login( candidate )
-      end
+      end.compact
       p[:user_id] = users.blank? ? nil : users.map(&:id)
+      p[:user_id] = p[:user_id].first if p[:user_id].is_a?( Array ) && p[:user_id].size == 1
 
       unless p[:user_id].blank? || p[:user_id].is_a?(Array)
         p[:user] = User.find_by_id(p[:user_id])

--- a/spec/controllers/observation_controller_api_spec.rb
+++ b/spec/controllers/observation_controller_api_spec.rb
@@ -1184,6 +1184,26 @@ shared_examples_for "an ObservationsController" do
       expect( json.detect {| obs | obs["id"] == o2.id } ).not_to be_blank
     end
 
+    it "should filter by single login in user_id" do
+      o1 = Observation.make!( observed_on_string: "2012-01-01 13:13" )
+      o2 = Observation.make!( observed_on_string: "2012-01-01 13:13" )
+      get :index, format: :json, params: { on: "2012-01-01", user_id: o1.user.login }
+      json = JSON.parse( response.body )
+      expect( json.detect {| obs | obs["id"] == o1.id } ).not_to be_blank
+      expect( json.detect {| obs | obs["id"] == o2.id } ).to be_blank
+    end
+
+    it "should filter by multiple logins in user_id" do
+      o1 = Observation.make!( observed_on_string: "2012-01-01 13:13" )
+      o2 = Observation.make!( observed_on_string: "2012-01-01 13:13" )
+      o3 = Observation.make!( observed_on_string: "2012-01-01 13:13" )
+      get :index, format: :json, params: { on: "2012-01-01", user_id: "#{o1.user.login},#{o2.user.login}" }
+      json = JSON.parse( response.body )
+      expect( json.detect {| obs | obs["id"] == o1.id } ).not_to be_blank
+      expect( json.detect {| obs | obs["id"] == o2.id } ).not_to be_blank
+      expect( json.detect {| obs | obs["id"] == o3.id } ).to be_blank
+    end
+
     it "should filter by week of the year" do
       o1 = Observation.make!( observed_on_string: "2012-01-05T13:13+00:00" )
       o2 = Observation.make!( observed_on_string: "2010-03-01T13:13+00:00" )

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -397,10 +397,11 @@ describe "Observation Index" do
     end
 
     it "filters by user and user_id" do
-      expect( Observation.params_to_elastic_query({ user: 1 }) ).to include(
-        filters: [ { terms: { "user.id.keyword" => [ 1 ] } } ] )
-      expect( Observation.params_to_elastic_query({ user_id: 1 }) ).to include(
-        filters: [ { terms: { "user.id.keyword" => [ 1 ] } } ] )
+      user = create :user
+      expect( Observation.params_to_elastic_query({ user: user.id }) ).to include(
+        filters: [ { term: { "user.id.keyword" => user.id } } ] )
+      expect( Observation.params_to_elastic_query({ user_id: user.id }) ).to include(
+        filters: [ { term: { "user.id.keyword" => user.id } } ] )
     end
 
     it "filters by taxon_id" do


### PR DESCRIPTION
observations/export still uses the Rails endpoint, which wasn't supporting queries like `user_id=carmela,sylvio&ident_user_id=mariner,boimler`.