### PR TITLE
Delete duplicate faves before merging users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -659,6 +659,20 @@ class User < ApplicationRecord
   def merge(reject)
     raise "Can't merge a user with itself" if reject.id == id
     reject.friendships.where(friend_id: id).each{ |f| f.destroy }
+
+    # Conditions should match index_votes_on_unique_obs_fave
+    reject.votes
+          .joins( "JOIN votes AS keeper_votes USING (votable_type, votable_id)" )
+          .where(
+            keeper_votes: {
+              voter_type: self.class.polymorphic_name,
+              voter_id: id,
+              vote_scope: nil
+            },
+            votable_type: Observation.polymorphic_name,
+            vote_scope: nil
+          )
+          .destroy_all
     merge_has_many_associations(reject)
     reject.delay( priority: USER_PRIORITY, unique_hash: { "User::sane_destroy": reject.id } ).sane_destroy
     User.delay( priority: USER_INTEGRITY_PRIORITY ).merge_cleanup( id )

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -976,6 +976,13 @@ describe User do
       f.reload
       expect( f.flaggable_user_id ).to eq keeper.id
     end
+
+    it "should merge favorited observations" do
+      o = Observation.make!
+      o.vote_by voter: keeper, vote: true
+      o.vote_by voter: reject, vote: true
+      expect { keeper.merge( reject ) }.not_to raise_error( ActiveRecord::RecordNotUnique )
+    end
   end
 
   describe "suggest_login" do


### PR DESCRIPTION
Fixes: inaturalist/inaturalist#3546

I'm happy to factor out some of this responsibility, but it wasn't clear that there was anything generalizable.

I'm using `destroy_all` because I don't know what kind of post-destroy hooks there might be on the records, and because I don't expect there to be enough duplicates for it to be a performance problem.