### PR TITLE
Use appropriate locale when translating email subjects

### DIFF
--- a/lib/bulk_observation_file.rb
+++ b/lib/bulk_observation_file.rb
@@ -1,17 +1,20 @@
+# frozen_string_literal: true
+
 # Custom DelayedJob task for the bulk upload functionality.
 class BulkObservationFile
   class BulkObservationException < StandardError
     attr_reader :reason, :row_count, :errors, :tag
 
-    def initialize(reason, row_count = nil, errors = [], tag = nil)
+    def initialize( reason, row_count = nil, errors = [], tag = nil )
+      super( reason )
       @reason    = reason
       @row_count = row_count unless row_count.nil?
       @tag       = tag unless tag.nil?
 
-      if errors.empty?
-        @errors = [reason]
+      @errors = if errors.empty?
+        [reason]
       else
-        @errors = errors
+        errors
       end
     end
   end
@@ -20,7 +23,7 @@ class BulkObservationFile
   IMPORT_BATCH_SIZE = 1000
   MAX_ERROR_COUNT   = 100
 
-  def initialize(observation_file, user_id, options = {})
+  def initialize( observation_file, user_id, options = {} )
     @observation_file = observation_file
     @coord_system     = options[:coord_system]
     @user_id          = user_id
@@ -32,8 +35,8 @@ class BulkObservationFile
     else
       project = Project.find_by_id( @project_id )
       if project.nil?
-        e = BulkObservationException.new('Specified project not found')
-        Emailer.delay.bulk_observation_error(user, File.basename(observation_file), e).deliver_now
+        e = BulkObservationException.new( "Specified project not found" )
+        Emailer.delay.bulk_observation_error( user, File.basename( observation_file ), e ).deliver_now
       end
     end
 
@@ -49,23 +52,21 @@ class BulkObservationFile
   end
 
   def perform
-    begin
-      # Run a validation check over the file to make sure it's valid CSV.
-      validate_file
+    # Run a validation check over the file to make sure it's valid CSV.
+    validate_file
 
-      # Start adding observations.
-      import_file
+    # Start adding observations.
+    import_file
 
-      # Email uploader to say that the upload has finished.
-      Emailer.bulk_observation_success(user, File.basename(@observation_file)).deliver_now
-    rescue BulkObservationException => e
-      # Collate the errors into a hash for emailing
-      error_details = collate_errors(e)
+    # Email uploader to say that the upload has finished.
+    Emailer.bulk_observation_success( user, File.basename( @observation_file ) ).deliver_now
+  rescue BulkObservationException => e
+    # Collate the errors into a hash for emailing
+    error_details = collate_errors( e )
 
-      # puts "error_details: #{error_details.inspect}"
-      # Email the uploader with exception details
-      Emailer.bulk_observation_error(user, File.basename(@observation_file), error_details).deliver_now
-    end
+    # puts "error_details: #{error_details.inspect}"
+    # Email the uploader with exception details
+    Emailer.bulk_observation_error( user, File.basename( @observation_file ), error_details ).deliver_now
   end
 
   def validate_file
@@ -74,13 +75,14 @@ class BulkObservationFile
 
     # Parse the entire observation file looking for possible errors.
     begin
-      CSV.foreach(@observation_file, encoding: 'iso-8859-1:utf-8', headers: true) do |row|
-        next if skip_row?(row)
-        
+      CSV.foreach( @observation_file, encoding: "iso-8859-1:utf-8", headers: true ) do | row |
+        next if skip_row?( row )
+
         # Look for the species and flag it if it's not found.
-        taxon = Taxon.single_taxon_for_name(row[0])
+        taxon = Taxon.single_taxon_for_name( row[0] )
         if taxon.nil?
-          errors << BulkObservationException.new("Single taxon not found: #{row[0]}", row_count + 1, [], 'species_not_found')
+          errors << BulkObservationException.new( "Single taxon not found: #{row[0]}", row_count + 1, [],
+            "species_not_found" )
         end
 
         # Check the validity of the observation
@@ -90,24 +92,25 @@ class BulkObservationFile
         end
 
         # Increment the row count.
-        row_count = row_count + 1
+        row_count += 1
 
         # Stop if we have reached our max error count
         break if errors.count >= MAX_ERROR_COUNT
       end
     rescue CSV::MalformedCSVError => e
       line = e.message[/line (\d+)/, 1]
