### PR TITLE
Add pg ilike search to posts title and body

### DIFF
--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -89,6 +89,7 @@ form.post_form .observationSelectorObservations {
 #pageheader img {
   max-height: 55px;
 }
+
 #post_header {
   display: flex;
   justify-content: space-between;

--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -89,3 +89,7 @@ form.post_form .observationSelectorObservations {
 #pageheader img {
   max-height: 55px;
 }
+
+#post_search {
+  margin-bottom: 2em;
+}

--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -89,7 +89,8 @@ form.post_form .observationSelectorObservations {
 #pageheader img {
   max-height: 55px;
 }
-
-#post_search {
-  margin-bottom: 2em;
+#post_header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,13 +1,14 @@
 class PostsController < ApplicationController
-  before_action :doorkeeper_authorize!, :only => [ :for_project_user, :for_user ], :if => lambda { authenticate_with_oauth? }
-  before_action :authenticate_user!, :except => [:index, :show, :browse, :for_user, :archives ], :unless => lambda { authenticated_with_oauth? }
-  load_only = [ :show, :edit, :update, :destroy ]
-  before_action :load_post, :only => load_only
-  blocks_spam :only => load_only, :instance => :post
-  check_spam only: [:create, :update], instance: :post
-  before_action :load_parent, :except => [:browse, :for_project_user, :for_user]
-  before_action :load_new_post, :only => [:new, :create]
-  before_action :owner_required, :only => [:create, :edit, :update, :destroy]
+  before_action :doorkeeper_authorize!, only: %i[for_project_user for_user], if: -> { authenticate_with_oauth? }
+  before_action :authenticate_user!, except: %i[index show browse for_user archives search],
+                unless: -> { authenticated_with_oauth? }
+  load_only = %i[show edit update destroy]
+  before_action :load_post, only: load_only
+  blocks_spam only: load_only, instance: :post
+  check_spam only: %i[create update], instance: :post
+  before_action :load_parent, except: %i[browse for_project_user for_user]
+  before_action :load_new_post, only: %i[new create]
+  before_action :owner_required, only: %i[create edit update destroy]
 
   # Might want to try this if /journal becomes a problem.
   # caches_action :browse,

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -230,7 +230,17 @@ class PostsController < ApplicationController
       paginate(page: params[:page] || 1, per_page: 10)
     get_archives
   end
-  
+
+  def search
+    @posts = Post.not_flagged_as_spam.published.dbsearch( params[:q] ).page( params[:page] ).
+      per_page( limited_per_page )
+    pagination_headers_for @posts
+    respond_to do | format |
+      format.html
+      format.json { render json: @posts }
+    end
+  end
+
   def browse
     @posts = Post.not_flagged_as_spam.published.page(params[:page] || 1).order('published_at DESC')
     @posts = @posts.where( "posts.id < ?", params[:from] ) unless params[:from].blank?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1441,7 +1441,7 @@ module ApplicationHelper
   end
 
   def post_parent_path( parent, options = {} )
-    parent_slug = @parent_slug || parent.try_methods( :login, :slug )
+    parent_slug = @parent.journal_slug || parent.try_methods( :login, :slug )
     case parent.class.name
     when "Project"
       project_journal_path( options.merge( project_id: parent_slug ) )
@@ -1453,7 +1453,7 @@ module ApplicationHelper
   end
 
   def post_archives_by_month_path( parent, year, month )
-    parent_slug = @parent_slug || parent.try_methods( :login, :slug )
+    parent_slug = @parent.journal_slug || parent.try_methods( :login, :slug )
     case parent.class.name
     when "Project"
       project_journal_archives_by_month_path( parent_slug, year, month )

--- a/app/models/concerns/has_journal.rb
+++ b/app/models/concerns/has_journal.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module HasJournal
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :journal_posts, class_name: "Post", as: :parent, dependent: :destroy
+  end
+
+  def journal_display_name
+    case self
+    when Project
+      title
+    when Site
+      name
+    when User
+      login
+    else
+      t(:journal)
+    end
+  end
+
+  def journal_owned_by?(user)
+    case self
+    when Project
+      curated_by? user
+    when Site
+      editable_by? user
+    when User
+      self == user
+    end
+  end
+
+  def journal_path
+    case self
+    when Project
+      Rails.application.routes.url_helpers.project_journal_path( slug )
+    when Site
+      Rails.application.routes.url_helpers.site_posts_path
+    when User
+      Rails.application.routes.url_helpers.journal_by_login_path( login )
+    end
+  end
+
+  def journal_slug
+    case self
+    when Project
+      slug
+    when Site
+      name.to_param
+    when User
+      login
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -49,14 +49,16 @@ class Post < ApplicationRecord
   validates_length_of :body, in: 1..1000000
   validates_presence_of :parent
   validate :user_must_be_on_site_long_enough
