### PR TITLE
clicking on subgenus should open taxonomy tab

### DIFF
--- a/app/webpack/taxa/show/components/taxon_page_tabs.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_tabs.jsx
@@ -305,7 +305,7 @@ class TaxonPageTabs extends React.Component {
             />
           </div>
           <div
-            role="tabpanel"
+            role="tabpanel" 
             className={`tab-pane ${genusOrSpecies ? "" : "hidden"} ${chosenTab === "similar" ? "active" : ""}`}
             id="similar-tab"
           >
@@ -327,7 +327,7 @@ TaxonPageTabs.propTypes = {
 };
 
 TaxonPageTabs.defaultProps = {
-  chosenTab: "articles"
+  chosenTab: "taxonomy"
 };
 
 export default TaxonPageTabs;


### PR DESCRIPTION
When we click on taxon of rank genus and species, About tab was loading instead of Taxonomy Tab.