-      errors << BulkObservationException.new(e.message, line, [e])
+      errors << BulkObservationException.new( e.message, line, [e] )
     end
-    if errors.count > 0
+    if errors.count.positive?
       raise BulkObservationException.new(
-        I18n.t(:we_tried_to_process_your_upload_named_filename, :filename => File.basename(@observation_file)), 
-        nil, 
-        errors)
+        I18n.t( :we_tried_to_process_your_upload_named_filename, filename: File.basename( @observation_file ) ),
+        nil,
+        errors
+      )
     end
-    if row_count == 0
-      raise BulkObservationException.new("The observation file '#{File.basename(@observation_file)}' was empty.")
-    end
+    return unless row_count.zero?
+
+    raise BulkObservationException, "The observation file '#{File.basename( @observation_file )}' was empty."
   end
 
   # Import the observations in the file, and add to the specified project.
@@ -115,15 +118,15 @@ class BulkObservationFile
     row_count = 1
     observations = []
     ActiveRecord::Base.transaction do
-      CSV.foreach(@observation_file, encoding: 'iso-8859-1:utf-8', headers: true) do |row|
-        next if skip_row?(row)
+      CSV.foreach( @observation_file, encoding: "iso-8859-1:utf-8", headers: true ) do | row |
+        next if skip_row?( row )
 
         # Add the observation file name as a tag for identification purposes.
-        tags = row[6].blank? ? [] : row[6].split(',')
-        tags << File.basename(@observation_file)
-        row[6] = tags.join(',')
+        tags = row[6].blank? ? [] : row[6].split( "," )
+        tags << File.basename( @observation_file )
+        row[6] = tags.join( "," )
 
-        obs = new_observation(row)
+        obs = new_observation( row )
         # Not sure why but without this the OFVs won't save as of Rails 6 ~~~kueda 20211028
         obs.observation_field_values.to_a
         begin
@@ -134,37 +137,37 @@ class BulkObservationFile
           observations << obs
 
           # Increment the row count so we can tell them where any errors are.
-          row_count = row_count + 1
+          row_count += 1
         rescue ActiveRecord::RecordInvalid
-          raise BulkObservationException.new('Invalid record encountered', row_count)
+          raise BulkObservationException.new( "Invalid record encountered", row_count )
         end
       end
 
       # Add all of the observations to the project if a project was specified
       if project
-        observations.each do |obs|
-          project.project_observations.create(:observation => obs)
+        observations.each do | obs |
+          project.project_observations.create( observation: obs )
         end
 
         # Manually update counter caches.
-        ProjectUser.update_observations_counter_cache_from_project_and_user(project.id, user.id)
-        ProjectUser.update_taxa_counter_cache_from_project_and_user(project.id, user.id)
-        Project.update_observed_taxa_count(project.id)
+        ProjectUser.update_observations_counter_cache_from_project_and_user( project.id, user.id )
+        ProjectUser.update_taxa_counter_cache_from_project_and_user( project.id, user.id )
+        Project.update_observed_taxa_count( project.id )
       end
     end
-    Observation.elastic_index!(ids: observations.map(&:id), wait_for_index_refresh: true)
+    Observation.elastic_index!( ids: observations.map( &:id ), wait_for_index_refresh: true )
   end
 
-  def new_observation(row)
+  def new_observation( row )
     obs = Observation.new(
-      :user               => user,
-      :species_guess      => row[0],
-      :observed_on_string => row[1],
-      :description        => row[2],
-      :place_guess        => row[3],
-      :time_zone          => user.time_zone,
-      :tag_list           => row[6],
-      :geoprivacy         => row[7],
+      user: user,
+      species_guess: row[0],
+      observed_on_string: row[1],
+      description: row[2],
+      place_guess: row[3],
+      time_zone: user.time_zone,
+      tag_list: row[6],
+      geoprivacy: row[7]
     )
 
     # If a coordinate system other than WGS84 is in use
@@ -179,20 +182,18 @@ class BulkObservationFile
     end
 
     # Are we adding to a specific project?
-    unless project.nil?
-      project.project_observation_fields.each do |pof|
-        value = row[pof.observation_field.name]
-        if value.blank?
-          if pof.required
-            obs.custom_field_errors ||= []
-            obs.custom_field_errors << "#{pof.observation_field.name} is required"
-          end
-        else
-          obs.observation_field_values.build(
-            observation_field_id: pof.observation_field_id,
-            value: value
-          )
+    project&.project_observation_fields&.each do | pof |
+      value = row[pof.observation_field.name]
+      if value.blank?
+        if pof.required
+          obs.custom_field_errors ||= []
+          obs.custom_field_errors << "#{pof.observation_field.name} is required"
         end