-  
+
   before_save :skip_update_for_draft
   after_save :update_user_counter_cache
   after_destroy :update_user_counter_cache
-  
+
   scope :published, -> { where("published_at IS NOT NULL") }
   scope :unpublished, -> { where("published_at IS NULL") }
-  scope :dbsearch, ->( q ) { where( "posts.title ILIKE ? OR posts.body ILIKE ?", "%#{q}%", "%#{q}%" ) }
+  scope :dbsearch, lambda {| parent:, q: |
+    where( parent: parent ).where( "posts.title ILIKE ? OR posts.body ILIKE ?", "%#{q}%", "%#{q}%" )
+  }
 
   FORMATTING_SIMPLE = "simple"
   FORMATTING_NONE = "none"
@@ -143,12 +145,12 @@ class Post < ApplicationRecord
       errors.add(:user, :must_be_on_site_long_enough)
     end
   end
-  
+
   def skip_update_for_draft
     @skip_update = true if draft?
     true
   end
-  
+
   def update_user_counter_cache
     if parent_type == "User" && (saved_change_to_published_at? || destroyed?)
       User.where( id: user_id, ).update_all( journal_posts_count: user.journal_posts.published.count )
@@ -159,7 +161,7 @@ class Post < ApplicationRecord
   def to_s
     "<Post #{self.id}: #{self.to_plain_s}>"
   end
-  
+
   def to_plain_s(options = {})
     s = self.title || ""
     s += ", by #{self.user.try(:login)}" unless options[:no_user]
@@ -169,7 +171,7 @@ class Post < ApplicationRecord
   def to_param
     "#{id}-#{title.parameterize}"
   end
-  
+
   def draft?
     published_at.blank?
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -56,6 +56,7 @@ class Post < ApplicationRecord
   
   scope :published, -> { where("published_at IS NOT NULL") }
   scope :unpublished, -> { where("published_at IS NULL") }
+  scope :dbsearch, ->( q ) { where( "posts.title ILIKE ? OR posts.body ILIKE ?", "%#{q}%", "%#{q}%" ) }
 
   FORMATTING_SIMPLE = "simple"
   FORMATTING_NONE = "none"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
 
   include ActsAsElasticModel
+  include HasJournal
 
   belongs_to :user
   belongs_to :place, inverse_of: :projects
@@ -17,7 +18,6 @@ class Project < ApplicationRecord
   has_many :project_observation_fields, -> { order("position") }, dependent: :destroy, inverse_of: :project
   has_many :observation_fields, through: :project_observation_fields
   has_many :posts, as: :parent, dependent: :destroy
-  has_many :journal_posts, class_name: "Post", as: :parent
   has_many :assessments, dependent: :destroy
   has_many :site_featured_projects, dependent: :destroy
   has_many :project_observation_rules_as_operand, class_name: "ProjectObservationRule", as: :operand

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Site < ApplicationRecord
+  include HasJournal
+
   has_many :observations, inverse_of: :site
   has_many :users, inverse_of: :site
   has_many :site_admins, inverse_of: :site
   has_many :posts, as: :parent, dependent: :destroy
-  has_many :journal_posts, class_name: "Post", as: :parent, dependent: :destroy
   has_many :site_featured_projects, dependent: :destroy
   has_and_belongs_to_many :announcements
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   include ActsAsSpammable::User
   include ActsAsElasticModel
   # include ActsAsUUIDable
+  include HasJournal
+
   before_validation :set_uuid
   def set_uuid
     self.uuid ||= SecureRandom.uuid
@@ -159,7 +161,6 @@ class User < ApplicationRecord
   has_many :photos, :dependent => :destroy
   has_many :sounds, dependent: :destroy
   has_many :posts #, :dependent => :destroy
-  has_many :journal_posts, :class_name => "Post", :as => :parent, :dependent => :destroy
   has_many :trips, -> { where("posts.type = 'Trip'") }, :class_name => "Post", :foreign_key => "user_id"
   has_many :taxon_links, :dependent => :nullify
   has_many :comments, :dependent => :destroy

