### PR TITLE
Replace FakeView url helpers in models

### DIFF
--- a/app/models/guide_section.rb
+++ b/app/models/guide_section.rb
@@ -146,7 +146,7 @@ class GuideSection < ApplicationRecord
   def reuse
     gs = clone
     gs.rights_holder = attribution_name
-    gs.source_url = FakeView.guide_taxon_url(guide_taxon_id)
+    gs.source_url = UrlHelper.guide_taxon_url guide_taxon_id
     gs
   end
 

--- a/app/models/guide_section.rb
+++ b/app/models/guide_section.rb
@@ -146,7 +146,7 @@ class GuideSection < ApplicationRecord
   def reuse
     gs = clone
     gs.rights_holder = attribution_name
-    gs.source_url = UrlHelper.guide_taxon_url guide_taxon_id
+    gs.source_url = UrlHelper.guide_taxon_url( guide_taxon_id )
     gs
   end
 

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -181,9 +181,8 @@ class List < ApplicationRecord
     key
   end
 
-  def self.icon_preview_cache_key(list)
-    list_id = list.is_a?(List) ? list.id : list
-    FakeView.icon_preview_list_url( list_id, locale: I18n.locale )
+  def self.icon_preview_cache_key( list )
+    list_id = list.is_a?( List ) ? list.id : list
+    UrlHelper.icon_preview_list_url list_id, locale: I18n.locale
   end
-
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -183,6 +183,6 @@ class List < ApplicationRecord
 
   def self.icon_preview_cache_key( list )
     list_id = list.is_a?( List ) ? list.id : list
-    UrlHelper.icon_preview_list_url list_id, locale: I18n.locale
+    UrlHelper.icon_preview_list_url( list_id, locale: I18n.locale )
   end
 end

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -756,11 +756,11 @@ class ListedTaxon < ApplicationRecord
       end
     end
     if list
-      ctrl.expire_page UrlHelper.list_path list_id, format: "csv"
-      ctrl.expire_page UrlHelper.list_show_formatted_view_path list_id, format: "csv", view_type: "taxonomic"
-      ctrl.expire_page UrlHelper.list_path list, format: "csv"
-      ctrl.expire_page UrlHelper.list_show_formatted_view_path list, format: "csv", view_type: "taxonomic"
-      ctrl.expire_fragment List.icon_preview_cache_key( list_id )
+      ctrl.expire_page( UrlHelper.list_path( list_id, format: "csv" ) )
+      ctrl.expire_page( UrlHelper.list_show_formatted_view_path( list_id, format: "csv", view_type: "taxonomic" ) )
+      ctrl.expire_page( UrlHelper.list_path( list, format: "csv" ) )
+      ctrl.expire_page( UrlHelper.list_show_formatted_view_path( list, format: "csv", view_type: "taxonomic" ) )
+      ctrl.expire_fragment( List.icon_preview_cache_key( list_id ) )
       ListedTaxon::ORDERS.each do |order|
         ctrl.expire_fragment( UrlHelper.url_for( controller: "observations", action: "add_from_list", id: list_id,
           order: order ) )

--- a/app/models/listed_taxon.rb
+++ b/app/models/listed_taxon.rb
@@ -109,9 +109,9 @@ class ListedTaxon < ApplicationRecord
     order( Arel.sql( "taxa.ancestry || '/' || listed_taxa.taxon_id, listed_taxa.observations_count" ) )
   }
   scope :with_species, -> { joins(:taxon).where(taxa: { rank_level: 10 }) }
-  
+
   scope :excluding_infraspecies, -> { joins(:taxon).where("taxa.rank_level >= 10 ") }
-  
+
   #with taxonomic status (by itself)
   scope :with_taxonomic_status, ->(taxonomic_status) {
     # this would be a better way to do this, but it causes Rails 4 to freak when it gets nested in a subselect
@@ -167,7 +167,7 @@ class ListedTaxon < ApplicationRecord
     # among the ancestors, i.e. it is a leaf
     excluding_infraspecies.joins(join).where("ancestor_ids.ancestor_id IS NULL")
   }
-  
+
   ALPHABETICAL_ORDER = "alphabetical"
   TAXONOMIC_ORDER = "taxonomic"
   ORDERS = [ALPHABETICAL_ORDER, TAXONOMIC_ORDER]