+      else
+        obs.observation_field_values.build(
+          observation_field_id: pof.observation_field_id,
+          value: value
+        )
       end
     end
 
@@ -204,40 +205,41 @@ class BulkObservationFile
     obs
   end
 
-  def skip_row?(row)
-    row.blank? || row[0].to_s =~ /^\s*\#/ || row.fields.reject{|s| s.blank?}.blank?
+  def skip_row?( row )
+    row.blank? || row[0].to_s =~ /^\s*\#/ || row.fields.reject( &:blank? ).blank?
   end
 
-  def collate_errors(exception)
+  def collate_errors( exception )
     # enumerate the exceptions and collate error messages
     field_options = {}
     errors = {}
-    exception.errors.each do |e|
-      if e.errors.is_a?(ActiveModel::Errors)
-        e.errors.each do |field, error|
-          errors[field] ||= {}
-          full_error = e.errors.full_message(field, error)
-          errors[field][full_error] ||= []
-          errors[field][full_error] << e.row_count
+    exception.errors.each do | e |
+      if e.errors.is_a?( ActiveModel::Errors )
+        # e.errors.each do |field, error|
+        e.errors.each do | error |
+          errors[error.attribute] ||= {}
+          full_error = e.errors.full_message( error.attribute, error.message )
+          errors[error.attribute][full_error] ||= []
+          errors[error.attribute][full_error] << e.row_count
         end
       elsif !e.tag.nil?
-        e.errors.each do |error|
+        e.errors.each do | error |
           errors[e.tag] ||= {}
           errors[e.tag][error] ||= []
           errors[e.tag][error] << e.row_count
         end
       else
-        e.errors.each do |error|
-          errors['base'] ||= {}
-          errors['base'][error] ||= []
-          errors['base'][error] << e.row_count
+        e.errors.each do | error |
+          errors["base"] ||= {}
+          errors["base"][error] ||= []
+          errors["base"][error] << e.row_count
         end
       end
     end
 
     {
       reason: exception.reason,
-      errors: errors.stringify_keys.sort_by { |k, v| k },
+      errors: errors.stringify_keys.sort_by {| k, _v | k },
       field_options: field_options
     }
   end
@@ -245,5 +247,4 @@ class BulkObservationFile
   def max_attempts
     1
   end
-
 end

--- a/spec/models/emailer_spec.rb
+++ b/spec/models/emailer_spec.rb
@@ -1,16 +1,17 @@
-# encoding: UTF-8
-require File.dirname(__FILE__) + '/../spec_helper.rb'
+# frozen_string_literal: true
+
+require "#{File.dirname( __FILE__ )}/../spec_helper.rb"
 
 describe Emailer, "updates_notification" do
   include ActionView::Helpers::TextHelper
   elastic_models( Taxon, Observation )
-  before(:all) do
-    DatabaseCleaner.clean_with(:truncation, except: %w[spatial_ref_sys])
+  before( :all ) do
+    DatabaseCleaner.clean_with( :truncation, except: %w(spatial_ref_sys) )
   end
   before do
     enable_has_subscribers
     @observation = Observation.make!
-    @comment = without_delay { Comment.make!(:parent => @observation) }
+    @comment = without_delay { Comment.make!( parent: @observation ) }
     @user = @observation.user
   end
   after { disable_has_subscribers }
@@ -20,28 +21,35 @@ describe Emailer, "updates_notification" do
     t = Taxon.make!
     tn_default = TaxonName.make!( taxon: t, lexicon: TaxonName::LEXICONS[:ENGLISH], name: "Default Name" )
     tn_local = TaxonName.make!( taxon: t, lexicon: TaxonName::LEXICONS[:ENGLISH], name: "Localized Name" )
-    ptn = PlaceTaxonName.make!( taxon_name: tn_local, place: p )
+    PlaceTaxonName.make!( taxon_name: tn_local, place: p )
     @user.update( place_id: p.id )
-    identification = without_delay { Identification.make!( taxon: t, observation: @observation ) }
-    update_action = UpdateAction.last
+    without_delay { Identification.make!( taxon: t, observation: @observation ) }
     mail = Emailer.updates_notification( @user, @user.recent_notifications )
