### PR TITLE
Add Identify keyboard shortcut to play observation's sound

### DIFF
--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -1128,20 +1128,17 @@ export function subscribe( ) {
 
 export function togglePlayFirstSound( ) {
   return ( ) => {
-    const player = $(".obs-media .sounds").find("audio:first")[0];
-    const is_active_element_audio = $(document.activeElement).is("audio");
-    if ( !player ) { 
-      return; 
-    }
-    // Use default processing if an audio element is already active.
-    if ( is_active_element_audio ) {
+    const player = $( ".obs-media .sounds" ).find( "audio:first" )[0];
+    const hasFocus = player === document.activeElement;
+    if ( !player ) {
       return;
     }
-    player.focus();
+    if ( !hasFocus ) {
+      player.focus();
+    }
     if ( player.paused ) {
       player.play( );
-    }
-    else {
+    } else {
       player.pause( );
     }
   };

--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -1126,6 +1126,27 @@ export function subscribe( ) {
   };
 }
 
+export function togglePlayFirstSound( ) {
+  return ( ) => {
+    const player = $(".obs-media .sounds").find("audio:first")[0];
+    const is_active_element_audio = $(document.activeElement).is("audio");
+    if ( !player ) { 
+      return; 
+    }
+    // Use default processing if an audio element is already active.
+    if ( is_active_element_audio ) {
+      return;
+    }
+    player.focus();
+    if ( player.paused ) {
+      player.play( );
+    }
+    else {
+      player.pause( );
+    }
+  };
+}
+
 export {
   SHOW_CURRENT_OBSERVATION,
   HIDE_CURRENT_OBSERVATION,

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -391,7 +391,7 @@ class ObservationModal extends React.Component {
       { keys: ["i"], label: I18n.t( "add_id" ) },
       { keys: ["f"], label: I18n.t( "add_to_favorites" ) },
       { keys: ["z"], label: I18n.t( "zoom_photo" ) },
-      { keys: ["Space"], label: I18n.t( "play_first_sound" ) },
+      { keys: ["SPACE"], label: I18n.t( "play_first_sound" ) },
       { keys: ["&larr;"], label: I18n.t( "previous_observation" ) },
       { keys: ["&rarr;"], label: I18n.t( "next_observation" ) },
       { keys: ["SHIFT", "&larr;"], label: I18n.t( "previous_tab" ) },

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -391,6 +391,7 @@ class ObservationModal extends React.Component {
       { keys: ["i"], label: I18n.t( "add_id" ) },
       { keys: ["f"], label: I18n.t( "add_to_favorites" ) },
       { keys: ["z"], label: I18n.t( "zoom_photo" ) },
+      { keys: ["Space"], label: I18n.t( "play_first_sound" ) },
       { keys: ["&larr;"], label: I18n.t( "previous_observation" ) },
       { keys: ["&rarr;"], label: I18n.t( "next_observation" ) },
       { keys: ["SHIFT", "&larr;"], label: I18n.t( "previous_tab" ) },

--- a/app/webpack/observations/identify/keyboard_shortcuts.js
+++ b/app/webpack/observations/identify/keyboard_shortcuts.js
@@ -185,7 +185,7 @@ const setupKeyboardShortcuts = dispatch => {
   bindShortcut( "r", toggleReviewed, dispatch, { eventType: "keyup" } );
   bindShortcut( "a", agreeWithCurrentObservation, dispatch, { eventType: "keyup" } );
   bindShortcut( "z", zoomCurrentPhoto, dispatch );
-  bindShortcut( "space", togglePlayFirstSound, dispatch, { eventType: "keyup" } );
+  bindShortcut( "space", togglePlayFirstSound, dispatch, { eventType: "keydown" } );
   bindShortcut( "f", toggleFave, dispatch );
   bindShortcut( ["command+left", "alt+left"], showPrevPhoto, dispatch );
   bindShortcut( ["command+right", "alt+right"], showNextPhoto, dispatch );

--- a/app/webpack/observations/identify/keyboard_shortcuts.js
+++ b/app/webpack/observations/identify/keyboard_shortcuts.js
@@ -9,6 +9,7 @@ import {
   toggleCaptive,
   toggleReviewed,
   toggleFave,
+  togglePlayFirstSound,
   addAnnotationFromKeyboard,
   zoomCurrentPhoto,
   showPrevPhoto,
@@ -184,6 +185,7 @@ const setupKeyboardShortcuts = dispatch => {
   bindShortcut( "r", toggleReviewed, dispatch, { eventType: "keyup" } );
   bindShortcut( "a", agreeWithCurrentObservation, dispatch, { eventType: "keyup" } );
   bindShortcut( "z", zoomCurrentPhoto, dispatch );
+  bindShortcut( "space", togglePlayFirstSound, dispatch, { eventType: "keyup" } );
   bindShortcut( "f", toggleFave, dispatch );
   bindShortcut( ["command+left", "alt+left"], showPrevPhoto, dispatch );
   bindShortcut( ["command+right", "alt+right"], showNextPhoto, dispatch );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4051,6 +4051,7 @@ en:
     For what it's worth, we will have to restrict the conditions under which
     people can add places in the future given iNat's current rate of growth.
   plants: plants
+  play_first_sound: Play First Sound
   please_add_a_citation_for_this_change: Please add a citation for this change.
   please_allow_a_few_weeks_for_external_sites:
     Please allow a few weeks for external sites to sync changes from this observation


### PR DESCRIPTION
[#3419](https://github.com/inaturalist/inaturalist/issues/3419)

Set focus to first `<audio>` element and play associated sound file. If an `<audio>` element is already active, the `togglePlayFirstSound` action exits early to avoid interfering with default processing.