@@ -184,11 +184,11 @@ class ListedTaxon < ApplicationRecord
   OCCURRENCE_STATUS_DESCRIPTIONS = ActiveSupport::OrderedHash.new
   OCCURRENCE_STATUS_DESCRIPTIONS["present" ] =  "occurs in the area"
   OCCURRENCE_STATUS_DESCRIPTIONS["common" ] =  "occurs frequently"
-  OCCURRENCE_STATUS_DESCRIPTIONS["uncommon" ] =  "occurs regularly, but in small numbers; requires careful searching of proper habitat" 
+  OCCURRENCE_STATUS_DESCRIPTIONS["uncommon" ] =  "occurs regularly, but in small numbers; requires careful searching of proper habitat"
   OCCURRENCE_STATUS_DESCRIPTIONS["irregular" ] =  "presence unpredictable, including vagrants; may be common in some years and absent others"
   OCCURRENCE_STATUS_DESCRIPTIONS["doubtful" ] =  "presumed to occur, but doubt exists over the evidence"
   OCCURRENCE_STATUS_DESCRIPTIONS["absent" ] =  "does not occur in the area"
-  
+
   OCCURRENCE_STATUS_LEVELS.each do |level, name|
     const_set name.upcase, level
     define_method "#{name}?" do
@@ -205,7 +205,7 @@ class ListedTaxon < ApplicationRecord
       establishment_means == means
     end
   end
-  
+
   NATIVE_EQUIVALENTS = %w(native endemic)
   INTRODUCED_EQUIVALENTS = %w(introduced)
   CHECK_LIST_FIELDS = %w(place_id occurrence_status establishment_means)
@@ -233,19 +233,19 @@ class ListedTaxon < ApplicationRecord
                 :old_list,
                 :force_trickle_down_establishment_means,
                 :skip_index_taxon
-  
+
   def ancestry
     taxon.ancestry
   end
-  
+
   def to_s
     "<ListedTaxon #{self.id}: taxon_id: #{self.taxon_id} list_id: #{self.list_id} place_id: #{place_id}>"
   end
-  
+
   def to_plain_s
     "#{taxon.default_name.name} on #{list.title}"
   end
-  
+
   def not_on_a_comprehensive_check_list
     return true unless taxon
     return true unless list.is_a?(CheckList)
@@ -257,7 +257,7 @@ class ListedTaxon < ApplicationRecord
     end
     true
   end
-  
+
   def existing_comprehensive_list
     return nil unless list.is_a?(CheckList)
     return @existing_comprehensive_list unless @existing_comprehensive_list.blank?
@@ -267,15 +267,15 @@ class ListedTaxon < ApplicationRecord
     end
     places.compact!
     @existing_comprehensive_list = CheckList.where([
-      "comprehensive = 't' AND id != ? AND taxon_id IN (?) AND place_id IN (?)", 
+      "comprehensive = 't' AND id != ? AND taxon_id IN (?) AND place_id IN (?)",
       list_id, taxon.ancestor_ids, places]).first
   end
-  
+
   def existing_comprehensive_listed_taxon
     return nil unless existing_comprehensive_list
     @existing_listed_taxon ||= existing_comprehensive_list.listed_taxa.where(taxon_id: taxon_id).first
   end
-  
+
   def absent_only_if_not_confirming_observations
     return true unless occurrence_status_level_changed?
     return true unless absent?
@@ -288,7 +288,7 @@ class ListedTaxon < ApplicationRecord
   def list_rules_pass
     # don't bother if validates_presence_of(:taxon) has already failed
     if !errors.include?(:taxon) && taxon
-      if list 
+      if list
         list.rules.each do |rule|
           if rule.operator == "observed_in_place?" && manually_added?
             next
@@ -303,8 +303,8 @@ class ListedTaxon < ApplicationRecord
     return false if taxon.blank?
     if last_observation
       if last_observation.taxon_id.blank? || !(
-          taxon_id == last_observation.taxon_id || 
-          taxon.ancestor_of?(last_observation.taxon) || 
+          taxon_id == last_observation.taxon_id ||
+          taxon.ancestor_of?(last_observation.taxon) ||
           last_observation.taxon.ancestor_of?(taxon))
         if taxon_matches_curator_identification? #cases where project listed_taxon is based on curator_id
           return true
@@ -313,7 +313,7 @@ class ListedTaxon < ApplicationRecord
       end
     end
   end
-  
+
   def taxon_matches_curator_identification?
     unless list.is_a?(ProjectList) && last_observation
       return false
