### PR TITLE
constructor.name unreliable with minification; replace with constructor comparison

### DIFF
--- a/app/webpack/.eslintrc
+++ b/app/webpack/.eslintrc
@@ -46,6 +46,15 @@
     "quotes": [2, "double"],
     "space-in-parens": [2, "always"],
     "no-restricted-globals": 0,
+    "no-restricted-syntax": [
+      "error",
+      // This disallows things like `photo.constructor.name === "Photo"`
+      // because webpack's minifier will abbreviate `constructor.name` to
+      // something like `p` so we can't rely on that value. Instead do
+      // something like `photo.constuctor === Photo`.
+      // https://stackoverflow.com/a/49610802
+      "MemberExpression[object.property.name='constructor'][property.name='name']"
+    ],
     "no-param-reassign": 0,
     "prefer-const": [2, { "destructuring": "all" }],
     "react/forbid-prop-types": 0,

--- a/app/webpack/observations/show/components/flagging_modal.jsx
+++ b/app/webpack/observations/show/components/flagging_modal.jsx
@@ -2,6 +2,13 @@ import _ from "lodash";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Button, Glyphicon, Modal } from "react-bootstrap";
+import {
+  Identification,
+  Observation,
+  Photo,
+  Project,
+  Sound
+} from "inaturalistjs";
 
 class FlaggingModal extends Component {
   constructor( props, context ) {
@@ -19,6 +26,24 @@ class FlaggingModal extends Component {
     this.props.setFlaggingModalState( { radioOption: name } );
   }
 
+  getItemClassName( ) {
+    const { state: propsState } = this.props;
+    const { item } = propsState;
+    let className = "Comment";
+    if ( item.constructor === Project ) {
+      className = "Project";
+    } else if ( item.constructor === Observation || item.quality_grade ) {
+      className = "Observation";
+    } else if ( item.constructor === Identification || item.taxon ) {
+      className = "Identification";
+    } else if ( item.constructor === Photo || item.square_url ) {
+      className = "Photo";
+    } else if ( item.constructor === Sound || item.file_url ) {
+      className = "Sound";
+    }
+    return className;
+  }
+
   close( ) {
     this.props.setFlaggingModalState( { show: false } );
   }
@@ -34,24 +59,6 @@ class FlaggingModal extends Component {
       body
     );
     this.close( );
-  }
-
-  getItemClassName( ) {
-    const { state: propsState } = this.props;
-    const { item } = propsState;
-    let className = "Comment";
-    if ( item.constructor.name === "Project" ) {
-      className = "Project";
-    } else if ( item.constructor.name === "Observation" || item.quality_grade ) {
-      className = "Observation";
-    } else if ( item.constructor.name === "Identification" || item.taxon ) {
-      className = "Identification";
-    } else if ( item.constructor.name === "Photo" || item.square_url ) {
-      className = "Photo";
-    } else if ( item.constructor.name === "Sound" || item.file_url ) {
-      className = "Sound";
-    }
-    return className;
   }
 
   render( ) {

--- a/app/webpack/projects/show/components/app.jsx
+++ b/app/webpack/projects/show/components/app.jsx
@@ -312,6 +312,7 @@ const App = ( {
             <Col xs={12}>
               <FlagAnItemContainer
                 item={project}
+                itemTypeLabel={I18n.t( "project" )}
                 manageFlagsPath={`/projects/${project.id}/flags`}
               />
             </Col>

--- a/app/webpack/shared/components/flag_an_item.jsx
+++ b/app/webpack/shared/components/flag_an_item.jsx
@@ -19,11 +19,14 @@ const FlagAnItem = ( {
     } else if ( groupedFlags.inappropriate ) {
       flagQualifier = "inappropriate";
     }
-    const editLink = loggedIn ? (
-      <a href={manageFlagsPath} className="view">
-        { I18n.t( "add_edit_flags" ) }
-      </a> ) : null;
-    const type = itemTypeLabel || item.constructor.name;
+    const editLink = loggedIn
+      ? (
+        <a href={manageFlagsPath} className="view">
+          { I18n.t( "add_edit_flags" ) }
+        </a>
+      )
+      : null;
+    const type = itemTypeLabel;
     return (
       <div className="FlagAnItem alert alert-danger">
         <i className="fa fa-flag" />
@@ -67,7 +70,7 @@ FlagAnItem.propTypes = {
   setFlaggingModalState: PropTypes.func,
   manageFlagsPath: PropTypes.string,
   item: PropTypes.object,
-  itemTypeLabel: PropTypes.string
+  itemTypeLabel: PropTypes.string.isRequired
 };
 
 export default FlagAnItem;


### PR DESCRIPTION
The problem in #3715 is that ea109554321997116a07063ff61d8bb28c1064bd enabled production webpack builds, which minifies the outputs, a part of which is abbreviating constructor names, so code like `photo.constructor.name === "Photo"` will not work because `photo.constructor.name` gets abbreviated to `"p"`. This forbids the use of constructor.name with eslint and replaces our uses of it with direct constructor comparison per the advice in https://stackoverflow.com/a/49610802, but an alternative approach might be to reconfigure [webpack's minifier](https://webpack.js.org/plugins/terser-webpack-plugin/#minify), or just not minify and rely on the asset pipeline to do that. I'm agnostic, this just seemed like a simple working solution.

Closes #3715