### PR TITLE
Upgrade Google Maps API

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1372,13 +1372,18 @@ module ApplicationHelper
   end
 
   def google_maps_js(libraries: [])
-    source = URI::HTTPS.build host: "maps.google.com", path: "/maps/api/js", query: {
-      callback: "GOOGLE_MAPS_CALLBACK",
+    javascript_include_tag google_maps_loader_uri(libraries: libraries)
+  end
+
+  # https://developers.google.com/maps/documentation/javascript/url-params
+  # https://developers.google.com/maps/documentation/javascript/libraries
+  # https://developers.google.com/maps/documentation/javascript/versions
+  def google_maps_loader_uri(libraries: [])
+    URI::HTTPS.build host: "maps.google.com", path: "/maps/api/js", query: {
       key: CONFIG.google.browser_api_key,
-      libraries: libraries.join(','),
-      v: Rails.env.development? ? "weekly" : "3.51",
+      libraries: libraries.join(","),
+      v: "3.51",
     }.to_query
-    javascript_include_tag source
   end
 
   def leaflet_js(options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1371,12 +1371,14 @@ module ApplicationHelper
     args.join('/').gsub(/\/+/, '/')
   end
 
-  def google_maps_js(options = {})
-    libraries = options[:libraries] || []
-    version = Rails.env.development? ? "weekly" : "3.48"
-    params = "v=#{version}&key=#{CONFIG.google.browser_api_key}"
-    params += "&libraries=#{libraries.join(',')}" unless libraries.blank?
-    "<script type='text/javascript' src='http#{'s' if request.ssl?}://maps.google.com/maps/api/js?#{params}'></script>".html_safe
+  def google_maps_js(libraries: [])
+    source = URI::HTTPS.build host: "maps.google.com", path: "/maps/api/js", query: {
+      callback: "GOOGLE_MAPS_CALLBACK",
+      key: CONFIG.google.browser_api_key,
+      libraries: libraries.join(','),
+      v: Rails.env.development? ? "weekly" : "3.51",
+    }.to_query
+    javascript_include_tag source
   end
 
   def leaflet_js(options = {})

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -270,8 +270,10 @@
         $.fn.btn = btn;
       }
     </script>
-    <%= google_maps_js( libraries: %w(places geometry drawing) ) unless @skip_external_connections %>
-    <%= javascript_include_tag "map_bundle" unless @minimal_header || @skip_external_connections %>
+    <% unless @skip_external_connections %>
+      <%= javascript_include_tag google_maps_loader_uri(libraries: %w(places geometry drawing)) %>
+      <%= javascript_include_tag "map_bundle" unless @minimal_header %>
+    <% end %>
     <%= yield :extrajs %>
     <% if logged_in? && !@minimal_header -%>
       <script type="text/javascript" charset="utf-8">

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -37,7 +37,7 @@ base: &base
         # See http://bitbucket.org/springmeyer/tilelite/
         observations: 'http://localhost:8000'
         tilestache: 'http://localhost:8080'
-        elasticsearch: http://localhost:4000
+        elasticsearch: http://localhost:4000/v1
 
     google_webmaster:
         verification: abiglongkey

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@formatjs/intl-locale": "^2.4.19",
         "@formatjs/intl-numberformat": "^6.2.2",
-        "@types/googlemaps": "^3.30.16",
+        "@types/google.maps": "^3.51.1",
         "@types/markerclustererplus": "^2.1.33",
         "@types/react": "^16.4.18",
         "acorn": ">=6.4.1",
@@ -1578,6 +1578,11 @@
       "dependencies": {
         "@types/googlemaps": "*"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.52.2",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.52.2.tgz",
+      "integrity": "sha512-zhzHLgAU4EDai3/NDorWTYUskS7KSoK6m8MYPu66lPVbz1RsKJjEEEI+89oj3rPG5Zw8bszoGGXrsH5ehXkuTw=="
     },
     "node_modules/@types/googlemaps": {
       "version": "3.30.16",
@@ -8103,6 +8108,11 @@
       "requires": {
         "@types/googlemaps": "*"
       }
+    },
+    "@types/google.maps": {
+      "version": "3.52.2",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.52.2.tgz",
+      "integrity": "sha512-zhzHLgAU4EDai3/NDorWTYUskS7KSoK6m8MYPu66lPVbz1RsKJjEEEI+89oj3rPG5Zw8bszoGGXrsH5ehXkuTw=="
     },
     "@types/googlemaps": {
       "version": "3.30.16",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@formatjs/intl-locale": "^2.4.19",
     "@formatjs/intl-numberformat": "^6.2.2",
-    "@types/googlemaps": "^3.30.16",
+    "@types/google.maps": "^3.51.1",
     "@types/markerclustererplus": "^2.1.33",
     "@types/react": "^16.4.18",
     "acorn": ">=6.4.1",


### PR DESCRIPTION
In service of #3636.

Changes:
- Upgrade Google Maps to from 3.48 to 3.51 ([ChangeLog](https://developers.google.com/maps/documentation/javascript/releases#3.48.1)). **NB: 3.48.1 removes support for Internet Explorer**.
- Use the same Maps API version regardless of environment.
- Upgrade type signatures package, whose name changed slightly.
- Do less raw string manipulation in the helper.
- Always load the Maps API over a secure connection.
- Fix a setting in `config.yml.example` that tripped me up when setting up my development environment.

### Async Loading

While Google [says](https://developers.google.com/maps/documentation/javascript/overview#sync) you can load the Maps API synchronously, this generates a warning in the console, which is visible in production. It's possible that Google would remove support for synchronous loading in the future.

I implemented a proof of concept of loading the Maps API asynchronously and triggering the initialization in `map3.js.erb` via a `Promise`. That change worked okay for me, but would probably require lots of regression testing.

### Next Steps

#3636 reads to me as a roundup of related but separate race conditions. @synrg is probably right to finger the timeouts in `observation_search.js.erb`. It would not be hard to weave a `Promise` through the setup functions, and probably make the overall setup process snappier as a result. Maps increasingly provides `Promise`s for the asynchronous parts of its API, but in this case, I think it's our own setup process we need to wait on. I can do this in my next PR.