### PR TITLE
Make post attribution more consistent and translatable

### DIFF
--- a/app/views/posts/_attribution.html.haml
+++ b/app/views/posts/_attribution.html.haml
@@ -1,0 +1,12 @@
+- user_with_icon = capture do
+  - if post.user
+    = link_to_user post.user do
+      = user_image( post.user )
+  = link_to_user post.user
+- vow_or_con = post.user ? post.user.login[0].downcase : t( :deleted_user ).to_s[0].downcase
+- if post.published_at
+  - posted_date = capture do
+    %span.date= l post.published_at, format: :long
+  =t :posted_on_date_by_user_html, date: posted_date.html_safe, user: user_with_icon.html_safe, vow_or_con: vow_or_con
+- else
+  =t :draft_by_user_html, user: user_with_icon, vow_or_con: vow_or_con

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -21,17 +21,7 @@
     - else
       = text
   .meta
-    = t(:posted_on)
-    - if post.published_at
-      %span.date= l post.published_at, :format => :long
-    - else
-      %span= t(:draft)
-    = t(:by).downcase
-    - if post.user
-      = link_to user_image( post.user ), post.user
-      = link_to( post.user.login, observations_path( user_id: post.user.login ) )
-    - else
-      t(:deleted_user)
+    = render "posts/attribution", post: post
     - if post.observations.size > 0
       |
       =t :x_observations_html, count: post.observations.size

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -79,10 +79,7 @@
       .post
         = formatted_user_text(@post.body, scrubber: PostScrubber.new(tags: Post::ALLOWED_TAGS, attributes: Post::ALLOWED_ATTRIBUTES), skip_simple_format: (post.preferred_formatting == Post::FORMATTING_NONE))
       #postmeta.description
-        %span.label
-          - t(:posted_on)
-        - if @post.published_at
-          %span.date= l @post.published_at, :format=>:long
+        = render "posts/attribution", post: @post
       = separator
       #comments
         - if @post.published_at

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -100,11 +100,7 @@
         %section.stacked.post{:id => "description"}
           = formatted_user_text(@trip.body, scrubber: PostScrubber.new(tags: Post::ALLOWED_TAGS, attributes: Post::ALLOWED_ATTRIBUTES), skip_simple_format: (@trip.preferred_formatting == Post::FORMATTING_NONE))
           .small.text-muted.stacked
-            =t :posted_by
-            = succeed ',' do
-              = user_image @trip.user, :size => "mini", :class => "img-rounded"
-              = link_to_user @trip.user
-            =l @trip.published_at, :format => :long if @trip.published?
+            = render "posts/attribution", post: @trip
       - if @trip.is_a?(Trip)
         - unless @target_list_set.blank?
           %section{:id => "target_list"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1806,6 +1806,7 @@ en:
   downstream_flagged_covered_taxa: Downstream flagged taxa
   draft: draft
   draft_: Draft
+  draft_by_user_html: Draft by %{user}
   draft_saved: Draft saved!
   drafts: Drafts
   drag_and_drop_some_photos_or_sounds: Drag & drop some photos or sounds
@@ -4207,7 +4208,9 @@ en:
   post_from_your_journal_html: Post from <a href="%{url}">your journal</a>
   post_published: Post published!
   posted_by: Posted by
-  posted_on: Posted on
+  posted_on_date_html: Posted on %{date}
+  # @vow_or_con applies to %{user}
+  posted_on_date_by_user_html: Posted on %{date} by %{user}
   posts: Posts
   potential_disagreement: Potential Disagreement
   powered_by: Powered by


### PR DESCRIPTION
I removed the `by` translation key because it can't be translated without context, and I neglected to address this usage. I've tried to make this more translatable by using text with more context... albeit with more variables.