--- a/app/views/lists/by_login.html.haml
+++ b/app/views/lists/by_login.html.haml
@@ -13,7 +13,7 @@
   .row.header
     - tools = capture do
       - if logged_in? && current_user == @selected_user
-        = link_to t( :new_list ), new_list_path( @parent_slug ), id: "newlistbutton", class: "btn btn-primary"
+        = link_to t( :new_list ), new_list_path( @parent.journal_slug ), id: "newlistbutton", class: "btn btn-primary"
     = render partial: "shared/by_login_header_bootstrap", locals: { after: tools, model_name: "Lists" }
   
   .row

--- a/app/views/posts/_breadcrumbs.html.erb
+++ b/app/views/posts/_breadcrumbs.html.erb
@@ -1,8 +1,8 @@
 <div class="breadcrumbs">
   <% if @parent.is_a?(Project) %>
-    <%= link_to t(:back_to_x_journal, :user => @parent.title),
-                project_journal_path(@parent_slug),
-                :class => 'back crumb' %>
+    <%= link_to t(:back_to_x_journal, user: @parent.title),
+                project_journal_path(@parent.journal_slug),
+                class: 'back crumb' %>
   <% elsif @parent.is_a?(Site) %>
     <%= link_to t(:back_to_x_blog, x: @parent.name), site_posts_path, :class => 'back crumb' %>
   <% else %>

--- a/app/views/posts/_header.html.haml
+++ b/app/views/posts/_header.html.haml
@@ -17,44 +17,32 @@
           - if @display_project.curated_by?(current_user)
             = link_to t(:new_post), new_project_journal_post_path(@parent.journal_slug), id: "newpostbutton",
                 class: "default button"
-        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
 - elsif @parent.is_a?(Project)
   - tools = capture do
-    #post_header
-      %div
-        - if @display_project.curated_by?(current_user)
-          #tools.buttonrow
-            = link_to t(:new_post), new_project_journal_post_path(@parent.journal_slug), id: "newpostbutton",
-              class: "default button"
-      = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
+    - if @display_project.curated_by?(current_user)
+      #tools.buttonrow
+        = link_to t(:new_post), new_project_journal_post_path(@parent.journal_slug), id: "newpostbutton",
+          class: "default button"
   = render :partial => "shared/by_project_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal", :project => @parent }
 - elsif @parent.is_a?( Site )
-  .row
-    #pageheader.col-md-12
-      #post_header
-        %div
-          = breadcrumbs
-          - if @site.logo_blog?
-            = image_tag @site.logo_blog.url
-          - else
-            = link_to(image_tag(@site.logo_square.url(:thumb), :class => "parenticon"), @site)
-            %h2
-              = link_to @site.name, site_posts_path
-            %ul#subnav.clear
-              %li=t :official_blog
-          - if @site.editable_by?( current_user )
-            #tools.buttonrow
-              = link_to t(:new_post), new_site_post_path, id: "newpostbutton", :class => "default button"
-        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
+  #pageheader.col-md-12
+    = breadcrumbs
+    - if @site.logo_blog?
+      = image_tag @site.logo_blog.url
+    - else
+      = link_to(image_tag(@site.logo_square.url(:thumb), :class => "parenticon"), @site)
+      %h2
+        = link_to @site.name, site_posts_path
+      %ul#subnav.clear
+        %li=t :official_blog
+    - if @site.editable_by?( current_user )
+      #tools.buttonrow
+        = link_to t(:new_post), new_site_post_path, id: "newpostbutton", :class => "default button"
 - else # parent is a user
-  .row
-    - tools = capture do
-      #post_header
-        %div
-          - if logged_in? && current_user.login == @parent.journal_display_name
-            #tools.btn-grp
-              = link_to t(:new_post), new_journal_post_path(@parent.journal_slug), id: "newpostbutton", class: "btn btn-primary"
-              = feature_test :trips do
-                = link_to t(:new_trip), new_trip_path, :id => "newtripbutton", :class => "btn btn-primary"
-        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
-    = render :partial => "shared/by_login_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal" }
+  - tools = capture do
+    - if logged_in? && current_user.login == @parent.journal_display_name
+      #tools.btn-grp
+        = link_to t(:new_post), new_journal_post_path(@parent.journal_slug), id: "newpostbutton", class: "btn btn-primary"
+        = feature_test :trips do
+          = link_to t(:new_trip), new_trip_path, :id => "newtripbutton", :class => "btn btn-primary"
+  = render :partial => "shared/by_login_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal" }

