### PR TITLE
fix issue #3110 - sorting by date added

### DIFF
--- a/app/webpack/lifelists/show/reducers/lifelist.js
+++ b/app/webpack/lifelists/show/reducers/lifelist.js
@@ -402,7 +402,7 @@ export function setObservationSort( sort ) {
     } ) );
     const searchParams = {
       user_id: lifelist.user.id,
-      order_by: "observed_on",
+      order_by: "created_at",
       order: "desc"
     };
     if ( sort === "dateAsc" ) {


### PR DESCRIPTION
Sorting obs by "Date Added" now correctly sorts by date added instead of date observed