### PR TITLE
Redirect to notification settings for email link

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -582,12 +582,16 @@ class UsersController < ApplicationController
       format.json { render :json => @updates }
     end
   end
-  
+
   def edit
     respond_to do |format|
       format.html do
-        @monthly_supporter = @user.donorbox_plan_status == "active" && @user.donorbox_plan_type == "monthly"
-        render :edit2, layout: "bootstrap"
+        if params[:notifications]
+          redirect_to generic_edit_user_url( anchor: "notifications" )
+        else
+          @monthly_supporter = @user.donorbox_plan_status == "active" && @user.donorbox_plan_type == "monthly"
+          render :edit2, layout: "bootstrap"
+        end
       end
       format.json do
         render :json => @user.to_json(

--- a/app/views/emailer/_footer.html.erb
+++ b/app/views/emailer/_footer.html.erb
@@ -103,7 +103,7 @@
                         <p>
                           <em><%= t(:email_copyright, :x => Time.now.year).html_safe %>.</em>
                           <br/>
-                          <a href="<%= generic_edit_user_url %>" style="-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;color: #606060;font-weight: normal;text-decoration: underline;"><%= t(:update_subscription_preferences) %></a>
+                          <a href="<%= generic_edit_user_url(notifications: true) %>" style="-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;color: #606060;font-weight: normal;text-decoration: underline;"><%= t(:update_subscription_preferences) %></a>
                           <br/>
                           <%-
                             # Sendgrid unsubscribe template tag


### PR DESCRIPTION
#3664 - On emails, change URL for "Update subscription preferences" link

- Adds a redirect to `#notifications` anchor if notifications param present
- Allows linking directly to `#notifications` tab, even when not logged in


## Not logged in
(note url in bottom left of first image)
![image](https://user-images.githubusercontent.com/19367605/220800564-e9d9bbdb-f413-41bf-9c63-ed7090373bd7.png)
->
![image](https://user-images.githubusercontent.com/19367605/220800609-2a36ab10-0b52-4ad0-af83-e901bf055ed2.png)
-> 
![image](https://user-images.githubusercontent.com/19367605/220800676-ed03b0dc-a942-4387-be7f-173eb35b145e.png)


## Logged in
![image](https://user-images.githubusercontent.com/19367605/220800887-2b67ab80-bee5-44c8-b430-e2df4c63cdf9.png)
->
![image](https://user-images.githubusercontent.com/19367605/220800907-512ffca8-92ee-49bb-afc9-c62fe8c36e57.png)

