### PR TITLE
Allow taxon_ids to be ints or strings

### DIFF
--- a/lib/observation_search.rb
+++ b/lib/observation_search.rb
@@ -140,7 +140,7 @@ module ObservationSearch
         api_params.delete(:observations_taxon_ids)
       end
       unless api_params[:taxon_ids].blank?
-        api_params[:taxon_id] += params[:taxon_ids].map{ |id| id.split(",") }.flatten.map(&:to_i)
+        api_params[:taxon_id] += params[:taxon_ids].map{ |id| id.to_s.split(",") }.flatten.map(&:to_i)
         api_params[:taxon_id].uniq!
         api_params.delete(:taxon_ids)
       end


### PR DESCRIPTION
Fixes: https://github.com/inaturalist/inaturalist/issues/3639

I wrote a test for this, but without clear type expectations around params/search_params/etc, the test had to be at the controller level, and I ran out of energy figuring out how to create the fixtures and stubs I needed there. The test did run far enough to exhibit the issue and confirm the fix, as did manual testing.