### PR TITLE
Add translation

### DIFF
--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,5 +1,6 @@
 <%- 
   parent ||= comments
+  parent_comments_disabled ||= parent && parent.respond_to?(:prefers_no_comments?) && parent.prefers_no_comments?
   hide_form ||= false
   hide_form = true if current_user && current_user.blocked_by?( parent.try(:user) )
   remote ||= nil 
@@ -12,7 +13,7 @@
     end
   end
 -%>
-<% if parent && parent.respond_to?(:prefers_no_comments?) && parent.prefers_no_comments? && comments.blank? %>
+<% if parent_comments_disabled && comments.blank? %>
 <%# Just don't show anything if there's nothing to show %>
 <% else %>
   <%= content_tag header_tag do %>
@@ -20,10 +21,12 @@
   <% end -%>
   <% for comment in comments.sort {|a,b| a.created_at <=> b.created_at } %>
     <div class="<%= cycle('odd', 'even') %>">
-      <%= render :partial => 'shared/activity_item', :object => comment %>
+      <%= render partial: 'shared/activity_item',
+                 object: comment,
+                 locals: { parent_comments_disabled: parent_comments_disabled } %>
     </div>
   <%- end -%>
-  <% if parent && parent.respond_to?(:prefers_no_comments?) && parent.prefers_no_comments? %>
+  <% if parent_comments_disabled %>
     <div class="text-muted noresults"><%=t :comments_have_been_disabled %></div>
   <% elsif comments.empty? %>
     <div class="text-muted noresults"><%=t :no_comments_yet %></div>

--- a/app/views/shared/_activity_item.html.erb
+++ b/app/views/shared/_activity_item.html.erb
@@ -117,7 +117,7 @@
         <span class="comment_actions">
           <%-
             pieces = []
-            if is_me?(item.user) && edit_url
+            if is_me?(item.user) && edit_url && !parent_comments_disabled
               pieces << link_to(t(:edit), edit_url)
             end
             if item.is_a?( Identification ) && is_me?( item.user )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8815,6 +8815,13 @@ en:
               has_query_parameter: "cannot contain a query parameter."
               invalid_uri: "must be a valid URI."
               relative_uri: "must be an absolute URI."
+        comment:
+          attributes:
+            parent:
+              # Error message shown when a client tries to create a comment on a
+              # post that does not allow comments. Theoretically an end user
+              # should never see this, though an API client might.
+              prefers_no_comments: does not allow new comments
         flag:
           attributes:
             flag:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8821,7 +8821,7 @@ en:
               # Error message shown when a client tries to create a comment on a
               # post that does not allow comments. Theoretically an end user
               # should never see this, though an API client might.
-              prefers_no_comments: does not allow new comments
+              prefers_no_comments: has disabled comments
         flag:
           attributes:
             flag:


### PR DESCRIPTION
#3418 

Adds the translation.

Alternatively, we could add a message here: 
```rb
# app/models/comment.rb:118
errors.add( :parent, :prefers_no_comments,  I18n.t(:prefers_no_comment))
```
and reference the existing post translation, though I feel that's less explicit.

Side-note/question:

Should comments made prior to marking the post as non-comment-able be visible at all? (see edit screenshot) 
It's not really a "new comment" either...

## post
![image](https://user-images.githubusercontent.com/19367605/201543676-1052e325-638e-42d1-b549-398b0d9880f0.png)

## edit 
![image](https://user-images.githubusercontent.com/19367605/201543697-5e69e844-60d7-4aeb-81be-43be41950042.png)
