### PR TITLE
Touch the observation when flagging a comment or identification

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -109,6 +109,7 @@ class Comment < ApplicationRecord
   end
 
   def flagged_with(flag, options)
+    parent&.touch
     evaluate_new_flag_for_spam(flag)
     index_parent
   end

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -380,12 +380,13 @@ class Identification < ApplicationRecord
     true
   end
 
-  def flagged_with(flag, options)
-    evaluate_new_flag_for_spam(flag)
+  def flagged_with( flag, _options )
+    evaluate_new_flag_for_spam( flag )
     elastic_index!
-    if observation
-      observation.elastic_index!
-    end
+    return unless observation
+
+    observation.touch
+    observation.elastic_index!
   end
 
   # /Callbacks ##############################################################


### PR DESCRIPTION
This ensures that the observation's `updated_at` changes after flagging an identification or a comment on that observation, this allowing a client to detect that something has changed with the observation and it probably needs to update its copy. This specifically emerged from trying to implement flagging in the React Native app, where (at present) everything is driven through the local database, so after creating a flag, the app needs to update its local database and the simplest way to do so seemed to be to re-fetch the observation after flagging.

Couple potential problems:

1. We refetch the observation after updating associated records in other clients, but do we still think that's a good approach?
2. If the observation is updated in postgres and reindexed in es during the request to create a flag, can we assume that the API will actually return an up-to-date copy of the observation on refetch, or does the client need to do something to accommodate some indexing lag?