### PR TITLE
Don't suggest logins containing sensitive numbers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,7 +279,14 @@ class User < ApplicationRecord
   
   MIN_LOGIN_SIZE = 3
   MAX_LOGIN_SIZE = 40
-  DEFAULT_LOGIN = "naturalist"
+  DEFAULT_LOGIN = "naturalist".freeze
+
+  # Do not append these numbers to usernames when generating an unused username for a new user.
+  # Source: https://www.adl.org/resources/hate-symbols/search?f%5B0%5D=topic%3A1709
+  LOGIN_SUFFIX_EXCLUSIONS = [
+    100, 109, 110, 111, 12, 13, 1352, 1390, 52, 90, 14, 1410, 1423, 1488, 18, 21_212, 2316, 28, 23, 16, 311,
+    318, 336, 38, 43, 511, 737, 83, 88, 9, 10
+  ].freeze
 
   # Regexes from restful_authentication
   LOGIN_PATTERN     = "[A-Za-z][\\\w\\\-_]+"
@@ -862,40 +869,43 @@ class User < ApplicationRecord
     u
   end
 
-  # given a requested login, will try to find existing users with that login
-  # and suggest handle2, handle3, handle4, etc if the login's taken
-  # to prevent namespace clashes (e.g. i register with twitter @joe but 
-  # there's already an inat user where login=joe, so it suggest joe2)
+  # Sanitize the requested login.
+  # If the sanitized login is available, return it.
+  # If not, add numbers to the end until we find an available login. Particularly long requested logins may have
+  # characters removed from the end.
+  # If we somehow couldn't find a reasonable login, return nil.
   def self.suggest_login(requested_login)
-    requested_login = requested_login.to_s
-    requested_login = DEFAULT_LOGIN if requested_login.blank?
-    requested_login = I18n.transliterate( requested_login ).sub( /^\d*/, "" ).gsub( /\?+/, "" )
-    requested_login = if requested_login.blank?
-      DEFAULT_LOGIN
-    else
-      requested_login.gsub( /\W/, "_" ).downcase
-    end
-    suggested_login = requested_login
+    base_login = sanitize_login( requested_login.to_s ).presence || DEFAULT_LOGIN
 
-    if suggested_login.size > MAX_LOGIN_SIZE
-      suggested_login = suggested_login[0..MAX_LOGIN_SIZE/2]
-    end
+    # Random-number suffixes shouldn't be more than half the total character count available for a login.
+    max_random_suffix = 10 ** ( MAX_LOGIN_SIZE / 2 ).to_i
+    random_suffixes = Enumerator.produce { rand( max_random_suffix ) }
+    numeric_suffixes =  ( 1..9 ).
+      chain( random_suffixes.take( 20 ) ).
+      reject { |number| LOGIN_SUFFIX_EXCLUSIONS.include? number }
+    suffixes = [""].chain( numeric_suffixes.map( &:to_s ) )
 
-    if suggested_login =~ /^#{DEFAULT_LOGIN}\d+?/
-      while suggested_login.to_s.size < MIN_LOGIN_SIZE || User.find_by_login( suggested_login )
-        suggested_login = "#{requested_login}#{rand( User.maximum(:id) * 2 )}"
-      end
-    else
-      # if the name is semi-unique, try to append integers, so kueda would get
-      # kueda2 and not kueda34097348976 off the bat
-      appendix = 1
-      while suggested_login.to_s.size < MIN_LOGIN_SIZE || User.find_by_login(suggested_login)
-        suggested_login = "#{requested_login}#{appendix}"
-        appendix += 1
-      end
-    end
+    # Delete some characters off the end of the end if necessary to fit the suffix while staying under
+    # MAX_LOGIN_SIZE.
+    suggested_logins = suffixes.
+      map { |suffix| base_login[0..MAX_LOGIN_SIZE - ( suffix.size + 1 )] + suffix }.
+      reject { |login| login.size < MIN_LOGIN_SIZE }
 
-    (MIN_LOGIN_SIZE..MAX_LOGIN_SIZE).include?(suggested_login.size) ? suggested_login : nil
+    # Find an available login.
+    suggested_logins.find { |login| where( login: login ).none? }
+  end
+
+  # A sanitized login:
+  # - contains only the characters a-z, 0-9, and _
+  # - does not begin with a number
+  # - may or may not be taken
+  # - may or may not fit the size requirements for a login
+  def self.sanitize_login( login )
+    I18n.transliterate( login ).
+      sub( /^\d*/, "" ).
+      gsub( "?", "" ).
+      gsub( /\W/, "_" ).
+      downcase
   end
 
   # Destroying a user triggers a giant, slow, costly cascade of deletions that

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -877,8 +877,8 @@ class User < ApplicationRecord
   def self.suggest_login(requested_login)
     base_login = sanitize_login( requested_login.to_s ).presence || DEFAULT_LOGIN
 
-    # Random-number suffixes shouldn't be more than half the total character count available for a login.
-    max_random_suffix = 10 ** ( MAX_LOGIN_SIZE / 2 ).to_i
+    # Biggest random number to append to the login to make it unique
+    max_random_suffix = 100_000
     random_suffixes = Enumerator.produce { rand( max_random_suffix ) }
     numeric_suffixes =  ( 1..9 ).
       chain( random_suffixes.take( 20 ) ).

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -986,7 +986,7 @@ describe User do
   end
 
   describe "suggest_login" do
-    it "should suggest logins that are too short" do
+    it "should not suggest logins that are too short" do
       suggestion = User.suggest_login("AJ")
       expect(suggestion).not_to be_blank
       expect(suggestion.size).to be >= User::MIN_LOGIN_SIZE

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1020,10 +1020,13 @@ describe User do
       expect(suggestion).not_to be_blank
       expect(suggestion).to eq "naturalist1"
 
-      User.make!(login: "naturalist1")
+      # 9 is forbidden
+      (1..8).each do |i|
+        User.make!(login: "naturalist#{i}")
+      end
+      allow(User).to receive(:rand).and_return(12345)
       suggestion = User.suggest_login("")
-      expect(suggestion).not_to be_blank
-      expect(suggestion).to eq "naturalist2"
+      expect(suggestion).to eq "naturalist12345"
     end
 
   end


### PR DESCRIPTION
Fixes: #3713 

Do you want to include 666, 69, 420, or anything else in here?

- Clean up code. Remove all conditionals. You can read what happens in a straight line from top to bottom. Variables have meaningful names. The comments are hopefully helpful.
- The same logic is applied to `DEFAULT_LOGIN` as to requested logins. We try the base login, then try adding a single digit (except 9), then try twenty psuedorandom numbers.
- Random-number suffixes are limited at half of `MAX_LOGIN_SIZE` rather than a number derived from the storage of the `id` field.
- It will fail rather than trying logins indefinitely.

This could be done in a single SQL query, but I'd have to write custom Arel, which didn't seem worth it.

This method should perhaps raise an error rather than returning nil, but that would change its contract.