### PR TITLE
Fix load time zone geometries

### DIFF
--- a/app/models/time_zone_geometry.rb
+++ b/app/models/time_zone_geometry.rb
@@ -22,6 +22,7 @@ class TimeZoneGeometry < ActiveRecord::Base
       pg_string = {
         dbname: ApplicationRecord.connection_db_config.configuration_hash[:database],
         host: ApplicationRecord.connection_db_config.configuration_hash[:host],
+        port: ApplicationRecord.connection_db_config.configuration_hash[:port],
         user: ApplicationRecord.connection_db_config.configuration_hash[:username],
         password: ApplicationRecord.connection_db_config.configuration_hash[:password],
       }.map { |k, v| "#{k}=#{v}" }.join( " " )
@@ -73,6 +74,7 @@ class TimeZoneGeometry < ActiveRecord::Base
       pg_string = {
         dbname: ApplicationRecord.connection_db_config.configuration_hash[:database],
         host: ApplicationRecord.connection_db_config.configuration_hash[:host],
+        port: ApplicationRecord.connection_db_config.configuration_hash[:port],
         user: ApplicationRecord.connection_db_config.configuration_hash[:username],
         password: ApplicationRecord.connection_db_config.configuration_hash[:password],
       }.map { |k, v| "#{k}=#{v}" }.join( " " )

--- a/app/models/time_zone_geometry.rb
+++ b/app/models/time_zone_geometry.rb
@@ -25,7 +25,7 @@ class TimeZoneGeometry < ActiveRecord::Base
         port: ApplicationRecord.connection_db_config.configuration_hash[:port],
         user: ApplicationRecord.connection_db_config.configuration_hash[:username],
         password: ApplicationRecord.connection_db_config.configuration_hash[:password],
-      }.map { |k, v| "#{k}=#{v}" }.join( " " )
+      }.reject {|_k, v| v.blank? }.map { |k, v| "#{k}=#{v}" }.join( " " )
       # Note that ogr2ogr will automatically create a spatial index on the geom column
       cmd = <<-BASH
         ogr2ogr -f "PostgreSQL" PG:"#{pg_string}" \
@@ -77,7 +77,7 @@ class TimeZoneGeometry < ActiveRecord::Base
         port: ApplicationRecord.connection_db_config.configuration_hash[:port],
         user: ApplicationRecord.connection_db_config.configuration_hash[:username],
         password: ApplicationRecord.connection_db_config.configuration_hash[:password],
-      }.map { |k, v| "#{k}=#{v}" }.join( " " )
+      }.reject {|_k, v | v.blank? }.map {|k, v| "#{k}=#{v}" }.join( " " )
       # Note that ogr2ogr will automatically create a spatial index on the geom column
       cmd = <<-BASH
         ogr2ogr -f "PostgreSQL" PG:"#{pg_string}" \

--- a/tools/load_time_zone_geometries.rb
+++ b/tools/load_time_zone_geometries.rb
@@ -4,15 +4,26 @@
 #
 # Usage:
 #  rails r tools/load_time_zone_geometries.rb /path/to/combined-with-oceans.geojson
-#
 
-unless File.exist?( ARGV[0] )
-  puts "No file at #{ARGV[0]}"
-  exit 0
+filename = ARGV[0]
+
+unless File.exist?( filename )
+  abort "No file at #{filename}"
 end
 
-TimeZoneGeometry.load_geojson_file(
-  ARGV[0],
-  logger: Logger.new( STDOUT ),
-  debug: true
-)
+case File.extname( filename )
+when ".shp"
+  TimeZoneGeometry.load_shapefile(
+    filename,
+    logger: Logger.new( STDOUT ),
+    debug: true
+  )
+when ".json", ".geojson"
+  TimeZoneGeometry.load_geojson_file(
+    filename,
+    logger: Logger.new( STDOUT ),
+    debug: true
+  )
+else
+  abort "Don't know how to load file #{filename}"
+end


### PR DESCRIPTION
### Context

https://github.com/inaturalist/inaturalist/wiki/Development-Setup-Guide gives instructions for loading timezone geometries from a shapefile. However, `tools/load_time_zone_geometries.rb` expects a geojson file, not a shapefile.

### Changes

* Allow the tool to import shapefiles in addition to geogjson files.
* Fix the connection string fed to `ogr2ogr` to include the port number