@@ -325,14 +325,14 @@ class ListedTaxon < ApplicationRecord
       return false
     end
     if ident.taxon_id.blank? || !(
-        taxon_id == ident.taxon_id || 
-        taxon.ancestor_of?(ident.taxon) || 
+        taxon_id == ident.taxon_id ||
+        taxon.ancestor_of?(ident.taxon) ||
         ident.taxon.ancestor_of?(taxon))
       return false
     end
     return true
   end
-  
+
   def check_list_editability
     if list.is_a?(CheckList)
       if (list.comprehensive? || list.user) && user && user != list.user && !user.is_curator?
@@ -352,26 +352,26 @@ class ListedTaxon < ApplicationRecord
     end
     true
   end
-  
+
   def set_old_list
     @old_list = self.list
   end
-  
+
   def set_user_id
     self.user_id ||= list.user_id if list
     true
   end
-  
+
   def set_source_id
     self.source_id ||= list.source_id if list
     true
   end
-  
+
   def set_updater_id
     self.updater_id ||= user_id
     true
   end
-  
+
   def set_place_id
     self.place_id = self.list.place_id if list.is_a?(CheckList)
     true
@@ -400,7 +400,7 @@ class ListedTaxon < ApplicationRecord
     self.primary_listing = false unless can_set_as_primary?
     true
   end
-  
+
   def sync_parent_check_list
     return true unless list.is_a?(CheckList)
     return true if skip_sync_with_parent
@@ -409,7 +409,7 @@ class ListedTaxon < ApplicationRecord
       sync_with_parent(:time_since_last_sync => updated_at)
     true
   end
-  
+
   def sync_species_if_infraspecies
     return true if skip_species_for_infraspecies
     return true unless list.is_a?(CheckList) && taxon
@@ -435,7 +435,7 @@ class ListedTaxon < ApplicationRecord
     set_cache_columns
     true
   end
-  
+
   def set_cache_columns
     return unless taxon_id
     if cc = cache_columns
@@ -443,7 +443,7 @@ class ListedTaxon < ApplicationRecord
       self.observations_count = cc
     end
   end
-  
+
   def update_cache_columns_for_check_list
     return true if skip_update_cache_columns
     return true unless list.is_a?(CheckList)
@@ -490,7 +490,7 @@ class ListedTaxon < ApplicationRecord
     SQL
     ActiveRecord::Base.connection.execute(sql)
   end
-  
+
   def has_atlas_or_complete_set?(options = {})
     return false unless list.is_a?( CheckList ) && list.is_default?
     return false unless [Place::COUNTRY_LEVEL, Place::STATE_LEVEL, Place::COUNTY_LEVEL].include? place.admin_level
@@ -514,7 +514,7 @@ class ListedTaxon < ApplicationRecord
     return true if cs > 0
     false
   end
-  
+
   def log_create
     if has_atlas_or_complete_set?
       ListedTaxonAlteration.create(
@@ -525,7 +525,7 @@ class ListedTaxon < ApplicationRecord
       )
     end
   end
-  
+
   def log_destroy
     if has_atlas_or_complete_set?
       updater_id = updater.nil? ? nil : updater.id
@@ -537,7 +537,7 @@ class ListedTaxon < ApplicationRecord
       )
     end
   end
-  
+
   def log_create_if_taxon_id_changed
     return true unless saved_change_to_taxon_id?
     return true if taxon_id_before_last_save.nil?
@@ -635,7 +635,7 @@ class ListedTaxon < ApplicationRecord
       last_observation_id: lt.last_observation_id,
       observations_count: lt.observations_count)
   end
-  
+
   def self.species_for_infraspecies(lt)
     lt = ListedTaxon.includes(:taxon,:place).find_by_id(lt) unless lt.is_a?(ListedTaxon)
     return nil unless lt
@@ -672,7 +672,7 @@ class ListedTaxon < ApplicationRecord
     end
     true
   end
-  
+
   def occurrence_status
     OCCURRENCE_STATUS_LEVELS[occurrence_status_level]
   end
@@ -688,11 +688,11 @@ class ListedTaxon < ApplicationRecord
   def is_absent?
     !is_present?
   end
-  
+
   def editable_by?(target_user)
     list.editable_by?(target_user)
   end
-  
+
   def removable_by?(target_user)
     return false unless target_user
     return true if user == target_user
@@ -701,36 +701,36 @@ class ListedTaxon < ApplicationRecord
     return true if citation_object.blank?
     citation_object == target_user
   end
-  
+
   def citation_object
     source || taxon_range || first_observation || last_observation || user
   end
