### PR TITLE
Change place size messaging and implementation to use square km

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -199,8 +199,12 @@ class Place < ApplicationRecord
 
   # 66 is roughly the size of Texas
   MAX_PLACE_AREA_FOR_NON_STAFF = 66.0
+  # 700,000 km2 is roughly the size of Texas or Somalia
+  MAX_PLACE_AREA_FOR_NON_STAFF_KM2 = 700_000
   # 6 is roughly the size of West Virginia
   MAX_PLACE_AREA_FOR_NON_STAFF_DURING_FREEZE = 6.0
+  # 70,000 km2 is roughly the size of West Virginia or Croatia
+  MAX_PLACE_AREA_FOR_NON_STAFF_DURING_FREEZE_KM2 = 70_000
 
   MAX_PLACE_OBSERVATION_COUNT = 200000
   MAX_PLACE_OBSERVATION_COUNT_DURING_FREEZE = 10000
@@ -951,6 +955,13 @@ class Place < ApplicationRecord
     else
       display_name
     end
+  end
+
+  def area_km2
+    PlaceGeometry.
+      where( place_id: id ).
+      select( "id, ST_Area(geom::geography) / (1000 * 1000) AS area_km2" ).
+      first&.area_km2
   end
 
   def self.param_to_array(places)

--- a/app/views/places/edit.html.haml
+++ b/app/views/places/edit.html.haml
@@ -57,7 +57,7 @@
     = link_to_toggle_box t(:replace_boundary_with_kml) do
       .notice=t :places_warning_editing_places_is_slow
       = file_field_tag :file, :accept => "application/vnd.google-earth.kml+xml"
-      .meta= t('views.places.kml_field_desc2')
+      .meta= t('views.places.kml_field_desc3')
     %input{:type => "hidden", :name => "geojson"}
     .clear.buttonrow.upstacked
       = f.submit t(:save), :class => 'default button', "data-loading-click" => t(:saving)

--- a/app/views/places/new.html.erb
+++ b/app/views/places/new.html.erb
@@ -125,7 +125,7 @@
       <%= f.text_field :parent_id, :placeholder => t(:type_place_name), :style => "width: 300px", label: t(:parent) %>
       <%= f.hidden_field :latitude %>
       <%= f.hidden_field :longitude %>
-      <%= f.form_field :kml, :label => t(:kml), required: true, :description => t('views.places.kml_field_desc2') do %>
+      <%= f.form_field :kml, :label => t(:kml), required: true, :description => t('views.places.kml_field_desc3') do %>
         <%= file_field_tag :file, :accept => "application/vnd.google-earth.kml+xml" %>
       <% end -%>
       <%= f.select :place_type, Place::PLACE_TYPE_CODES.map{|type, code| [t("place_geo.geo_planet_place_types.#{type.gsub(" ", "_")}"), code]}.sort,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7347,11 +7347,12 @@ en:
           leave copyright infringement flags as unresolved if this photo does
           infringe copyright.
     places:
-      kml_field_desc2: |
+      kml_field_desc3: |
         KML of the place boundary. You can make one using Google Maps, Google
         Earth, or most GIS applications. Must have at least one polygon, be
-        under 1 MB (5 MB for site curators), and have an area smaller than the
-        US state of Texas.
+        under 1 MB (5 MB for site curators), and have an area smaller than
+        ~700,000 square kilometers (roughly the size of Somalia or the US state of
+        Texas).
       edit:
         complex_boundary_note_html: |
           This boundary is a bit too complex to edit on the web. However, you can


### PR DESCRIPTION
Using square degrees means the restriction varies based on latitude, and it means we can't reasonably communicate the way the restriction works to users because no one knows what a square degree is. This changes most uses of the restriction to use square kilometers.