### PR TITLE
Fix suggestions tab for Unknown

### DIFF
--- a/app/webpack/observations/identify/ducks/suggestions.js
+++ b/app/webpack/observations/identify/ducks/suggestions.js
@@ -89,7 +89,7 @@ export default function reducer(
       if ( observation && isFeaturedObs ) {
         newState.query = Object.assign( newState.query, {
           taxon: state.query.taxon,
-          taxon_id: state.query.taxon.id,
+          taxon_id: state.query.taxon_id,
           place: state.query.place,
           place_id: state.query.place_id
         } );


### PR DESCRIPTION
Bug:

- Identify some unknowns: https://www.inaturalist.org/observations/identify?per_page=100&order_by=random&without_taxon_id=48460
- Click one of them
- Switch to the suggestions tab
- Switch back to the info tab
- Switch back to the suggestions tab
- Get error: `TypeError: state.query.taxon is null`

This line of code assumes that `state.query.taxon` is not null, but it is null.