### PR TITLE
Fix ticks for streaks chart in YIR

### DIFF
--- a/app/models/year_statistic.rb
+++ b/app/models/year_statistic.rb
@@ -240,7 +240,7 @@ class YearStatistic < ApplicationRecord
         histogram: {
           date_histogram: {
             field: "created_at",
-            interval: interval,
+            calendar_interval: interval,
             format: "yyyy-MM-dd",
             time_zone: time_zone_for_options( options )
           }
@@ -954,7 +954,7 @@ class YearStatistic < ApplicationRecord
         histogram: {
           date_histogram: {
             field: date_field,
-            interval: interval,
+            calendar_interval: interval,
             format: "yyyy-MM-dd",
             time_zone: time_zone_for_options( params )
           },
@@ -1131,7 +1131,7 @@ class YearStatistic < ApplicationRecord
         histogram: {
           date_histogram: {
             field: "created_at_details.date",
-            interval: "month",
+            calendar_interval: "month",
             format: "yyyy-MM-dd",
             time_zone: time_zone_for_options( options )
           }

--- a/app/webpack/stats/year/components/streaks.jsx
+++ b/app/webpack/stats/year/components/streaks.jsx
@@ -6,7 +6,9 @@ import {
   scaleLinear,
   min as d3min,
   max as d3max,
+  timeMonth,
   timeFormatLocale,
+  timeYear,
   interpolateWarm
 } from "d3";
 import moment from "moment";
@@ -36,7 +38,12 @@ const Streaks = ( {
   const scale = scaleTime( )
     .domain( dates )
     .range( [0, 1.0] );
-  const ticks = scale.ticks( ( ( year - startYear + 1 ) * 12 ) );
+  let ticks = scale.ticks( timeMonth.every( 1 ) );
+  if ( ticks.length > 24 ) ticks = scale.ticks( timeYear.every( 1 ) );
+  let dateFormat = "MMM";
+  if ( multiYear ) {
+    dateFormat = ticks.length > 24 ? "YYYY" : "MMM 'YY";
+  }
   const days = data.map( d => d.days );
   const dayScale = scaleLog( )
     .domain( [d3min( days ), d3max( days )] )
@@ -92,7 +99,7 @@ const Streaks = ( {
                     width: `${tickWidth * 100}%`
                   }}
                 >
-                  { moment( tick ).format( multiYear ? "MMM 'YY" : "MMM" ) }
+                  { moment( tick ).format( dateFormat ) }
                 </div>
               );
             } ) }

--- a/app/webpack/stats/year/components/streaks.jsx
+++ b/app/webpack/stats/year/components/streaks.jsx
@@ -39,10 +39,10 @@ const Streaks = ( {
     .domain( dates )
     .range( [0, 1.0] );
   let ticks = scale.ticks( timeMonth.every( 1 ) );
-  if ( ticks.length > 24 ) ticks = scale.ticks( timeYear.every( 1 ) );
-  let dateFormat = "MMM";
-  if ( multiYear ) {
-    dateFormat = ticks.length > 24 ? "YYYY" : "MMM 'YY";
+  let dateFormat = ticks.length > 12 ? "MMM 'YY" : "MMM";
+  if ( ticks.length > 24 ) {
+    ticks = scale.ticks( timeYear.every( 1 ) );
+    dateFormat = "YYYY";
   }
   const days = data.map( d => d.days );
   const dayScale = scaleLog( )


### PR DESCRIPTION
Previously it was showing overlapping text for multi-year streaks.

Part of #3553