-    expect( mail.body ).to match /#{tn_local.name}/
-    expect( mail.body ).not_to match /#{tn_default.name}/
+    expect( mail.body ).to match( /#{tn_local.name}/ )
+    expect( mail.body ).not_to match( /#{tn_default.name}/ )
   end
 
   it "sends updates on observation field values, in all languages" do
     @ofv = nil
-    without_delay { @ofv = ObservationFieldValue.make!(observation: @observation, user: User.make!) }
-    I18N_SUPPORTED_LOCALES.each do |loc|
-      @user.update(locale: loc)
-      mail = Emailer.updates_notification(@user, @user.recent_notifications)
-      expect(mail.body).to include I18n.t(:user_added_an_observation_field_html,
-        user: FakeView.link_to(@ofv.user.login, FakeView.person_url(@ofv.user, host: Site.default.url)),
-        field_name: @ofv.observation_field.name.truncate(30),
+    without_delay { @ofv = ObservationFieldValue.make!( observation: @observation, user: User.make! ) }
+    I18N_SUPPORTED_LOCALES.each do | loc |
+      @user.update( locale: loc )
+      mail = Emailer.updates_notification( @user, @user.recent_notifications )
+      expect( mail.body ).to include I18n.t( :user_added_an_observation_field_html,
+        user: FakeView.link_to( @ofv.user.login, FakeView.person_url( @ofv.user, host: Site.default.url ) ),
+        field_name: @ofv.observation_field.name.truncate( 30 ),
         owner: @user.login,
-        locale: loc)
+        locale: loc )
     end
-    @user.update(locale: "en")
+    @user.update( locale: "en" )
+  end
+
+  it "should translate the subject" do
+    locale_was = @user.locale
+    @user.update( locale: "es" )
+    mail = Emailer.updates_notification( @user, @user.recent_notifications )
+    expect( mail.subject ).to include "Nuevas"
+    @user.update( locale: locale_was )
   end
 
   describe "with a site" do
@@ -60,20 +68,20 @@ describe Emailer, "updates_notification" do
     end
 
     it "should use the user's site url as the base url" do
-      mail = Emailer.updates_notification(@user, @user.recent_notifications)
-      expect(mail.body).to match @site.url
+      mail = Emailer.updates_notification( @user, @user.recent_notifications )
+      expect( mail.body ).to match @site.url
     end
 
     it "should include site name in subject" do
-      mail = Emailer.updates_notification(@user, @user.recent_notifications)
-      expect(mail.subject).to match @site.name
+      mail = Emailer.updates_notification( @user, @user.recent_notifications )
+      expect( mail.subject ).to match @site.name
     end
   end
 
   describe "with curator change" do
-    let(:project) { Project.make! }
+    let( :project ) { Project.make! }
     def test_user_with_project_and_viewer( user, project, viewer )
-      viewer_pu = ProjectUser.make!( user: viewer, project: project)
+      viewer_pu = ProjectUser.make!( user: viewer, project: project )
       pu = if user == viewer
         viewer_pu
       else
@@ -81,19 +89,19 @@ describe Emailer, "updates_notification" do
       end
       # Test change to curator
       pu.update( role: ProjectUser::CURATOR )
-      Delayed::Job.all.each{ |j| Delayed::Worker.new.run( j ) }
+      Delayed::Job.all.each {| j | Delayed::Worker.new.run( j ) }
       mail = Emailer.updates_notification( viewer, viewer.recent_notifications )
-      expect( mail.body ).to match /curator/
+      expect( mail.body ).to match( /curator/ )
       # Test change to manage
       pu.update( role: ProjectUser::MANAGER )
-      Delayed::Job.all.each{ |j| Delayed::Worker.new.run( j ) }
+      Delayed::Job.all.each {| j | Delayed::Worker.new.run( j ) }
       mail = Emailer.updates_notification( viewer, viewer.recent_notifications )
-      expect( mail.body ).to match /manager/
+      expect( mail.body ).to match( /manager/ )
       # Test change to admin
       project.update( user: user )
-      Delayed::Job.all.each{ |j| Delayed::Worker.new.run( j ) }
+      Delayed::Job.all.each {| j | Delayed::Worker.new.run( j ) }
       mail = Emailer.updates_notification( viewer, viewer.recent_notifications )
-      expect( mail.body ).to match /admin/
+      expect( mail.body ).to match( /admin/ )
     end
     it "should work when it's about you" do
       u = User.make!
@@ -108,34 +116,33 @@ end
 describe Emailer, "new_message" do
   it "should work" do
     m = make_message
-    mail = Emailer.new_message(m)
-    expect(mail.body).not_to be_blank
+    mail = Emailer.new_message( m )
+    expect( mail.body ).not_to be_blank
   end
 
   it "should not deliver flagged messages" do
     from_user = make_user_with_privilege( UserPrivilege::SPEECH )
     to_user = User.make!
-    m = make_message(:from_user => from_user, :to_user => to_user, :user => from_user)
+    m = make_message( from_user: from_user, to_user: to_user, user: from_user )
     m.send_message
-    f = m.flags.create(:flag => "spam")
+    m.flags.create( flag: "spam" )
     m.reload
-    mail = Emailer.new_message(m)
-    expect(mail.body).to be_blank
+    mail = Emailer.new_message( m )
+    expect( mail.body ).to be_blank
   end
 
   it "should not deliver if from_user is suspended" do
     m = make_message
     m.from_user.suspend!
-    mail = Emailer.new_message(m)
-    expect(mail.body).to be_blank
+    mail = Emailer.new_message( m )
+    expect( mail.body ).to be_blank
   end
 
   it "does not raise en error if the message is missing" do
-    expect {
+    expect do
       Emailer.new_message( nil ).deliver_now
-    }.to_not raise_error
+    end.to_not raise_error
   end
-
 end
 
 describe Emailer, "project_user_invitation" do
@@ -143,18 +150,18 @@ describe Emailer, "project_user_invitation" do
     pui = ProjectUserInvitation.make!
     pui.user.destroy
     pui.reload
-    expect(pui.user).to be_blank
-    mail = Emailer.project_user_invitation(pui)
-    expect(mail.body).not_to be_blank
+    expect( pui.user ).to be_blank
+    mail = Emailer.project_user_invitation( pui )
+    expect( mail.body ).not_to be_blank
   end
 end
 
 describe Emailer, "bulk_observation_success" do
-  let(:user) { User.make! }
+  let( :user ) { User.make! }
   it "should mention the filename" do
-    mail = Emailer.bulk_observation_success(user, "the_filename")
-    expect(mail.body).to match /the_filename/
-    expect(mail.subject).to match /the_filename/
+    mail = Emailer.bulk_observation_success( user, "the_filename" )
+    expect( mail.body ).to match( /the_filename/ )
+    expect( mail.subject ).to match( /the_filename/ )
   end
 
   describe "with a site" do
@@ -165,8 +172,8 @@ describe Emailer, "bulk_observation_success" do
       user.save!
     end
     it "should include the site name" do
-      mail = Emailer.bulk_observation_success(user, "the_filename")
-      expect(mail.body).to match /#{@site.name}/
+      mail = Emailer.bulk_observation_success( user, "the_filename" )
+      expect( mail.body ).to match( /#{@site.name}/ )
     end
   end
 end
@@ -174,17 +181,17 @@ end
 describe Emailer, "bulk_observation_error" do
   it "should mention the error reasons" do
     user = User.make!
-    bof = BulkObservationFile.new(nil, user.id)
+    bof = BulkObservationFile.new( nil, user.id )
     o = Observation.new
-    expect(o).not_to be_valid
+    expect( o ).not_to be_valid
     e = BulkObservationFile::BulkObservationException.new(
-      "failed to process", 
-      1, 
-      [BulkObservationFile::BulkObservationException.new("observation was invalid", 1, o.errors)]
+      "failed to process",
+      1,
+      [BulkObservationFile::BulkObservationException.new( "observation was invalid", 1, o.errors )]
     )
-    errors = bof.collate_errors(e)
-    mail = Emailer.bulk_observation_error(user, "the_filename", errors)
-    expect(mail.subject).to match /the_filename/
-    expect(mail.body).to match /failed to process/
+    errors = bof.collate_errors( e )
+    mail = Emailer.bulk_observation_error( user, "the_filename", errors )
+    expect( mail.subject ).to match( /the_filename/ )
+    expect( mail.body ).to match( /failed to process/ )
   end
 end


### PR DESCRIPTION
As of f44050455e2a04a122c17f8f58c33047b7f3a996 we have not been using the
correct locale when translating email subjects. This allows the subject to be
specified with an array of arguments to I18n.t. Also fixed up some code
style.