### PR TITLE
Donation page urls

### DIFF
--- a/app/views/donate/index.html.haml
+++ b/app/views/donate/index.html.haml
@@ -21,17 +21,17 @@
   .row
     .col-md-5.col-md-offset-1.col-xs-12
       - # Note: the donorbox iframe does *not* support utm params as of 2020-12-17. It retrieves those from the URL of the parent window. ~~~kueda 20201217
-      %iframe#donorbox-iframe{ src: "https://donorbox.org/embed/support-inaturalist?amount=100", seamless: "seamless", name: "donorbox", frameborder: "0", scrolling: "no", allowpaymentrequest: true }
+      %iframe#donorbox-iframe{ src: "https://donorbox.org/embed/support-inaturalist?", seamless: "seamless", name: "donorbox", frameborder: "0", scrolling: "no", allowpaymentrequest: true }
     .col-md-5.col-xs-12
       =t "views.donate.donate_desc_html"
       .sharing
         %p.lead.text-center=t :share_colon, default: t(:share)
-        = link_to "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape( donate_url( utm_source: "facebook", utm_campaign: "2018-launch", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-facebook", target: "_blank" do
+        = link_to "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape( donate_url( utm_source: "facebook", utm_campaign: "share", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-facebook", target: "_blank" do
           %i.fa.fa-facebook
           = t(:facebook)
-        = link_to "https://twitter.com/intent/tweet/?url=#{CGI.escape( donate_url( utm_source: "twitter", utm_campaign: "2018-launch", utm_medium: "social" ) )}&text=#{t( "views.donate.post_donate_social_media_text" )}", class: "btn btn-inat btn-sm btn-twitter", target: "_blank" do
+        = link_to "https://twitter.com/intent/tweet/?url=#{CGI.escape( donate_url( utm_source: "twitter", utm_campaign: "share", utm_medium: "social" ) )}&text=#{t( "views.donate.post_donate_social_media_text" )}", class: "btn btn-inat btn-sm btn-twitter", target: "_blank" do
           %i.fa.fa-twitter
           = t(:twitter)
-        = link_to "https://www.linkedin.com/shareArticle?mini=true&url=#{CGI.escape( donate_url( utm_source: "linkedin", utm_campaign: "2018-launch", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-linkedin", target: "_blank" do
+        = link_to "https://www.linkedin.com/shareArticle?mini=true&url=#{CGI.escape( donate_url( utm_source: "linkedin", utm_campaign: "share", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-linkedin", target: "_blank" do
           %i.fa.fa-linkedin
           = t(:linkedin)

--- a/app/views/donate/monthly_supporters.html.haml
+++ b/app/views/donate/monthly_supporters.html.haml
@@ -21,17 +21,17 @@
   .row
     .col-md-5.col-md-offset-1.col-xs-12
       - # Note: the donorbox iframe supports an amount param in the URL, but it does *not* support utm params as of 2020-12-17. It retrieves those from the URL of the parent window. ~~~kueda 20201217
-      %iframe#donorbox-iframe{ src: "https://donorbox.org/embed/inaturalist-monthly-supporters?amount=30", seamless: "seamless", name: "donorbox", frameborder: "0", scrolling: "no", allowpaymentrequest: true }
+      %iframe#donorbox-iframe{ src: "https://donorbox.org/embed/inaturalist-monthly-supporters?", seamless: "seamless", name: "donorbox", frameborder: "0", scrolling: "no", allowpaymentrequest: true }
     .col-md-5.col-xs-12
       =t "views.donate.monthly_supporters.desc_html", donate_url: donate_url( utm_campaign: "monthly-supporters", utm_medium: "web", utm_source: @site.domain, utm_content: "inline-link", utm_term: "one-time" )
       .sharing
         %p.lead.text-center=t :share_colon, default: t(:share)
-        = link_to "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape( donate_url( utm_source: "facebook", utm_campaign: "2018-launch", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-facebook", target: "_blank" do
+        = link_to "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape( donate_url( utm_source: "facebook", utm_campaign: "share", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-facebook", target: "_blank" do
           %i.fa.fa-facebook
           = t(:facebook)
-        = link_to "https://twitter.com/intent/tweet/?url=#{CGI.escape( donate_url( utm_source: "twitter", utm_campaign: "2018-launch", utm_medium: "social" ) )}&text=#{t( "views.donate.post_donate_social_media_text" )}", class: "btn btn-inat btn-sm btn-twitter", target: "_blank" do
+        = link_to "https://twitter.com/intent/tweet/?url=#{CGI.escape( donate_url( utm_source: "twitter", utm_campaign: "share", utm_medium: "social" ) )}&text=#{t( "views.donate.post_donate_social_media_text" )}", class: "btn btn-inat btn-sm btn-twitter", target: "_blank" do
           %i.fa.fa-twitter
           = t(:twitter)
-        = link_to "https://www.linkedin.com/shareArticle?mini=true&url=#{CGI.escape( donate_url( utm_source: "linkedin", utm_campaign: "2018-launch", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-linkedin", target: "_blank" do
+        = link_to "https://www.linkedin.com/shareArticle?mini=true&url=#{CGI.escape( donate_url( utm_source: "linkedin", utm_campaign: "share", utm_medium: "social" ) )}", class: "btn btn-inat btn-sm btn-linkedin", target: "_blank" do
           %i.fa.fa-linkedin
           = t(:linkedin)


### PR DESCRIPTION
-removes the default amount selection from /donate and /monthly-supporters. 
-updates the 2018 campaign utm from the social media share links. 