### PR TITLE
Webpack production mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .vagrant
 .vscode
 app/assets/javascripts/*-webpack.js
+app/assets/javascripts/*-webpack.js.LICENSE.txt
 backup/
 cache/
 config/*.mapnik.xml

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -4,7 +4,7 @@ const webpack = require( "webpack" );
 const webpackAssetsPath = path.join( "app", "webpack" );
 
 const config = {
-  mode: "none",
+  mode: process.env.NODE_ENV === "production" ? "production" : "none",
   target: ["web", "es5"],
   context: path.resolve( webpackAssetsPath ),
   entry: {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -4,7 +4,7 @@ const webpack = require( "webpack" );
 const webpackAssetsPath = path.join( "app", "webpack" );
 
 const config = {
-  mode: process.env.NODE_ENV === "production" ? "production" : "none",
+  mode: process.env.RAILS_ENV === "production" ? "production" : "none",
   target: ["web", "es5"],
   context: path.resolve( webpackAssetsPath ),
   entry: {
@@ -55,12 +55,7 @@ const config = {
         }
       }
     ]
-  },
-  plugins: [
-    new webpack.DefinePlugin( {
-      "process.env.NODE_ENV": JSON.stringify( process.env.NODE_ENV )
-    } )
-  ]
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
Closes #3708 by ensuring webpack is in `production` mode when we transpile JS for production. This definitely results in smaller JS files and may result in other performance improvements. May also alleviate some personal embarrassment, in time.