### PR TITLE
Ensure our translations override devise's

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 # tell the I18n library where to find your translations
-I18n.load_path += Dir[Rails.root.join( "config", "locales", "*.{rb,yml}" )]
-I18n.load_path += Dir[Rails.root.join( "config", "locales", "extra", "*.{rb,yml}" )]
 I18N_LOCALES = Dir[Rails.root.join( "config", "locales", "*.{rb,yml}" )].map do | p |
   p[%r{/([\w\-]+?)\.yml}, 1]
 end.compact.uniq


### PR DESCRIPTION
Fixes inaturalist/inaturalist#3576.

The load paths set in the initializer are already set as part of the default behavior of devise. By adding them in the initializer, they will not be added later by devise, at a higher priority (i.e. later in the list).

```diff
inaturalist fix-i18n-load-path % diff load-path-before.yml load-path-after.yml
353a354,355
> - "/Users/rainhead/.rvm/gems/ruby-3.0.4/gems/devise-4.8.0/config/locales/en.yml"
> - "/Users/rainhead/.rvm/gems/ruby-3.0.4/gems/doorkeeper-5.5.4/config/locales/en.yml"
433,434d434
< - "/Users/rainhead/.rvm/gems/ruby-3.0.4/gems/devise-4.8.0/config/locales/en.yml"
< - "/Users/rainhead/.rvm/gems/ruby-3.0.4/gems/doorkeeper-5.5.4/config/locales/en.yml"
```