### PR TITLE
API query optimizations

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -792,8 +792,8 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
         ? dataLoadPromises.unshift( $scope.loadObservers )
         : dataLoadPromises.push( $scope.loadObservers );
 
-      dataLoadPromises.reduce( ( p, promise ) => {
-         return p.then( ( ) => promise( thisSearchTime ) );
+      dataLoadPromises.reduce( function( p, promise ) {
+         return p.then( function( ) { return promise( thisSearchTime ); } );
       }, Promise.resolve( ) );
     } );
   };

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -796,7 +796,7 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
         });
         $scope.speciesPagination.searching = false;
       } ).then( function( ) {
-        ObservationsFactory
+        return ObservationsFactory
           .identifiers( $scope.currentView === "identifiers" ? statsParams : statsParamsOnlyCount )
           .then( function( response ) {
           if( $scope.lastSearchTime != thisSearchTime ) { return; }

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -808,7 +808,7 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
           } );
           $scope.identifiersPagination.searching = false;
         } );
-      } ).then( ( ) => {
+      } ).then( function( ) => {
         ObservationsFactory
           .observers( $scope.currentView === "observers" ? statsParams : statsParamsOnlyCount )
           .then( function( response ) {

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -682,6 +682,10 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
     $scope.pagination.perPage = $scope.pagination.maxSections * $scope.pagination.perSection;
     $scope.pagination.searching = true;
     $scope.pagination.stopped = false;
+    $scope.identifiersPagination = $scope.identifiersPagination || { };
+    $scope.identifiersPagination.searching = true;
+    $scope.observersPagination = $scope.observersPagination || { };
+    $scope.observersPagination.searching = true;
     $scope.speciesPagination = $scope.speciesPagination || { };
     $scope.speciesPagination.page = 1;
     $scope.speciesPagination.perPage = 50;
@@ -780,6 +784,8 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
       var speciesParams = _.extend( { }, statsParams, {
         per_page: $scope.speciesPagination.perPage
       } );
+      $scope.statsParams = statsParams;
+      var statsParamsOnlyCount = _.extend( { }, statsParams, { per_page: 0 } );
       ObservationsFactory.speciesCounts( speciesParams ).then( function( response ) {
         if( $scope.lastSearchTime != thisSearchTime ) { return; }
         $scope.totalSpecies = response.data.total_results;
@@ -789,19 +795,23 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
           return t;
         });
         $scope.speciesPagination.searching = false;
-      } );
-      ObservationsFactory.identifiers( statsParams ).then( function( response ) {
-        if( $scope.lastSearchTime != thisSearchTime ) { return; }
-        $scope.totalIdentifiers = response.data.total_results;
-        $scope.identifiers = _.map( response.data.results, function( r ) {
-          var u = new iNatModels.User( r.user );
-          u.resultCount = r.count;
-          return u;
-        });
-        // identifiers is currently on average a little faster than observers.
-        // Query for identifiers first, and only when that's done fetch observers
-        // to help spread out query load
-        ObservationsFactory.observers( statsParams ).then( function( response ) {
+      } ).then( function( ) {
+        ObservationsFactory
+          .identifiers( $scope.currentView === "identifiers" ? statsParams : statsParamsOnlyCount )
+          .then( function( response ) {
+          if( $scope.lastSearchTime != thisSearchTime ) { return; }
+          $scope.totalIdentifiers = response.data.total_results;
+          $scope.identifiers = _.map( response.data.results, function( r ) {
+            var u = new iNatModels.User( r.user );
+            u.resultCount = r.count;
+            return u;
+          } );
+          $scope.identifiersPagination.searching = false;
+        } );
+      } ).then( ( ) => {
+        ObservationsFactory
+          .observers( $scope.currentView === "observers" ? statsParams : statsParamsOnlyCount )
+          .then( function( response ) {
           if( $scope.lastSearchTime != thisSearchTime ) { return; }
           $scope.totalObservers = response.data.total_results;
           $scope.observers = _.map( response.data.results, function( r ) {
@@ -809,40 +819,77 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
             u.observationCount = r.observation_count;
             u.speciesCount = r.species_count;
             return u;
-          });
-        });
-      });
-    });
+          } );
+          $scope.observersPagination.searching = false;
+        } );
+      } );
+    } );
   };
