### PR TITLE
chore: fix typos

### DIFF
--- a/app/webpack/taxa/show/components/interactions_tab.jsx
+++ b/app/webpack/taxa/show/components/interactions_tab.jsx
@@ -84,7 +84,15 @@ const InteractionsTab = ( { interactions } ) => {
         <Col xs={4}>
           <h3>About Interactions</h3>
           <p>
-            Most organisms interact with other organisms in some way or another, and how they do so usually defines how they fit into an ecosystem. These interactions come to us from <a href="http://www.globalbioticinteractions.org/">Global Biotic Interactions (GLoBI)</a>, a database and webservice that combines interaction data from numerous sources, including iNaturalist. You can actually contribute to this database by adding the "Eating", "Eaten by", and "Host" observation fields to observations that demonstrate those interactions.
+            Most organisms interact with other organisms in some way or
+            another, and how they do so usually defines how they fit into an
+            ecosystem. These interactions come to us
+            from <a href="http://www.globalbioticinteractions.org/">Global Biotic Interactions (GLoBI)</a>,
+            a database and webservice that combines
+            interaction data from numerous sources, including iNaturalist.
+            You can actually contribute to this database by adding the
+            "Eating", "Eaten by", and "Host" observation fields to
+            observations that demonstrate those interactions.
           </p>
           <h3>Learn More</h3>
           <ul className="tab-links list-group">

--- a/app/webpack/taxa/show/components/interactions_tab.jsx
+++ b/app/webpack/taxa/show/components/interactions_tab.jsx
@@ -84,16 +84,7 @@ const InteractionsTab = ( { interactions } ) => {
         <Col xs={4}>
           <h3>About Interactions</h3>
           <p>
-            Most organisms interact with other organisms in some way or
-            another, and how they do so usually defines how they fit into an
-            ecosystem. These intereactions come to us
-            from
-            <a href="http://www.globalbioticinteractions.org/">Global Biotic Interactions (GLoBI)</a>,
-            a database and webservice that combines
-            interaction data from numerous sources, including iNaturalist.
-            You can actually contribute to this database by adding the
-            "Eating", "Eaten by", and "Host" observation fields to
-            observations that demonstrate those interactions.
+            Most organisms interact with other organisms in some way or another, and how they do so usually defines how they fit into an ecosystem. These interactions come to us from <a href="http://www.globalbioticinteractions.org/">Global Biotic Interactions (GLoBI)</a>, a database and webservice that combines interaction data from numerous sources, including iNaturalist. You can actually contribute to this database by adding the "Eating", "Eaten by", and "Host" observation fields to observations that demonstrate those interactions.
           </p>
           <h3>Learn More</h3>
           <ul className="tab-links list-group">


### PR DESCRIPTION
I know this is a 'hidden' feature, but there are a couple typos that have been bothering me for a long time. I'm unsure why this view renders with a missing space, so I made it one line to be more sure it this edit would work.

<img width="385" alt="image" src="https://user-images.githubusercontent.com/48165493/206530449-3393cffd-9b05-4ca1-8aba-bbad99551ad8.png">