-  
+
   def auto_removable_from_check_list?
     list.is_a?(CheckList) &&
       first_observation_id.blank? &&
       last_observation_id.blank? &&
       taxon_range_id.blank? &&
       source_id.blank? &&
-      !user_id && 
-      !updater_id && 
+      !user_id &&
+      !updater_id &&
       comments_count.to_i == 0 &&
       list.is_default? &&
       !has_atlas_or_complete_set?
   end
-  
+
   def introduced?
     INTRODUCED_EQUIVALENTS.include?(establishment_means)
   end
-  
+
   def native?
     NATIVE_EQUIVALENTS.include?(establishment_means)
   end
-  
+
   def endemic?
     establishment_means == "endemic"
   end
-  
+
   def taxon_name
     taxon.name
   end
@@ -746,21 +746,24 @@ class ListedTaxon < ApplicationRecord
   def expire_caches
     ctrl = ActionController::Base.new
     if !place_id.blank? && manually_added && list.is_a?( CheckList )
-      I18N_SUPPORTED_LOCALES.each do |locale|
-        ctrl.send( :expire_action, FakeView.url_for( controller: "places", action: "cached_guide", id: place_id, locale: locale ) )
+      I18N_SUPPORTED_LOCALES.each do | locale |
+        ctrl.send( :expire_action, UrlHelper.url_for( controller: "places", action: "cached_guide", id: place_id,
+          locale: locale ) )
         if place && !place.slug.blank?
-          ctrl.send( :expire_action, FakeView.url_for( controller: "places", action: "cached_guide", id: place.slug, locale: locale ) )
+          ctrl.send( :expire_action, UrlHelper.url_for( controller: "places", action: "cached_guide", id: place.slug,
+            locale: locale ) )
         end
       end
     end
     if list
-      ctrl.expire_page FakeView.list_path(list_id, :format => 'csv')
-      ctrl.expire_page FakeView.list_show_formatted_view_path(list_id, :format => 'csv', :view_type => 'taxonomic')
-      ctrl.expire_page FakeView.list_path(list, :format => 'csv')
-      ctrl.expire_page FakeView.list_show_formatted_view_path(list, :format => 'csv', :view_type => 'taxonomic')
-      ctrl.expire_fragment(List.icon_preview_cache_key(list_id))
+      ctrl.expire_page UrlHelper.list_path list_id, format: "csv"
+      ctrl.expire_page UrlHelper.list_show_formatted_view_path list_id, format: "csv", view_type: "taxonomic"
+      ctrl.expire_page UrlHelper.list_path list, format: "csv"
+      ctrl.expire_page UrlHelper.list_show_formatted_view_path list, format: "csv", view_type: "taxonomic"
+      ctrl.expire_fragment List.icon_preview_cache_key( list_id )
       ListedTaxon::ORDERS.each do |order|
-        ctrl.expire_fragment(FakeView.url_for(:controller => 'observations', :action => 'add_from_list', :id => list_id, :order => order))
+        ctrl.expire_fragment( UrlHelper.url_for( controller: "observations", action: "add_from_list", id: list_id,
+          order: order ) )
       end
     end
     true
@@ -773,7 +776,7 @@ class ListedTaxon < ApplicationRecord
       lt.expire_caches
     end
   end
-  
+
   def merge(reject)
     mutable_columns = self.class.column_names - %w(id created_at updated_at)
     mutable_columns.each do |column|
@@ -790,7 +793,7 @@ class ListedTaxon < ApplicationRecord
     scope = Observation.joins(:observations_places).where("observations_places.place_id = ?", p).of(taxon)
     scope.exists?
   end
-  
+
   def self.merge_duplicates(options = {})
     debug = options.delete(:debug)
     where = options.map{|k,v| "#{k} = #{v}"}.join(' AND ') unless options.blank?
@@ -809,7 +812,7 @@ class ListedTaxon < ApplicationRecord
 
       # remove the rejects from the list before merging to avoid alread-on-list validation errors
       ListedTaxon.where(id: rejects).update_all(list_id: nil)
-      
+
       rejects.each do |reject|
         begin
           lt.merge( reject )
@@ -857,13 +860,13 @@ class ListedTaxon < ApplicationRecord
     scope = scope.where("id != ?", id) if id
     scope.count > 0
   end
-  
+
   def multiple_primary_listed_taxa?
     scope = ListedTaxon.where( taxon_id: taxon_id, place_id: place_id, primary_listing: true )
     scope = scope.where("id != ?", id) if id
     scope.count > 1
   end