-  // simple "pagination" of results already fetched, so we're not
-  // rendering too many DOM elements, which need images fetched
+
   $scope.showMoreIdentifiers = function( ) {
+    $scope.identifiersPagination = $scope.identifiersPagination || { };
+    if ( $scope.totalIdentifiers > 0 && _.isEmpty( $scope.identifiers ) ) {
+      if ( $scope.identifiersPagination.searching === true ) { return; }
+      $scope.identifiersPagination.searching = true;
+      ObservationsFactory
+        .identifiers( _.extend( { }, $scope.statsParams, { no_total_hits: true } ) )
+        .then( function( response ) {
+          $scope.identifiers = _.map( response.data.results, function( r ) {
+            var u = new iNatModels.User( r.user );
+            u.resultCount = r.count;
+            return u;
+          } );
+          $scope.identifiersPagination.searching = false;
+      } );
+      return;
+    }
+    // simple "pagination" of results already fetched, so we're not
+    // rendering too many DOM elements, which need images fetched
     $scope.numberIdentifiersShown += 20;
   };
+
   $scope.showMoreObservers = function( ) {
+    $scope.observersPagination = $scope.observersPagination || { };
+    if ( $scope.totalObservers > 0 && _.isEmpty( $scope.observers ) ) {
+      if ( $scope.observersPagination.searching === true ) { return; }
+      $scope.observersPagination.searching = true;
+      ObservationsFactory
+        .observers( _.extend( { }, $scope.statsParams, { no_total_hits: true } ) )
+        .then( function( response ) {
+          $scope.observers = _.map( response.data.results, function( r ) {
+            var u = new iNatModels.User( r.user );
+            u.observationCount = r.observation_count;
+            u.speciesCount = r.species_count;
+            return u;
+          } );
+          $scope.observersPagination.searching = false;
+      } );
+      return;
+    }
+    // simple "pagination" of results already fetched, so we're not
+    // rendering too many DOM elements, which need images fetched
     $scope.numberObserversShown += 20;
   };
