### PR TITLE
add topic id

### DIFF
--- a/app/views/users/dashboard.html.haml
+++ b/app/views/users/dashboard.html.haml
@@ -143,7 +143,7 @@
                 .list-group-item
                   - datetime = DateTime.parse( topic["created_at"] ).in_time_zone( Time.zone )
                   .title
-                    = link_to topic["title"], "#{@discourse_url}/t/#{topic["slug"]}"
+                    = link_to topic["title"], "#{@discourse_url}/t/#{topic["slug"]}/#{topic["id"]}"
                     .categories
                       - if dc = @discourse_data[:categories][topic["category_id"]]
                         %a.inlineblock.label.label-default{ href: "#{@discourse_url}/c/#{dc["slug"]}", style: "color: ##{dc["text_color"]}; background-color: ##{dc["color"]}" }


### PR DESCRIPTION
Discourse meta is quite clear that a URL is incomplete/malformed without the topic id, see https://meta.discourse.org/t/inbound-links-dont-show-up-when-topic-id-is-not-included/100551/2
https://meta.discourse.org/t/clicking-an-internal-link-with-slug-only-and-no-topic-id-should-create-a-history-entry/176475
https://meta.discourse.org/t/incomplete-topic-titles-beginning-with-a-number-can-have-odd-behavior/153975


When links are constructed without the topic id, they will redirect to the wrong topic if the topic title starts with a number, e.g.
https://forum.inaturalist.org/t/particular-topic-under-18s-photo-contest-is-redirected-to-an-unrelated-topic-unable-to-search-by-obs-id/23168
https://forum.inaturalist.org/t/forum-link-on-inat-home-page-takes-me-to-wrong-thread/11443
https://forum.inaturalist.org/t/broken-link-to-forum-topic-from-inat-dashboard/19849
https://forum.inaturalist.org/t/five-5-hours-of-scheduled-downtime-april-13th-14th/40675

This PR is to add the topic id.