### PR TITLE
Support rel=me attribute in profile links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -321,12 +321,17 @@ module ApplicationHelper
     text = compact(text, :all_tags => true) if options[:compact]
     text = auto_link(text.html_safe, :sanitize => false).html_safe
     # scrub to fix any encoding issues
-    text = text.scrub.gsub(/<a /, '<a rel="nofollow" ')
+    text = text.scrub
     unless options[:skip_simple_format]
       text = simple_format_with_structure( text, sanitize: false )
     end
     # Ensure all tags are closed
-    text = Nokogiri::HTML::DocumentFragment.parse( text ).to_s
+    parsed_text = Nokogiri::HTML::DocumentFragment.parse( text )
+    # Ensure all links have nofollow
+    parsed_text.css( "a" ).each do | node |
+      node[:rel] = "#{node[:rel]} nofollow".strip
+    end
+    text = parsed_text.to_s
     # Remove empty paragraphs
     text = text.gsub( "<p></p>", "" )
     text.html_safe
@@ -1507,12 +1512,23 @@ module ApplicationHelper
 
   def hyperlink_mentions( text, for_markdown: false )
     linked_text = text.dup
+    before_mention_pattern = [
+      # Either it's at the start of the line, or...
+      "^|",
+      # It's not preceded by the end of a start tag (e.g. a link)
+      '(?<!">)',
+      # And it's not preceded by slash (e.g. a part of a URL)
+      "(?<!/)"
+    ].join
     # link the longer logins first, to prevent mistakes when
     # one username is a substring of another username
-    linked_text.mentioned_users.sort_by{ |u| u.login.length }.reverse.each do |u|
+    linked_text.mentioned_users.sort_by {| u | u.login.length }.reverse.each do | u |
       # link `@login` when @ is preceded by a word break but isn't preceded by ">
       login_text = for_markdown ? u.login.gsub( "_", "\\_" ) : u.login
-      linked_text.gsub!(/(^|(?<!">))@#{ u.login }/, "\\1#{link_to("@#{login_text}", person_by_login_url(u.login))}")
+      linked_text.gsub!(
+        /(#{before_mention_pattern})@#{u.login}/,
+        "\\1#{link_to( "@#{login_text}", person_by_login_url( u.login ) )}"
+      )
     end
     linked_text
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,40 +1,50 @@
-require File.dirname(__FILE__) + '/../spec_helper'
-include ApplicationHelper
+# frozen_string_literal: true
+
+require "#{File.dirname( __FILE__ )}/../spec_helper"
 
 describe ApplicationHelper do
-
   describe "hyperlink_mentions" do
     it "links known user mentions in text" do
-      User.make!(login: "testmention")
+      User.make!( login: "testmention" )
       str = "Hello @testmention!"
-      expect(hyperlink_mentions(str)).to eq(
-        "Hello <a href=\"http://test.host/people/testmention\">@testmention</a>!")
+      expect( hyperlink_mentions( str ) ).to eq(
+        "Hello <a href=\"http://test.host/people/testmention\">@testmention</a>!"
+      )
     end
 
     it "does not link unknown logins" do
       str = "Hello @testmention!"
-      expect(hyperlink_mentions(str)).to eq str
+      expect( hyperlink_mentions( str ) ).to eq str
     end
 
     it "links mentions at the start and end of strings" do
-      User.make!(login: "alpha")
-      User.make!(login: "beta")
+      User.make!( login: "alpha" )
+      User.make!( login: "beta" )
       str = "@alpha, @beta"
-      expect(hyperlink_mentions(str)).to eq(
-        "<a href=\"http://test.host/people/alpha\">@alpha</a>, " +
-        "<a href=\"http://test.host/people/beta\">@beta</a>")
+      expect( hyperlink_mentions( str ) ).to eq(
+        "<a href=\"http://test.host/people/alpha\">@alpha</a>, " \
+          "<a href=\"http://test.host/people/beta\">@beta</a>"
+      )
     end
 
     it "properly links logins that are substrings of each other" do
-      User.make!(login: "alpha")
-      User.make!(login: "alphabeta")
-      User.make!(login: "alphabetagamma")
+      User.make!( login: "alpha" )
+      User.make!( login: "alphabeta" )
+      User.make!( login: "alphabetagamma" )
       str = "Hello @alpha, @alphabeta, @alphabetagamma"
-      expect(hyperlink_mentions(str)).to eq(
-        "Hello <a href=\"http://test.host/people/alpha\">@alpha</a>, " +
-        "<a href=\"http://test.host/people/alphabeta\">@alphabeta</a>, " +
-        "<a href=\"http://test.host/people/alphabetagamma\">@alphabetagamma</a>")
+      expect( hyperlink_mentions( str ) ).to eq(
+        "Hello <a href=\"http://test.host/people/alpha\">@alpha</a>, " \
+          "<a href=\"http://test.host/people/alphabeta\">@alphabeta</a>, " \
+          "<a href=\"http://test.host/people/alphabetagamma\">@alphabetagamma</a>"
+      )
+    end
+
+    it "ignores links that look like mentions" do
+      user = create :user
+      txt = <<~TXT
+        Hey, it's <a rel="me" href="https://foo.bar/@#{user.login}">me</a>
+      TXT
+      expect( hyperlink_mentions( txt ) ).to eq txt
     end
   end
-
 end


### PR DESCRIPTION
Mainly so links with `rel="me"` can be used as a kind of verification, as they seem to be with Mastodon. Also tried to explain what's happening with the negative look behind pattern matching in `hyperlink_mentions`. Not sure if these changes have any performance implications, but I figured they wouldn't since we're already doing that Nokogiri parsing.