+
   $scope.showMoreTaxa = function( ) {
     $scope.speciesPagination = $scope.speciesPagination || { };
-    if( !$scope.taxa || _.isEmpty( $scope.speciesPagination ) ) { return; }
+    if ( !$scope.taxa || _.isEmpty( $scope.speciesPagination ) ) { return; }
     if ( $scope.speciesPagination.page >= 20 ||
       ( $scope.speciesPagination.page * $scope.speciesPagination.perPage ) > $scope.totalSpecies ) {
       $scope.speciesPagination.stopped = true;
     }
-    if( $scope.speciesPagination.searching === true ) { return; }
-    if( $scope.speciesPagination.stopped === true ) { return; }
+    if ( $scope.speciesPagination.searching === true ) { return; }
+    if ( $scope.speciesPagination.stopped === true ) { return; }
     $scope.speciesPagination.searching = true;
     $scope.speciesPagination.page += 1;
 
-    var taxonParams = ObservationsFactory.processParamsForAPI( _.extend( { },
-      $scope.params,
-      iNaturalist.localeParams( ), {
+    var taxonParams = _.extend( { },
+      $scope.statsParams,
+      {
         page: $scope.speciesPagination.page,
         per_page: $scope.speciesPagination.perPage
       }
-    ), $scope.possibleFields );
-    taxonParams = _.omit( taxonParams, [ "order_by", "order" ] );
-
+    );
     ObservationsFactory.speciesCounts( taxonParams ).then( function( response ) {
       $scope.totalSpecies = response.data.total_results;
       $scope.taxa = $scope.taxa.concat( _.map( response.data.results, function( r ) {

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -781,13 +781,30 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
         return;
       }
       $scope.observations = ObservationsFactory.responseToInstances( response );
-      var speciesParams = _.extend( { }, statsParams, {
-        per_page: $scope.speciesPagination.perPage
-      } );
       $scope.statsParams = statsParams;
-      var statsParamsOnlyCount = _.extend( { }, statsParams, { per_page: 0 } );
-      ObservationsFactory.speciesCounts( speciesParams ).then( function( response ) {
-        if( $scope.lastSearchTime != thisSearchTime ) { return; }
+      $scope.statsParamsOnlyCount = _.extend( { }, statsParams, { per_page: 0 } );
+
+      var dataLoadPromises = [$scope.loadSpecies];
+      $scope.currentView === "identifiers"
+        ? dataLoadPromises.unshift( $scope.loadIdentifiers )
+        : dataLoadPromises.push( $scope.loadIdentifiers );
+      $scope.currentView === "observers"
+        ? dataLoadPromises.unshift( $scope.loadObservers )
+        : dataLoadPromises.push( $scope.loadObservers );
+
+      dataLoadPromises.reduce( ( p, promise ) => {
+         return p.then( ( ) => promise( thisSearchTime ) );
+      }, Promise.resolve( ) );
+    } );
+  };
+
+  $scope.loadSpecies = function( searchTime ) {
+    var speciesParams = _.extend( { }, $scope.statsParams, {
+      per_page: $scope.speciesPagination.perPage
+    } );
+    return ObservationsFactory.speciesCounts( speciesParams )
+      .then( function( response ) {
+        if( $scope.lastSearchTime != searchTime ) { return; }
         $scope.totalSpecies = response.data.total_results;
         $scope.taxa = _.map( response.data.results, function( r ) {
           var t = new iNatModels.Taxon( r.taxon );
@@ -795,36 +812,43 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
           return t;
         });
         $scope.speciesPagination.searching = false;
-      } ).then( function( ) {
-        return ObservationsFactory
-          .identifiers( $scope.currentView === "identifiers" ? statsParams : statsParamsOnlyCount )
-          .then( function( response ) {
-          if( $scope.lastSearchTime != thisSearchTime ) { return; }
-          $scope.totalIdentifiers = response.data.total_results;
-          $scope.identifiers = _.map( response.data.results, function( r ) {
-            var u = new iNatModels.User( r.user );
-            u.resultCount = r.count;
-            return u;
-          } );
-          $scope.identifiersPagination.searching = false;
-        } );
-      } ).then( function( ) {
-        ObservationsFactory
-          .observers( $scope.currentView === "observers" ? statsParams : statsParamsOnlyCount )
-          .then( function( response ) {
-          if( $scope.lastSearchTime != thisSearchTime ) { return; }
-          $scope.totalObservers = response.data.total_results;
-          $scope.observers = _.map( response.data.results, function( r ) {
-            var u = new iNatModels.User( r.user );
-            u.observationCount = r.observation_count;
-            u.speciesCount = r.species_count;
-            return u;
-          } );
-          $scope.observersPagination.searching = false;
-        } );
       } );
-    } );
-  };
+  }
+
+  $scope.loadIdentifiers = function( searchTime ) {
+    return ObservationsFactory
+      .identifiers( $scope.currentView === "identifiers"
+        ? $scope.statsParams
+        : $scope.statsParamsOnlyCount )
+      .then( function( response ) {
+        if( $scope.lastSearchTime != searchTime ) { return; }
+        $scope.totalIdentifiers = response.data.total_results;
+        $scope.identifiers = _.map( response.data.results, function( r ) {
+          var u = new iNatModels.User( r.user );
+          u.resultCount = r.count;
+          return u;
+        } );
+        $scope.identifiersPagination.searching = false;
+      } );
+  }
+
+  $scope.loadObservers = function( searchTime ) {
+    return ObservationsFactory
+      .observers( $scope.currentView === "observers"
+        ? $scope.statsParams
+        : $scope.statsParamsOnlyCount )
+      .then( function( response ) {
+        if( $scope.lastSearchTime != searchTime ) { return; }
+        $scope.totalObservers = response.data.total_results;
+        $scope.observers = _.map( response.data.results, function( r ) {
+          var u = new iNatModels.User( r.user );
+          u.observationCount = r.observation_count;
+          u.speciesCount = r.species_count;
+          return u;
+        } );
+        $scope.observersPagination.searching = false;
+      } );
+  }
 
   $scope.showMoreIdentifiers = function( ) {
     $scope.identifiersPagination = $scope.identifiersPagination || { };

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -808,7 +808,7 @@ function( ObservationsFactory, PlacesFactory, TaxaFactory, shared, $scope, $root
           } );
           $scope.identifiersPagination.searching = false;
         } );
