### PR TITLE
Move taxon_link comments up in view

### DIFF
--- a/app/views/taxon_links/_form.html.erb
+++ b/app/views/taxon_links/_form.html.erb
@@ -2,6 +2,7 @@
   <%= stylesheet_link_tag 'observations' %>
   <style type="text/css" media="screen">
     .field .text {width: 575px;}
+    #taxon_link_comments {margin: 1.5em 0 1.5em 0;}
   </style>
 <%- end -%>
 <%- content_for(:extrajs) do -%>
@@ -59,6 +60,12 @@
       <%= link_to user_image( @taxon_link.user ), @taxon_link.user %>
       <%= link_to @taxon_link.user.login, @taxon_link.user %>
       <%= t :on_day %> <%= l( @taxon_link.created_at.to_date, format: :long ) %>
+    </div>
+  <% end -%>
+  <% if @taxon_link.persisted? -%>
+    <div id="taxon_link_comments">
+      <hr/>
+      <%= render partial: "comments/comments", locals: { parent: @taxon_link } %>
     </div>
   <% end -%>
 </div>

--- a/app/views/taxon_links/edit.html.erb
+++ b/app/views/taxon_links/edit.html.erb
@@ -5,7 +5,3 @@
 <h2><%= t(:editing_taxon_link) %></h2>
 
 <%= render partial: "form" %>
-
-<div class="column span-12">
-  <%= render partial: "comments/comments", locals: { parent: @taxon_link } %>
-</div>


### PR DESCRIPTION
#3638 

Hey @tiwane, I think the easiest solution, without a redesign is to pull it up:
![image](https://user-images.githubusercontent.com/19367605/219761634-55286af1-cbdd-443b-888e-46808f3445f9.png)
