### PR TITLE
Email confirmation without lockout

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -15,6 +15,9 @@ module Users
 
     skip_before_action :verify_authenticity_token
 
+    # You should never automatically return to the confirmation views
+    before_action :return_here, only: []
+
     before_action do
       # If the user is already confirmed and they're not clicking a
       # confirmation link to confirm a change to their email address, don't

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -392,6 +392,9 @@ class User < ApplicationRecord
     child? && UserParent.where( "user_id = ? AND donorbox_donor_id IS NULL", id ).exists?
   end
 
+  EMAIL_CONFIRMATION_RELEASE_DATE = Date.parse( "2022-12-14" )
+  EMAIL_CONFIRMATION_REQUIREMENT_DATE = Date.parse( "2023-07-01" )
+
   # This is a dangerous override in that it doesn't call super, thereby
   # ignoring the results of all the devise modules like confirmable. We do
   # this b/c we want all users to be able to sign in, even if unconfirmed, but
@@ -401,8 +404,12 @@ class User < ApplicationRecord
 
     return false if child_without_permission?
 
-    # Temporary state to allow existing users to sign in
+    # Temporary state to allow existing users to sign in. Probably redundant
+    # with the next grandparent exception
     return true if confirmation_sent_at.blank?
+
+    # Temporary state to allow existing users to sign in
+    return true if created_at < EMAIL_CONFIRMATION_RELEASE_DATE
 
     super
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1260,9 +1260,8 @@ class User < ApplicationRecord
       # This is for existing users who explicitly request a confirmation
       # email, which sets confirmation_sent_at. This is imperfect, but it
       # should prevent most actual users from receiving the welcome email
-      # again. People with no privileges have not really added any content
-      # and could probably use a reminder of the links in the welcome email
-      !user_privileges.any?
+      # again.
+      created_at >= EMAIL_CONFIRMATION_RELEASE_DATE
     )
       Emailer.welcome( self ).deliver_now
     end

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -69,7 +69,7 @@
           <div class="bootstrap">
             <div id="full-width-notice" class="bg-warning">
               <div class="container">
-                <p><%=t :email_confirmation_banner_html, date: l( Date.parse( "2023-07-01" ), format: :short_with_year ), link_start_tag: "<a href='#{generic_edit_user_path( anchor: "profile" )}'>".html_safe, link_end_tag: "</a>".html_safe %></p>
+                <p><%=t :email_confirmation_banner_html, date: l( User::EMAIL_CONFIRMATION_REQUIREMENT_DATE, format: :short_with_year ), link_start_tag: "<a href='#{generic_edit_user_path( anchor: "profile" )}'>".html_safe, link_end_tag: "</a>".html_safe %></p>
               </div>
             </div>
           </div>

--- a/app/webpack/users/edit/ducks/user_settings.js
+++ b/app/webpack/users/edit/ducks/user_settings.js
@@ -263,7 +263,9 @@ export function resendConfirmation( ) {
     dispatch( setUserData( profile ) );
     return inatjs.users.resendConfirmation( { useAuth: true } ).then( ( ) => {
       dispatch( fetchUserSettings( "saved" ) );
-      window.location.reload( );
+      // If we go back to signing people out after sending the confirmation,
+      // we will need to reload the window
+      // window.location.reload( );
     } ).catch( e => {
       handleSaveError( e ).then( errors => {
         profile.errors = errors;
@@ -278,13 +280,14 @@ export function confirmResendConfirmation( ) {
     const state = getState( );
     dispatch( setConfirmModalState( {
       show: true,
-      message: I18n.t( "users_edit_send_confirmation_prompt_html", {
-        email: state.profile.email || "",
-        defaultValue: I18n.t( "users_edit_resend_confirmation_prompt_html" )
+      message: I18n.t( "users_edit_send_confirmation_prompt_with_grace_html", {
+        email: state.profile.email || ""
       } ),
-      confirmText: I18n.t( "send_and_sign_out", {
-        defaultValue: I18n.t( "resend_and_sign_out" )
-      } ),
+      confirmText: I18n.t( "send_confirmation_email" ),
+      // If we want to go back to signing people out, this is the text we should use
+      // confirmText: I18n.t( "send_and_sign_out", {
+      //   defaultValue: I18n.t( "resend_and_sign_out" )
+      // } ),
       onConfirm: async ( ) => {
         await dispatch( saveUserSettings( ) );
         const { profile } = getState( );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5749,6 +5749,24 @@ en:
     will not be able to sign in to your account until you click the link in
     the email, so <strong>make absolutely sure you have entered your email address
     correctly.</strong>
+  users_edit_send_confirmation_prompt_with_grace_html: |
+    <p>
+      Please ensure your email address is correct. Here's the email address we
+      will send the confirmation to:
+    </p>
+    <pre class="text-center text-large">%{email}</pre>
+    <p>
+      If you do not receive the email, here are some tips:
+    </p>
+    <ul>
+      <li><p>Check your spam folder</p></li>
+      <li><p>Check for any filters you made that might remove our emails from your inbox</p></li>
+    </ul>
+    <p>
+      If you are still not receiving the confirmation email, please contact us at
+      <a href="mailto:help+confirmation@inaturalist.org">help@inaturalist.org</a>
+      so we can assist you.
+    </p>
   users_edit_send_confirmation_prompt_html: |
     <h3>You are about to sign out</h3>
     <p>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1450,7 +1450,7 @@ describe User do
 
   describe "confirmation" do
     it "should deliver the welcome email when a new user is confirmed" do
-      user = create :user, :as_unconfirmed
+      user = create :user, :as_unconfirmed, created_at: ( User::EMAIL_CONFIRMATION_RELEASE_DATE + 1.day )
       expect( ActionMailer::Base.deliveries.last.subject ).to include "Confirm"
       expect { user.confirm }.to change( ActionMailer::Base.deliveries, :size ).by( 1 )
       expect( ActionMailer::Base.deliveries.last.subject ).to include "Welcome"


### PR DESCRIPTION
* allows email confirmation without signing existing users out and requiring
  them to confirm (way, way too many problems with email delivery)
* maintains lock out for new users, i.e. users created after the release of
  email confirmation
* restores guard against remembering that a user was on a confirmation page
* use a date-based definition of existing user to decide whether to send the
  welcome email