-      } ).then( function( ) => {
+      } ).then( function( ) {
         ObservationsFactory
           .observers( $scope.currentView === "observers" ? statsParams : statsParamsOnlyCount )
           .then( function( response ) {

--- a/app/assets/javascripts/ang/templates/observation_search/identifiers_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/identifiers_table.html.haml
@@ -16,7 +16,7 @@
           %user-icon{ u: "u" }
           %user-login{ u: "u" }
         %td {{ shared.numberWithCommas( u.resultCount ) }}
-  .spinner.ng-cloak{ "ng-show": "pagination.searching" }
+  .spinner.ng-cloak{ "ng-show": "pagination.searching || identifiersPagination.searching" }
     %span.fa.fa-spin.fa-refresh
   .noresults.text-muted.ng-cloak{ "ng-show": "noIdentifiers( )" }
     {{ shared.t( 'no_results_found' ) }}

--- a/app/assets/javascripts/ang/templates/observation_search/observers_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/observers_table.html.haml
@@ -21,7 +21,7 @@
           {{ shared.numberWithCommas( u.observationCount ) }}
         %td{ :class => "{{ observersSort == '-speciesCount' ? 'sorting' : '' }}" }
           {{ shared.numberWithCommas( u.speciesCount ) }}
-  .spinner.ng-cloak{ "ng-show": "pagination.searching" }
+  .spinner.ng-cloak{ "ng-show": "pagination.searching || observersPagination.searching" }
     %span.fa.fa-spin.fa-refresh
   .noresults.text-muted.ng-cloak{ "ng-show": "noObservers( )" }
     {{ shared.t( 'no_results_found' ) }}

--- a/app/webpack/observations/show/ducks/identifications.js
+++ b/app/webpack/observations/show/ducks/identifications.js
@@ -37,21 +37,19 @@ export function fetchIdentifiers( params ) {
     const { testingApiV2 } = state.config;
     const time = Date.now( );
     dispatch( setLastFetchTime( time ) );
-    const identifiersParams = Object.assign(
-      { },
-      params,
-      testingApiV2
-        ? {
-          fields: {
-            count: true,
-            user: {
-              login: true,
-              icon_url: true
-            }
-          }
+    const identifiersParams = {
+      ...params,
+      no_total_hits: true
+    };
+    if ( testingApiV2 ) {
+      identifiersParams.fields = {
+        count: true,
+        user: {
+          login: true,
+          icon_url: true
         }
-        : {}
-    );
+      };
+    }
     inatjs.identifications.identifiers( identifiersParams ).then( response => {
       // fetch the state again since we're reset lastFetchTime
       const { identifications } = getState( );

--- a/app/webpack/projects/shared/models/project.js
+++ b/app/webpack/projects/shared/models/project.js
@@ -35,6 +35,9 @@ const Project = class Project extends inatjs.Project {
       ttl: 900
     };
     if ( updatedSecondsAgo < 900 ) {
+      // the project was recently updated. Add a parameter ?v to the query,
+      // representing the value of updated_at, so results cached with
+      // potentially old search parameters are not used
       this.search_params.v = moment( this.updated_at ).format( "x" );
     }
     if ( this.is_traditional ) {

--- a/app/webpack/projects/shared/models/project.js
+++ b/app/webpack/projects/shared/models/project.js
@@ -29,11 +29,14 @@ const Project = class Project extends inatjs.Project {
     } );
     this.createSpecificRuleAttributes( );
     this.createRulePreferenceAttributes( );
+    const updatedSecondsAgo = moment( ).diff( this.updated_at, "seconds" );
     this.search_params = {
       project_id: this.id,
-      ttl: 900,
-      v: moment( this.updated_at ).format( "x" )
+      ttl: 900
     };
+    if ( updatedSecondsAgo < 900 ) {
+      this.search_params.v = moment( this.updated_at ).format( "x" );
+    }
     if ( this.is_traditional ) {
       this.search_params.collection_preview = true;
     }

--- a/app/webpack/projects/show/components/observers_tab.jsx
+++ b/app/webpack/projects/show/components/observers_tab.jsx
@@ -1,78 +1,96 @@
 import _ from "lodash";
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid, Row, Col } from "react-bootstrap";
+import InfiniteScroll from "react-infinite-scroller";
 import { numberWithCommas } from "../../../shared/util";
 import UserLink from "../../../shared/components/user_link";
 import UserImage from "../../../shared/components/user_image";
-import InfiniteScroll from "react-infinite-scroller";
 
-const ObserversTab = ( { config, observers, setConfig } ) => {
-  if ( _.isEmpty( observers ) ) { return ( <span /> ); }
-  const scrollIndex = config.observersScrollIndex || 30;
-  const loader = ( <div key="observers-tab-loading" className="loading_spinner huge" /> );
-  return (
-    <div className="Observers">
-      <Grid>
-        <Row>
-          <Col xs={ 12 }>
-            <InfiniteScroll
-              loadMore={ ( ) => { setConfig( { observersScrollIndex: scrollIndex + 30 } ); } }
-              hasMore={ observers.length >= scrollIndex }
-              loader={ loader }
-            >
-              <table key="observers-tab-table">
-                <thead>
-                  <tr>
-                    <th className="rank">{ I18n.t( "rank" ) }</th>
-                    <th>{ I18n.t( "user" ) }</th>
-                    <th
-                      className="clicky"
-                      onClick={ ( ) => setConfig( { observersSort: "observations" } ) }
-                    >
-                      { I18n.t( "observations" ) }
-                      <i className="fa fa-caret-down" />
-                    </th>
-                    <th
-                      className="clicky"
-                      onClick={ ( ) => setConfig( { observersSort: "species" } ) }
-                    >
-                      { I18n.t( "species" ) }
-                      <i className="fa fa-caret-down" />
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  { _.map( observers.slice( 0, scrollIndex ), ( i, index ) => {
-                    return (
-                      <tr className={ index % 2 !== 0 ? "odd" : "" } key={ `observer-${i.user.id}` }>
+class ObserversTab extends Component {
+  componentDidMount( ) {
+    this.props.fetchObservers( );
+  }
+
+  render( ) {
+    const {
+      project,
+      config,
+      observers,
+      setConfig,
+      setObserversSort
+    } = this.props;
+
+    if ( !project.all_observers_loaded ) {
+      return ( <div className="loading_spinner huge" /> );
+    }
+    if ( _.isEmpty( observers ) ) { return ( <span /> ); }
+    const scrollIndex = config.observersScrollIndex || 30;
+    const loader = ( <div key="observers-tab-loading" className="loading_spinner huge" /> );
+    return (
+      <div className="Observers">
+        <Grid>
+          <Row>
+            <Col xs={12}>
+              <InfiniteScroll
+                loadMore={( ) => { setConfig( { observersScrollIndex: scrollIndex + 30 } ); }}
+                hasMore={observers.length >= scrollIndex}
+                loader={loader}
+              >
+                <table key="observers-tab-table">
+                  <thead>
+                    <tr>
+                      <th className="rank">{ I18n.t( "rank" ) }</th>
+                      <th>{ I18n.t( "user" ) }</th>
+                      <th
+                        className="clicky"
+                        onClick={( ) => setObserversSort( "observations" )}
+                      >
+                        { I18n.t( "observations" ) }
+                        <i className="fa fa-caret-down" />
+                      </th>
+                      <th
+                        className="clicky"
+                        onClick={( ) => setObserversSort( "species" )}
+                      >
+                        { I18n.t( "species" ) }
+                        <i className="fa fa-caret-down" />
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    { _.map( observers.slice( 0, scrollIndex ), ( i, index ) => (
+                      <tr className={index % 2 !== 0 ? "odd" : ""} key={`observer-${i.user.id}`}>
                         <td className="rank">{ index + 1 }</td>
                         <td>
-                          <UserImage user={ i.user } />
-                          <UserLink user={ i.user } />
+                          <UserImage user={i.user} />
+                          <UserLink user={i.user} />
                         </td>
-                        <td className={ `count ${config.observersSort !== "species" && "sorted"}` }>
+                        <td className={`count ${config.observersSort !== "species" && "sorted"}`}>
                           { numberWithCommas( i.observation_count ) }
                         </td>
-                        <td className={ `count ${config.observersSort === "species" && "sorted"}` }>
+                        <td className={`count ${config.observersSort === "species" && "sorted"}`}>
                           { numberWithCommas( i.species_count ) }
                         </td>
                       </tr>
-                    );
-                  } ) }
-                </tbody>
-              </table>
-            </InfiniteScroll>
-          </Col>
-        </Row>
-      </Grid>
-    </div>
-  );
-};
+                    ) ) }
+                  </tbody>
+                </table>
+              </InfiniteScroll>
+            </Col>
+          </Row>
+        </Grid>
+      </div>
+    );
+  }
+}
 
 ObserversTab.propTypes = {
+  project: PropTypes.object,
   config: PropTypes.object,
   setConfig: PropTypes.func,
+  setObserversSort: PropTypes.func,
+  fetchObservers: PropTypes.func,
   observers: PropTypes.array
 };
 

--- a/app/webpack/projects/show/containers/observers_tab_container.js
+++ b/app/webpack/projects/show/containers/observers_tab_container.js
@@ -1,19 +1,21 @@
 import { connect } from "react-redux";
 import ObserversTab from "../components/observers_tab";
-import { setConfig } from "../../../shared/ducks/config";
+import { setObserversSort, fetchObservers } from "../ducks/project";
 
 function mapStateToProps( state ) {
   return {
     config: state.config,
-    observers: state.config.observersSort === "species" ?
-      state.project.species_observers && state.project.species_observers.results :
-      state.project.observers && state.project.observers.results
+    observers: state.config.observersSort === "species" && state.project.species_observers_loaded
+      ? state.project.species_observers && state.project.species_observers.results
+      : state.project.observers && state.project.observers.results,
+    project: state.project
   };
 }
 
 function mapDispatchToProps( dispatch ) {
   return {
-    setConfig: attributes => { dispatch( setConfig( attributes ) ); }
+    setObserversSort: attributes => { dispatch( setObserversSort( attributes ) ); },
+    fetchObservers: ( ) => { dispatch( fetchObservers( true ) ); }
   };
 }
 

--- a/app/webpack/projects/show/containers/top_species_observers_panel_container.js
+++ b/app/webpack/projects/show/containers/top_species_observers_panel_container.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { connect } from "react-redux";
 import LeaderboardPanel from "../components/leaderboard_panel";
 
@@ -6,8 +7,8 @@ function mapStateToProps( state ) {
     config: state.config,
     project: state.project,
     type: "species_observers",
-    leaders: state.project && state.project.species_observers_loaded ?
-      state.project.species_observers.results : null
+    leaders: state.project && state.project.observers_loaded
+      ? _.reverse( _.sortBy( state.project.observers.results, "species_count" ) ) : null
   };
 }
 

--- a/app/webpack/taxa/show/ducks/leaders.js
+++ b/app/webpack/taxa/show/ducks/leaders.js
@@ -44,7 +44,11 @@ export function fetchTopObserver( ) {
   return function ( dispatch, getState ) {
     const state = getState( );
     const { testingApiV2 } = state.config;
-    const params = { ...defaultObservationParams( state ), per_page: 1 };
+    const params = {
+      ...defaultObservationParams( state ),
+      per_page: 1,
+      no_total_hits: true
+    };
     if ( testingApiV2 ) {
       params.fields = {
         observation_count: true,
@@ -67,7 +71,8 @@ export function fetchTopIdentifier( ) {
     const params = {
       ...defaultObservationParams( getState( ) ),
       own_observation: false,
-      per_page: 1
+      per_page: 1,
+      no_total_hits: true
     };
     if ( testingApiV2 ) {
       params.fields = {


### PR DESCRIPTION
* project and explore pages load tab data in sequence, prioritizing current tab
* explore delays loading list of identifiers and observers
* umbrella projects delay loading list of observers
* avoid calculating query totals when possible