--- a/app/views/posts/_header.html.haml
+++ b/app/views/posts/_header.html.haml
@@ -2,32 +2,59 @@
 - breadcrumbs = capture do
   - if include_breadcrumbs
     = render :partial => 'posts/breadcrumbs'
-- if @parent.is_a?(Project)
+- if @parent.is_a?(Project) && @parent.is_new_project?
+  .row.project-back
+    .col-md-12
+      %a{ href: project_path( @parent ) }
+        %i.fa.fa-angle-left
+        = t( :back_to_x, noun: @parent.title )
+  .row
+    .col-md-12
+      - title = t( :x_project_journal, project: strip_tags( @parent.title ), name: t( :journal ) )
+      %h1= title
+      #post_header
+        %div
+          - if @display_project.curated_by?(current_user)
+            = link_to t(:new_post), new_project_journal_post_path(@parent_slug), id: "newpostbutton",
+                class: "default button"
+        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
+- elsif @parent.is_a?(Project)
   - tools = capture do
-    - if @display_project.curated_by?(current_user)
-      #tools.buttonrow
-        = link_to t(:new_post), new_project_journal_post_path(@parent_slug), |
-          :id => "newpostbutton", :class => "default button"                 |
+    #post_header
+      %div
+        - if @display_project.curated_by?(current_user)
+          #tools.buttonrow
+            = link_to t(:new_post), new_project_journal_post_path(@parent_slug), id: "newpostbutton",
+              class: "default button"
+      = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
   = render :partial => "shared/by_project_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal", :project => @parent }
 - elsif @parent.is_a?( Site )
-  #pageheader.col-md-12
-    = breadcrumbs
-    - if @site.logo_blog?
-      = image_tag @site.logo_blog.url
-    - else
-      = link_to(image_tag(@site.logo_square.url(:thumb), :class => "parenticon"), @site)
-      %h2
-        = link_to @site.name, site_posts_path
-      %ul#subnav.clear
-        %li=t :official_blog
-    - if @site.editable_by?( current_user )
-      #tools.buttonrow
-        = link_to t(:new_post), new_site_post_path, id: "newpostbutton", :class => "default button"
+  .row
+    #pageheader.col-md-12
+      #post_header
+        %div
+          = breadcrumbs
+          - if @site.logo_blog?
+            = image_tag @site.logo_blog.url
+          - else
+            = link_to(image_tag(@site.logo_square.url(:thumb), :class => "parenticon"), @site)
+            %h2
+              = link_to @site.name, site_posts_path
+            %ul#subnav.clear
+              %li=t :official_blog
+          - if @site.editable_by?( current_user )
+            #tools.buttonrow
+              = link_to t(:new_post), new_site_post_path, id: "newpostbutton", :class => "default button"
+        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
 - else # parent is a user
-  - tools = capture do
-    - if logged_in? && current_user.login == @parent_display_name
-      #tools.btn-grp
-        = link_to t(:new_post), new_journal_post_path(@parent_slug), :id => "newpostbutton", :class => "btn btn-primary"
-        = feature_test :trips do
-          = link_to t(:new_trip), new_trip_path, :id => "newtripbutton", :class => "btn btn-primary"
-  = render :partial => "shared/by_login_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal" }
+  .row
+    - tools = capture do
+      #post_header
+        %div
+          - if logged_in? && current_user.login == @parent_display_name
+            #tools.btn-grp
+              = link_to t(:new_post), new_journal_post_path(@parent_slug), :id => "newpostbutton", :class => "btn btn-primary"
+              = feature_test :trips do
+                = link_to t(:new_trip), new_trip_path, :id => "newtripbutton", :class => "btn btn-primary"
+        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
+    = render :partial => "shared/by_login_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal" }

--- a/app/views/posts/_header.html.haml
+++ b/app/views/posts/_header.html.haml
@@ -15,7 +15,7 @@
       #post_header
         %div
           - if @display_project.curated_by?(current_user)
-            = link_to t(:new_post), new_project_journal_post_path(@parent_slug), id: "newpostbutton",
+            = link_to t(:new_post), new_project_journal_post_path(@parent.journal_slug), id: "newpostbutton",
                 class: "default button"
         = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
 - elsif @parent.is_a?(Project)
