### PR TITLE
In search results at admin/users, link observations number to Explore, not Edit Observations

### DIFF
--- a/app/views/admin/users.html.haml
+++ b/app/views/admin/users.html.haml
@@ -51,6 +51,6 @@
                 %td= user.email
                 %td= user.created_at
                 %td= user.last_ip
-                %td= link_to user.observations_count, observations_by_login_path(user.login)
+                %td= link_to user.observations_count, observations_path( user_id: user.login, verifiable: "any", place_id: "any" )
                 %td= link_to user.identifications_count, identifications_by_login_path(user.login)
                 %td= link_to @comment_counts_by_user_id[user.id].to_i, comments_by_login_path(user.login)


### PR DESCRIPTION
This pull request is for issue [3444](https://github.com/inaturalist/inaturalist/issues/3444).