-  
+
   def primary_listed_taxon
     primary_listing ? self : ListedTaxon.where( taxon_id: taxon_id, place_id: place_id, primary_listing: true ).first
   end
@@ -876,14 +879,14 @@ class ListedTaxon < ApplicationRecord
   def can_set_as_primary?
     list && list.is_a?(CheckList)
   end
-  
+
   def remove_other_primary_listings
     return true unless primary_listing && multiple_primary_listed_taxa?
     ListedTaxon.where("taxon_id = ? AND place_id = ? AND id != ?",
       taxon_id, place_id, id).update_all(primary_listing: false)
     true
   end
-  
+
   def reassign_primary_listed_taxon
     return unless primary_listing
     related_listed_taxon = related_listed_taxa.first
@@ -896,7 +899,7 @@ class ListedTaxon < ApplicationRecord
       related_listed_taxon.primary_listing = false
       related_listed_taxon.establishment_means = establishment_means
       related_listed_taxon.first_observation_id = first_observation_id
-      related_listed_taxon.last_observation_id = last_observation_id 
+      related_listed_taxon.last_observation_id = last_observation_id
       related_listed_taxon.observations_count = observations_count
       related_listed_taxon.occurrence_status_level = occurrence_status_level
       related_listed_taxon.skip_index_taxon = true

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2210,7 +2210,7 @@ class Observation < ApplicationRecord
 
   def set_uri
     if uri.blank?
-      Observation.where( id: id ).update_all uri: UrlHelper.observation_url( id )
+      Observation.where( id: id ).update_all( uri: UrlHelper.observation_url( id ) )
     end
     true
   end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2210,7 +2210,7 @@ class Observation < ApplicationRecord
 
   def set_uri
     if uri.blank?
-      Observation.where(id: id).update_all(uri: FakeView.observation_url(id))
+      Observation.where( id: id ).update_all uri: UrlHelper.observation_url( id )
     end
     true
   end

--- a/app/models/observation_sweeper.rb
+++ b/app/models/observation_sweeper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ObservationSweeper < ActionController::Caching::Sweeper
   begin
     observe Observation
@@ -5,27 +7,27 @@ class ObservationSweeper < ActionController::Caching::Sweeper
     puts "Database not connected, failed to observe Observation. Ignore if setting up for the first time"
   end
   include Shared::SweepersModule
-  
-  def after_create(observation)
-    FileUtils.rm(private_page_cache_path(
-      FakeView.observations_by_login_all_path(observation.user.login, :format => 'csv')
-    ), :force => true)
+
+  def after_create( observation )
+    FileUtils.rm( private_page_cache_path(
+      UrlHelper.observations_by_login_all_path( observation.user.login, format: "csv" )
+    ), force: true )
     true
   end
-  
-  def after_update(observation)
-    observation.listed_taxa.each {|lt| expire_listed_taxon(lt) }
-    FileUtils.rm(private_page_cache_path(
-      FakeView.observations_by_login_all_path(observation.user.login, :format => 'csv')
-    ), :force => true)
+
+  def after_update( observation )
+    observation.listed_taxa.each {| lt | expire_listed_taxon lt }
+    FileUtils.rm( private_page_cache_path(
+      UrlHelper.observations_by_login_all_path( observation.user.login, format: "csv" )
+    ), force: true )
     true
   end
-  
-  def after_destroy(observation)
-    observation.listed_taxa.each {|lt| expire_listed_taxon(lt) }
-    FileUtils.rm(private_page_cache_path(
-      FakeView.observations_by_login_all_path(observation.user.login, :format => 'csv')
-    ), :force => true)
+
+  def after_destroy( observation )
+    observation.listed_taxa.each {| lt | expire_listed_taxon lt }
+    FileUtils.rm( private_page_cache_path(
+      UrlHelper.observations_by_login_all_path( observation.user.login, format: "csv" )
+    ), force: true )
     true
   end
 end

--- a/app/models/observations_export_flow_task.rb
+++ b/app/models/observations_export_flow_task.rb
@@ -12,7 +12,7 @@ class ObservationsExportFlowTask < FlowTask
   class ObservationsExportDeleted < ObservationsExportError; end
 
   before_save do |record|
-    record.redirect_url = FakeView.export_observations_path
+    record.redirect_url = UrlHelper.export_observations_path
   end
 
   def must_have_query

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -55,7 +55,7 @@ class Photo < ApplicationRecord
     original =  file.url( :original )
     return unless original
     if original !~ /http/