@@ -24,7 +24,7 @@
       %div
         - if @display_project.curated_by?(current_user)
           #tools.buttonrow
-            = link_to t(:new_post), new_project_journal_post_path(@parent_slug), id: "newpostbutton",
+            = link_to t(:new_post), new_project_journal_post_path(@parent.journal_slug), id: "newpostbutton",
               class: "default button"
       = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
   = render :partial => "shared/by_project_header_bootstrap", :locals => { :before => breadcrumbs, :after => tools, :model_name => "Journal", :project => @parent }
@@ -51,9 +51,9 @@
     - tools = capture do
       #post_header
         %div
-          - if logged_in? && current_user.login == @parent_display_name
+          - if logged_in? && current_user.login == @parent.journal_display_name
             #tools.btn-grp
-              = link_to t(:new_post), new_journal_post_path(@parent_slug), :id => "newpostbutton", :class => "btn btn-primary"
+              = link_to t(:new_post), new_journal_post_path(@parent.journal_slug), id: "newpostbutton", class: "btn btn-primary"
               = feature_test :trips do
                 = link_to t(:new_trip), new_trip_path, :id => "newtripbutton", :class => "btn btn-primary"
         = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }

--- a/app/views/posts/_posts.html.haml
+++ b/app/views/posts/_posts.html.haml
@@ -1,0 +1,12 @@
+- if !posts.blank?
+  - posts.each do |post|
+    .media
+      - if post.parent_type == "Project"
+        = link_to(image_tag(post.parent.icon.url(:thumb), class: "usericon media-object img-rounded"), project_journal_path(post.parent), class: "pull-left")
+      - else
+        = link_to(image_tag(post.user.icon.url(:thumb), class: "usericon media-object"), journal_by_login_path(post.user.login), class: "pull-left")
+      .media-body
+        = render "posts/post", post: post, hard_truncate_length: 500
+- else
+  #noposts.description= t(:no_one_posted_anything_yet)
+

--- a/app/views/posts/_search_form.html.haml
+++ b/app/views/posts/_search_form.html.haml
@@ -1,0 +1,8 @@
+#post_search
+  = form_tag posts_search_path, method: :get, class: "form-search form-inline" do
+    .input-group
+      = text_field_tag :q, params[:q], placeholder: t(:find_a_post), class: "form-control"
+      = hidden_field_tag 'post[parent_type]', parent_type
+      = hidden_field_tag 'post[parent_id]', parent_id
+      .input-group-btn
+        = submit_tag t(:search), class: "btn btn-primary"

--- a/app/views/posts/browse.html.haml
+++ b/app/views/posts/browse.html.haml
@@ -5,20 +5,27 @@
   :css
     .post {margin-bottom: 1em;}
     .iconcol {width: 48px;}
+    .namecol {width: 100px;}
+    .bodycol {width: 650px;}
+    .bodycol p:first-child:before {content: '\201C \0020';font-size: 160%;color: #ddd;}
+    .morecol {width: 100px;}
+    .morecol p:first-child:before {content: '\201C \0020';font-size: 160%;visibility: hidden;}
 .container
   .row
     #pageheader.col-md-12
       %h2= t(:everyone_journal_posts)
-  #post_search.row.stacked
-    .col-md-12
-      %h1= @title
-      = form_tag journal_search_path, method: :get, class: "form-search form-inline" do
-        .input-group
-          = text_field_tag :q, params[:q], placeholder: 'Find a journal post', class: "form-control"
-          .input-group-btn
-            = submit_tag t(:search), class: "btn btn-primary"
   .row
     .col-md-12
-      = render "posts/posts", posts: @posts, hard_truncate_length: 500
+      - if !@posts.blank?
+        - for post in @posts
+          .media
+            - if post.parent_type == "Project"
+              = link_to(image_tag(post.parent.icon.url(:thumb), :class => 'usericon media-object img-rounded'), project_journal_path(post.parent), :class => "pull-left")
+            - else
+              = link_to(image_tag(post.user.icon.url(:thumb), :class => 'usericon media-object'), journal_by_login_path(post.user.login), :class => "pull-left")
+            .media-body
+              = render "posts/post", post: post, hard_truncate_length: 500
+      - else
+        #noposts.description= t(:no_one_posted_anything_yet)
       - if @posts.total_entries > @posts.size
         = link_to t(:more), url_for( from: @posts.last.id ), class: "btn btn-default"

--- a/app/views/posts/index.atom.builder
+++ b/app/views/posts/index.atom.builder
@@ -1,5 +1,5 @@
 atom_feed({"xmlns"        => "http://www.w3.org/2005/Atom"}) do |feed|
-  feed.title("#{@site.name}: Journal by #{@parent_display_name}")
+  feed.title("#{@site.name}: Journal by #{@parent.journal_display_name}")
   feed.updated(@posts.first.created_at) unless @posts.empty?
   feed.icon(image_path('favicon.png'))
   

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title) do
-  =raw t(:x_journal, user: @parent_display_name)
+  =raw t(:x_journal, user: @parent.journal_display_name)
 - content_for(:extracss) do
   = stylesheet_link_tag "posts"
   %style{:media => "screen", :type => "text/css"}
