### PR TITLE
replace skip_total_hits with no_total_hits

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -866,10 +866,22 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
     $scope.pagination.section += 1;
     $scope.pagination.searching = true;
     var processedParams = ObservationsFactory.processParamsForAPI(
-      _.extend( { }, $scope.params, iNaturalist.localeParams( ),
-        { page: $scope.apiPage( ), per_page: $scope.pagination.perSection } ), $scope.possibleFields);
+      _.extend(
+        { },
+        $scope.params,
+        iNaturalist.localeParams( ),
+        {
+          page: $scope.apiPage( ),
+          per_page: $scope.pagination.perSection
+        }
+      ), $scope.possibleFields);
+    var searchHasManyResults = $scope.pagination.total > 10000;
+    if ( searchHasManyResults ) {
+      processedParams.no_total_hits = true;
+    }
+
     ObservationsFactory.search( processedParams ).then( function( response ) {
-      if( ( response.data.total_results <= ( response.data.page * response.data.per_page ) ) ||
+      if( ( ( response.data.total_results <= ( response.data.page * response.data.per_page ) ) && !searchHasManyResults ) ||
           ( $scope.pagination.section >= $scope.pagination.maxSections ) ) {
         $scope.pagination.stopped = true;
       }

--- a/app/webpack/observations/show/ducks/other_observations.js
+++ b/app/webpack/observations/show/ducks/other_observations.js
@@ -126,7 +126,7 @@ export function fetchNearby( ) {
       photos: true,
       not_id: observation.uuid,
       per_page: 6,
-      skip_total_hits: true,
+      no_total_hits: true,
       details: "all"
     } );
     return inatjs.observations.search( fetchParams ).then( response => {
@@ -162,7 +162,7 @@ export function fetchMoreFromClade( ) {
       photos: true,
       not_id: observation.uuid,
       per_page: 6,
-      skip_total_hits: true,
+      no_total_hits: true,
       details: "all"
     } );
     return inatjs.observations.search( fetchParams ).then( response => {
@@ -181,7 +181,7 @@ export function fetchMoreFromThisUser( ) {
       user_id: observation.user.id,
       order_by: "id",
       per_page: 6,
-      skip_total_hits: true,
+      no_total_hits: true,
       details: "all",
       preferred_place_id: s.config.preferredPlace ? s.config.preferredPlace.id : null,
       locale: I18n.locale,

--- a/app/webpack/projects/show/ducks/project.jsx
+++ b/app/webpack/projects/show/ducks/project.jsx
@@ -238,7 +238,8 @@ export function infiniteScrollObservations( previousScrollIndex, nextScrollIndex
     let params = {
       ...project.search_params,
       per_page: 50,
-      page: project.filtered_observations_page + 1
+      page: project.filtered_observations_page + 1,
+      no_total_hits: true
     };
     if ( config.observationFilters ) {
       params = Object.assign( params, config.observationFilters );

--- a/app/webpack/taxa/show/ducks/observations.js
+++ b/app/webpack/taxa/show/ducks/observations.js
@@ -254,7 +254,7 @@ export function fetchLastObservation( ) {
       order_by: "observed_on",
       order: "desc",
       per_page: 1,
-      skip_total_hits: true
+      no_total_hits: true
     };
     if ( testingApiV2 ) {
       params.fields = {


### PR DESCRIPTION
Requires https://github.com/inaturalist/iNaturalistAPI/pull/377 to be merged and deployed first.

Replaces all uses of `skip_total_hits` (which ends up running ES queries not specifying `track_total_hits`, ultimately using the default of 10,000) with `no_total_hits` (which ends up running ES queries specifying `track_total_hits:false`, returning no value for total hits). Also adds the `no_total_hits` param to explore and project page observation requests after the total has been fetched once, allowing for faster and more efficient infinite-scoll observations requests