-      original = FakeView.uri_join( FakeView.root_url, original ).to_s
+      original = FakeView.uri_join( UrlHelper.root_url, original ).to_s
     end
     if matches = original.match( /^(.*)\/#{id}\/original/ )
       return matches[1]
@@ -99,7 +99,7 @@ class Photo < ApplicationRecord
       return self.instance_variable_get("@remote_#{size}_url")
     end
     if processing?
-      return FakeView.uri_join( FakeView.root_url, LocalPhoto.new.file.url( size ) )
+      return FakeView.uri_join( UrlHelper.root_url, LocalPhoto.new.file.url( size ) )
     end
     "#{file_prefix.prefix}/#{id}/#{size}.#{file_extension.extension}"
   end

--- a/app/models/place_sweeper.rb
+++ b/app/models/place_sweeper.rb
@@ -23,9 +23,9 @@ class PlaceSweeper < ActionController::Caching::Sweeper
 
   def remove_geometry_page_cache( place )
     ctrl = ActionController::Base.new
-    ctrl.send :expire_page, UrlHelper.place_geometry_path( place, format: "kml" )
-    ctrl.send :expire_page, UrlHelper.place_geometry_path( place.id, format: "kml" )
-    ctrl.send :expire_page, UrlHelper.place_geometry_path( place, format: "geojson" )
-    ctrl.send :expire_page, UrlHelper.place_geometry_path( place.id, format: "geojson" )
+    ctrl.send( :expire_page, UrlHelper.place_geometry_path( place, format: "kml" ) )
+    ctrl.send( :expire_page, UrlHelper.place_geometry_path( place.id, format: "kml" ) )
+    ctrl.send( :expire_page, UrlHelper.place_geometry_path( place, format: "geojson" ) )
+    ctrl.send( :expire_page, UrlHelper.place_geometry_path( place.id, format: "geojson" ) )
   end
 end

--- a/app/models/place_sweeper.rb
+++ b/app/models/place_sweeper.rb
@@ -1,28 +1,31 @@
+# frozen_string_literal: true
+
 class PlaceSweeper < ActionController::Caching::Sweeper
   begin
     observe Place
   rescue ActiveRecord::NoDatabaseError
     puts "Database not connected, failed to observe Place. Ignore if setting up for the first time"
   end
-  
-  def after_update(place)
-    remove_geometry_page_cache(place)
+
+  def after_update( place )
+    remove_geometry_page_cache( place )
   end
-  
-  def after_destroy(place)
-    remove_geometry_page_cache(place)
+
+  def after_destroy( place )
+    remove_geometry_page_cache( place )
   end
-  
-  def after_merge(place)
-    remove_geometry_page_cache(place)
+
+  def after_merge( place )
+    remove_geometry_page_cache( place )
   end
-  
+
   private
-  def remove_geometry_page_cache(place)
+
+  def remove_geometry_page_cache( place )
     ctrl = ActionController::Base.new
-    ctrl.send(:expire_page, FakeView.place_geometry_path(place, :format => "kml"))
-    ctrl.send(:expire_page, FakeView.place_geometry_path(place.id, :format => "kml"))
-    ctrl.send(:expire_page, FakeView.place_geometry_path(place, :format => "geojson"))
-    ctrl.send(:expire_page, FakeView.place_geometry_path(place.id, :format => "geojson"))
+    ctrl.send :expire_page, UrlHelper.place_geometry_path( place, format: "kml" )
+    ctrl.send :expire_page, UrlHelper.place_geometry_path( place.id, format: "kml" )
+    ctrl.send :expire_page, UrlHelper.place_geometry_path( place, format: "geojson" )
+    ctrl.send :expire_page, UrlHelper.place_geometry_path( place.id, format: "geojson" )
   end
 end

--- a/app/models/project_observation.rb
+++ b/app/models/project_observation.rb
@@ -231,10 +231,13 @@ class ProjectObservation < ApplicationRecord
 
   def expire_caches
     return true if project_id.blank?
+
     begin
-      FileUtils.rm private_page_cache_path(FakeView.all_project_observations_path(project, :format => 'csv')), :force => true
+      FileUtils.rm( private_page_cache_path( UrlHelper.all_project_observations_path( project, format: "csv" ) ),
+        force: true )
     rescue ActionController::RoutingError, ActionController::UrlGenerationError
-      FileUtils.rm private_page_cache_path(FakeView.all_project_observations_path(project_id, :format => 'csv')), :force => true
+      FileUtils.rm( private_page_cache_path( UrlHelper.all_project_observations_path( project_id, format: "csv" ) ),
+        force: true )
     end
     true
   end

--- a/app/models/shared/sweepers_module.rb
+++ b/app/models/shared/sweepers_module.rb
@@ -17,12 +17,14 @@ module Shared::SweepersModule
     return unless taxon
     expire_listed_taxa(taxon)
     ctrl = ActionController::Base.new
-    ctrl.expire_fragment(FakeView.url_for(:controller => 'taxa', :action => 'photos', :id => taxon.id, :partial => "photo"))
-    I18N_SUPPORTED_LOCALES.each do |locale|
-      [true, false].each do |ssl|
-        ctrl.send( :expire_action, FakeView.url_for( controller: "taxa", action: "show", id: taxon.id, locale: locale, ssl: ssl ) )
-        ctrl.send( :expire_action, FakeView.url_for( controller: "taxa", action: "show", id: taxon.to_param, locale: locale, ssl: ssl ) )
-        ctrl.send( :expire_action, FakeView.taxon_path( id: taxon.id, locale: locale, format: "json" ) )
+    ctrl.expire_fragment UrlHelper.url_for( controller: "taxa", action: "photos", id: taxon.id, partial: "photo" )
+    I18N_SUPPORTED_LOCALES.each do | locale |
+      [true, false].each do | ssl |
+        ctrl.send( :expire_action, UrlHelper.url_for( controller: "taxa", action: "show", id: taxon.id, locale: locale,
+          ssl: ssl ) )
+        ctrl.send( :expire_action, UrlHelper.url_for( controller: "taxa", action: "show", id: taxon.to_param,
+          locale: locale, ssl: ssl ) )
+        ctrl.send( :expire_action, UrlHelper.taxon_path( id: taxon.id, locale: locale, format: "json" ) )
       end
     end
     Rails.cache.delete( taxon.photos_cache_key )

--- a/app/models/shared/sweepers_module.rb
+++ b/app/models/shared/sweepers_module.rb
@@ -17,7 +17,7 @@ module Shared::SweepersModule
     return unless taxon
     expire_listed_taxa(taxon)
     ctrl = ActionController::Base.new
-    ctrl.expire_fragment UrlHelper.url_for( controller: "taxa", action: "photos", id: taxon.id, partial: "photo" )
+    ctrl.expire_fragment( UrlHelper.url_for( controller: "taxa", action: "photos", id: taxon.id, partial: "photo" ) )
     I18N_SUPPORTED_LOCALES.each do | locale |
       [true, false].each do | ssl |
         ctrl.send( :expire_action, UrlHelper.url_for( controller: "taxa", action: "show", id: taxon.id, locale: locale,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -50,8 +50,7 @@ class Subscription < ApplicationRecord
 
   def clear_caches
     ctrl = ActionController::Base.new
-    ctrl.send :expire_action, FakeView.home_url( user_id: user_id, ssl: true )
-    ctrl.send :expire_action, FakeView.home_url( user_id: user_id, ssl: false )
+    ctrl.send :expire_action, UrlHelper.home_url( user_id: user_id, ssl: true )
+    ctrl.send :expire_action, UrlHelper.home_url( user_id: user_id, ssl: false )
   end
-
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -50,7 +50,7 @@ class Subscription < ApplicationRecord
 
   def clear_caches
     ctrl = ActionController::Base.new
-    ctrl.send :expire_action, UrlHelper.home_url( user_id: user_id, ssl: true )
-    ctrl.send :expire_action, UrlHelper.home_url( user_id: user_id, ssl: false )
+    ctrl.send( :expire_action, UrlHelper.home_url( user_id: user_id, ssl: true ) )
+    ctrl.send( :expire_action, UrlHelper.home_url( user_id: user_id, ssl: false ) )
   end
 end

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -476,7 +476,7 @@ class TaxonChange < ApplicationRecord
           user: user,
           change_group: (change_group || "#{self.class.name}-#{id}-children"),
           source: source,
-          description: "Automatically generated change from #{FakeView.taxon_change_url( self )}",
+          description: "Automatically generated change from #{UrlHelper.taxon_change_url( self )}",
           move_children: true
         )
         tc.add_input_taxon( child )

--- a/app/models/taxon_swap.rb
+++ b/app/models/taxon_swap.rb
@@ -88,7 +88,7 @@ class TaxonSwap < TaxonChange
       new_taxon_name.creator = nil
       new_taxon_name.updater = nil
       if new_taxon_name.source_url.blank?
-        new_taxon_name.source_url = FakeView.edit_taxon_name_url( taxon_name )
+        new_taxon_name.source_url = UrlHelper.edit_taxon_name_url( taxon_name )
       end
       if new_taxon_name.source_identifier.blank?
         new_taxon_name.source_identifier = taxon_name.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -704,7 +704,7 @@ class User < ApplicationRecord
 
   def set_uri
     if uri.blank?
-      User.where(id: id).update_all(uri: FakeView.user_url(id))
+      User.where( id: id ).update_all uri: UrlHelper.user_url( id )
     end
     true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -704,7 +704,7 @@ class User < ApplicationRecord
 
   def set_uri
     if uri.blank?
-      User.where( id: id ).update_all uri: UrlHelper.user_url( id )
+      User.where( id: id ).update_all( uri: UrlHelper.user_url( id ) )
     end
     true
   end

--- a/app/models/user_sweeper.rb
+++ b/app/models/user_sweeper.rb
@@ -9,7 +9,7 @@ class UserSweeper < ActionController::Caching::Sweeper
 
   def after_update( user )
     ctrl = ActionController::Base.new
-    ctrl.send :expire_action, UrlHelper.dashboard_updates_url( user_id: user.id, ssl: true )
-    ctrl.send :expire_action, UrlHelper.dashboard_updates_url( user_id: user.id, ssl: false )
+    ctrl.send( :expire_action, UrlHelper.dashboard_updates_url( user_id: user.id, ssl: true ) )
+    ctrl.send( :expire_action, UrlHelper.dashboard_updates_url( user_id: user.id, ssl: false ) )
   end
 end

--- a/app/models/user_sweeper.rb
+++ b/app/models/user_sweeper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSweeper < ActionController::Caching::Sweeper
   begin
     observe User
@@ -7,7 +9,7 @@ class UserSweeper < ActionController::Caching::Sweeper
 
   def after_update( user )
     ctrl = ActionController::Base.new
-    ctrl.send :expire_action, FakeView.dashboard_updates_url( user_id: user.id, ssl: true )
-    ctrl.send :expire_action, FakeView.dashboard_updates_url( user_id: user.id, ssl: false )
+    ctrl.send :expire_action, UrlHelper.dashboard_updates_url( user_id: user.id, ssl: true )
+    ctrl.send :expire_action, UrlHelper.dashboard_updates_url( user_id: user.id, ssl: false )
   end
 end

--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class UrlHelper
+  include Singleton
+  include Rails.application.routes.url_helpers
+
+  class << self
+    def method_missing( ... )
+      UrlHelper.instance.send( ... )
+    end
+
+    def respond_to_missing?( method, include_private = false )
+      UrlHelper.instance.respond_to? method, include_private
+    end
+  end
+
+  def default_url_options
+    @default_url_options ||= {
+      host: Site.default ? Site.default.url.sub( "http://", "" ) : "http://localhost",
+      port: Site.default && URI.parse( Site.default.url ).port != 80 ? URI.parse( Site.default.url ).port : nil,
+      protocol: URI.parse( Site.default.url ).scheme
+    }
+  end
+end

--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -10,7 +10,7 @@ class UrlHelper
     end
 
     def respond_to_missing?( method, include_private = false )
-      UrlHelper.instance.respond_to? method, include_private
+      UrlHelper.instance.respond_to?( method, include_private )
     end
   end
 

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -566,7 +566,7 @@ describe Observation do
     it "should set the URI" do
       o = Observation.make!
       o.reload
-      expect(o.uri).to eq(FakeView.observation_url(o))
+      expect(o.uri).to eq(UrlHelper.observation_url(o))
     end
 
     it "should not set the URI if already set" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -124,7 +124,7 @@ describe User do
 
     it "should set the URI" do
       u = User.make!
-      expect(u.uri).to eq(FakeView.user_url(u))
+      expect(u.uri).to eq(UrlHelper.user_url(u))
     end
 
     it "should set a default locale" do


### PR DESCRIPTION
#3264

First step in removing `FakeView`. 

- Creates `UrlHelper` which handles delegating to `Rails.application.routes.url_helpers` in a single purpose class. 
  - This should be a large portion, if not the majority, of `FakeView` usages.
- The next big step will be allow calls to these from outside of the view context:
  - `image_url`
  - `uri_join`
- Also need to address :
  - Calls to `render`
  - Calls to `ActionView::Helpers`
  - DarwinCore (not too familiar with what this is yet)