@@ -22,11 +22,11 @@
               = t(:no_post_yet)
               %br
               - if (@parent.is_a?(Project) && @display_project.editable_by?(current_user))
-                = link_to t(:add_one), new_project_journal_post_path(@parent_slug), |
-                  :id => "newpostbutton", :class => "default button"                |
-              - elsif logged_in? && current_user.login == @parent_display_name
-                = link_to t(:add_one), new_journal_post_path(@parent_slug), |
-                  :class => "default button"                                |
+                = link_to t(:add_one), new_project_journal_post_path(@parent.journal_slug), |
+                  id: "newpostbutton", class: "default button"                |
+              - elsif logged_in? && current_user.login == @parent.journal_display_name
+                = link_to t(:add_one), new_journal_post_path(@parent.journal_slug), |
+                  class: "default button"                                |
       = will_paginate @posts
     .col-md-4
       - unless @drafts.blank?

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -29,18 +29,23 @@
                   class: "default button"                                |
       = will_paginate @posts
     .col-md-4
-      - unless @drafts.blank?
-        .box
-          %h3= t(:drafts)
-          %ul
-            - for post in @drafts
-              %li
-                = link_to post.title, edit_post_path(post)
-                %div
-                  %span.text-muted= t(:created_on, gender: 'post')
-                  %span.date= l post.created_at, format: :long
-      - unless @archives.blank?
-        = render :partial => 'archives'
+      - unless @posts.empty?
+        .row
+          %h2.right
+            = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
+      .row
+        - unless @drafts.blank?
+          .box
+            %h3= t(:drafts)
+            %ul
+              - for post in @drafts
+                %li
+                  = link_to post.title, edit_post_path(post)
+                  %div
+                    %span.text-muted= t(:created_on, gender: 'post')
+                    %span.date= l post.created_at, format: :long
+        - unless @archives.blank?
+          = render :partial => 'archives'
   - unless @posts.empty? && @parent.is_a?(Project) && @parent.is_new_project?
     #footercol.row
       .feeds

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -7,22 +7,7 @@
     #footercol .feeds {text-align: right;}
 
 .container
-  - if @parent.is_a?(Project) && @parent.is_new_project?
-    .row.project-back
-      .col-md-12
-        %a{ href: project_path( @parent ) }
-          %i.fa.fa-angle-left
-          = t( :back_to_x, noun: @parent.title )
-    .row
-      .col-md-12
-        - title = t( :x_project_journal, project: strip_tags( @parent.title ), name: t( :journal ) )
-        %h1= title
-        - if @display_project.curated_by?(current_user)
-          = link_to t(:new_post), new_project_journal_post_path(@parent_slug), |
-            :id => "newpostbutton", :class => "default button"                 |
-  - else
-    .row
-      = render :partial => "posts/header"
+  = render :partial => "posts/header"
   .row
     .col-md-8
       #postdates.posts_by_date

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title) do
-  =raw t( :x_journal_new_post, user: @parent_display_name )
+  =raw t( :x_journal_new_post, user: @parent.journal_display_name )
 - content_for(:extracss) do
   = stylesheet_link_tag "posts"
 - content_for(:extrajs) do

--- a/app/views/posts/search.html.haml
+++ b/app/views/posts/search.html.haml
@@ -1,5 +1,5 @@
 - content_for :title do
-  = @title = "#{t(:find_posts_for)} #{@parent_display_name}"
+  = @title = "#{t(:find_posts_for)} #{@parent.journal_display_name}"
 - content_for(:extracss) do
   = stylesheet_link_tag "posts"
   :css
@@ -8,7 +8,7 @@
 .container
   %ul.breadcrumb
     %li
-      = link_to t(:journal_posts), parent_path(@parent)
+      = link_to t(:journal_posts), @parent.journal_path
       %li.active=t :search
   .row
     .col-xs-12

--- a/app/views/posts/search.html.haml
+++ b/app/views/posts/search.html.haml
@@ -1,24 +1,24 @@
-- content_for(:title) do
-  =raw t(:everyone_journal_posts)
+- content_for :title do
+  = @title = t(:find_journal_posts)
 - content_for(:extracss) do
   = stylesheet_link_tag "posts"
   :css
     .post {margin-bottom: 1em;}
     .iconcol {width: 48px;}
 .container
-  .row
-    #pageheader.col-md-12
-      %h2= t(:everyone_journal_posts)
+  %ul.breadcrumb
+    %li
+      = link_to t(:journal_posts), journals_path
+      %li.active=t :search
   #post_search.row.stacked
-    .col-md-12
+    .col-xs-12
       %h1= @title
       = form_tag journal_search_path, method: :get, class: "form-search form-inline" do
         .input-group
-          = text_field_tag :q, params[:q], placeholder: 'Find a journal post', class: "form-control"
+          = text_field_tag :q, params[:q], placeholder: t(:find_a_journal_post), class: "form-control"
           .input-group-btn
             = submit_tag t(:search), class: "btn btn-primary"
   .row
     .col-md-12
       = render "posts/posts", posts: @posts, hard_truncate_length: 500
-      - if @posts.total_entries > @posts.size
-        = link_to t(:more), url_for( from: @posts.last.id ), class: "btn btn-default"
+      = will_paginate @posts

--- a/app/views/posts/search.html.haml
+++ b/app/views/posts/search.html.haml
@@ -1,5 +1,5 @@
 - content_for :title do
-  = @title = "#{t(:find_posts_for)} #{@parent.journal_display_name}"
+  = @title = t( :find_posts_for, vow_or_con: @parent.journal_display_name[0].downcase, journal_name: @parent.journal_display_name )
 - content_for(:extracss) do
   = stylesheet_link_tag "posts"
   :css

--- a/app/views/posts/search.html.haml
+++ b/app/views/posts/search.html.haml
@@ -1,5 +1,5 @@
 - content_for :title do
-  = @title = t(:find_journal_posts)
+  = @title = "#{t(:find_posts_for)} #{@parent_display_name}"
 - content_for(:extracss) do
   = stylesheet_link_tag "posts"
   :css
@@ -8,16 +8,13 @@
 .container
   %ul.breadcrumb
     %li
-      = link_to t(:journal_posts), journals_path
+      = link_to t(:journal_posts), parent_path(@parent)
       %li.active=t :search
-  #post_search.row.stacked
+  .row
     .col-xs-12
-      %h1= @title
-      = form_tag journal_search_path, method: :get, class: "form-search form-inline" do
-        .input-group
-          = text_field_tag :q, params[:q], placeholder: t(:find_a_journal_post), class: "form-control"
-          .input-group-btn
-            = submit_tag t(:search), class: "btn btn-primary"
+      #post_header
+        %h1= @title
+        = render partial: 'search_form', locals: { parent_type: @parent.class.name, parent_id: @parent.id }
   .row
     .col-md-12
       = render "posts/posts", posts: @posts, hard_truncate_length: 500

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title) do
-  = t(:x_journal_middot, :user => @parent_display_name).html_safe
+  = t(:x_journal_middot, user: @parent.journal_display_name).html_safe
   = @title = @post.title
 - content_for(:extracss) do
   = stylesheet_link_tag "lists", "posts/show"
@@ -32,9 +32,9 @@
       - if @parent.is_a?(Project)
         = render :partial => 'shared/prevnext', :locals => {                                  |
             :prev_item => @previous,                                                          |
-            :prev_url => @previous ? project_journal_post_path(@parent_slug, @previous) : '', |
+            :prev_url => @previous ? project_journal_post_path(@parent.journal_slug, @previous) : '', |
             :next_item => @next,                                                              |
-            :next_url => @next ? project_journal_post_path(@parent_slug, @next) : ''          |
+            :next_url => @next ? project_journal_post_path(@parent.journal_slug, @next) : ''          |
           }
       - elsif @parent.is_a?( Site )
         = render partial: 'shared/prevnext', locals: {
@@ -56,7 +56,7 @@
         = @post.title
       - if (@parent.is_a?(Project) && logged_in? && @display_project.editable_by?(current_user))
         #tools.buttonrow
-          = link_to t(:edit), edit_project_journal_post_path(:project_id => @parent_slug, :id => @post.id), |
+          = link_to t(:edit), edit_project_journal_post_path(project_id: @parent.journal_slug, id: @post.id), |
             :id => "edit_post_button", :class => "button"                                                   |
           -#
           = link_to t(:delete), delete_project_journal_post_path(@parent, @post), |
@@ -66,8 +66,8 @@
             :class => "minor delete button"                                       |
       - elsif logged_in? && current_user.id == @post.user_id
         #tools.buttonrow
-          = link_to t(:edit), edit_journal_post_path(:login => @parent_slug, :id => @post.id), |
-            :id => "edit_post_button", :class => "button"                                      |
+          = link_to t(:edit), edit_journal_post_path(login: @parent.journal_slug, id: @post.id), |
+            id: "edit_post_button", class: "button"                                      |
           -#
           = link_to t(:delete), post_path(@post),                      |
             :data => {:confirm => t(:are_you_sure_you_want_to_delete_this_post)}, |

--- a/app/views/shared/_by_project_header_bootstrap.html.haml
+++ b/app/views/shared/_by_project_header_bootstrap.html.haml
@@ -1,6 +1,6 @@
 :ruby
   model_name ||= controller.class.to_s.underscore.humanize.split.first
-  title ||= t(:x_project_journal, :project => strip_tags(@parent_display_name), :name => t(model_name.downcase, :default => model_name))
+  title ||= t(:x_project_journal, :project => strip_tags(project.journal_display_name), :name => t(model_name.downcase, :default => model_name))
   before ||= nil
   after ||= nil
   after_title ||= nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1958,10 +1958,10 @@ en:
   filters: Filters
   find: Find
   find_a_guide: Find a guide
-  find_a_journal_post: Find a journal post
+  find_a_post: Find a post
   find_a_place: Find a Place
   find_guides: Find Guides
-  find_journal_posts: Find Journal Posts
+  find_posts_for: Find Posts for
   find_new_place_to_explore: Find a new place to explore!
   find_observations: Find observations
   find_photos: Find Photos

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1958,8 +1958,10 @@ en:
   filters: Filters
   find: Find
   find_a_guide: Find a guide
+  find_a_journal_post: Find a journal post
   find_a_place: Find a Place
   find_guides: Find Guides
+  find_journal_posts: Find Journal Posts
   find_new_place_to_explore: Find a new place to explore!
   find_observations: Find observations
   find_photos: Find Photos

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1961,7 +1961,7 @@ en:
   find_a_post: Find a post
   find_a_place: Find a Place
   find_guides: Find Guides
-  find_posts_for: Find Posts for
+  find_posts_for: "Find Posts for: %{journal_name}"
   find_new_place_to_explore: Find a new place to explore!
   find_observations: Find observations
   find_photos: Find Photos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -499,7 +499,7 @@ Rails.application.routes.draw do
       get :for_user
     end
   end
-  get "/journal_search", to: "posts#search"
+  get "/posts/search", to: "posts#search"
   resources :posts,
     as: "journal_posts",
     path: "/journal/:login",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -499,6 +499,7 @@ Rails.application.routes.draw do
       get :for_user
     end
   end
+  get "/journal_search", to: "posts#search"
   resources :posts,
     as: "journal_posts",
     path: "/journal/:login",


### PR DESCRIPTION
#3540

- Add pg ilike search to `posts.title` and `posts.body`
- Add search form to `/journal` (browse)
- Add post search results page which shows results, paginated

## Browse:
![image](https://user-images.githubusercontent.com/19367605/200447385-046670c6-39b1-48cf-9bb7-fef070e04ec1.png)

## Results:
![image](https://user-images.githubusercontent.com/19367605/200447468-010a99ba-29eb-4051-b518-f820ecde2cc9.png)

![image](https://user-images.githubusercontent.com/19367605/200447504-5562af37-b725-4bd9-b3ae-de3f389e3dcb.png)
