### PR TITLE
Script to remind unconfirmed users to confirm their email (#3764)

### DIFF
--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -241,6 +241,37 @@ class Emailer < ActionMailer::Base
     reset_locale
   end
 
+  def email_confirmation_reminder( user )
+    @user = user
+    @user.send( :generate_confirmation_token! ) if @user.confirmation_token.blank?
+    set_locale
+    @x_smtpapi_headers[:asm_group_id] = CONFIG&.sendgrid&.asm_group_ids&.account
+    ident_response = Identification.elastic_search(
+      size: 0,
+      filters: [
+        { term: { "user.id": @user.id } },
+        { term: { own_observation: false } },
+        { term: { current: true } }
+      ],
+      aggregate: {
+        distinct_obs_users: {
+          cardinality: { field: "observation.user_id" }
+        }
+      },
+      track_total_hits: true
+    )
+    @identifications_count = ident_response.total_entries
+    mail_with_defaults( set_site_specific_opts.merge(
+      to: user.email,
+      subject: t(
+        :email_confirmation_reminder_confirm_your_site_email_address_before_date,
+        site_name: @site.name,
+        date: l( User::EMAIL_CONFIRMATION_REQUIREMENT_DATE, format: :long )
+      )
+    ) )
+    reset_locale
+  end
+
   private
 
   def mail_with_defaults( defaults = {} )

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -261,11 +261,13 @@ class Emailer < ActionMailer::Base
       track_total_hits: true
     )
     @identifications_count = ident_response.total_entries
+    @skip_donate = true
     mail_with_defaults( set_site_specific_opts.merge(
       to: user.email,
       subject: t(
         :email_confirmation_reminder_confirm_your_site_email_address_before_date,
         site_name: @site.name,
+        vow_or_con: @site.name[0].downcase,
         date: l( User::EMAIL_CONFIRMATION_REQUIREMENT_DATE, format: :long )
       )
     ) )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -393,7 +393,7 @@ class User < ApplicationRecord
   end
 
   EMAIL_CONFIRMATION_RELEASE_DATE = Date.parse( "2022-12-14" )
-  EMAIL_CONFIRMATION_REQUIREMENT_DATE = Date.parse( "2023-07-01" )
+  EMAIL_CONFIRMATION_REQUIREMENT_DATE = Date.parse( "2023-09-01" )
 
   # This is a dangerous override in that it doesn't call super, thereby
   # ignoring the results of all the devise modules like confirmable. We do
@@ -406,10 +406,10 @@ class User < ApplicationRecord
 
     # Temporary state to allow existing users to sign in. Probably redundant
     # with the next grandparent exception
-    return true if confirmation_sent_at.blank?
+    return true if confirmation_sent_at.blank? && Time.now < EMAIL_CONFIRMATION_REQUIREMENT_DATE
 
     # Temporary state to allow existing users to sign in
-    return true if created_at < EMAIL_CONFIRMATION_RELEASE_DATE
+    return true if created_at < EMAIL_CONFIRMATION_RELEASE_DATE && Time.now < EMAIL_CONFIRMATION_REQUIREMENT_DATE
 
     super
   end

--- a/app/views/emailer/_footer.html.erb
+++ b/app/views/emailer/_footer.html.erb
@@ -119,7 +119,9 @@
                           <table width="100%">
                             <tr>
                               <td align="right">
-                                <%= link_to t(:donate), donate_url( utm_content: "footer-button", utm_campaign: "default", utm_source: @site.domain, utm_medium: "email", utm_term: "donate" ), title: t(:donate), style: "width: auto; min-width: 50%; margin-bottom: 20px; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;" %>
+                                <%- unless @skip_donate -%>
+                                  <%= link_to t(:donate), donate_url( utm_content: "footer-button", utm_campaign: "default", utm_source: @site.domain, utm_medium: "email", utm_term: "donate" ), title: t(:donate), style: "width: auto; min-width: 50%; margin-bottom: 20px; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;" %>
+                                <%- end -%>
                                 <%= link_to t(:store_caps), "https://store.inaturalist.org", title: t(:store), style: "width: auto; min-width: 50%; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;" %>
                               </td>
                             </tr>

--- a/app/views/emailer/_footer.html.erb
+++ b/app/views/emailer/_footer.html.erb
@@ -120,7 +120,7 @@
                             <tr>
                               <td align="right">
                                 <%= link_to t(:donate), donate_url( utm_content: "footer-button", utm_campaign: "default", utm_source: @site.domain, utm_medium: "email", utm_term: "donate" ), title: t(:donate), style: "width: auto; min-width: 50%; margin-bottom: 20px; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;" %>
-                                <%= link_to t(:store), "https://store.inaturalist.org", title: t(:store), style: "width: auto; min-width: 50%; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;" %>
+                                <%= link_to t(:store_caps), "https://store.inaturalist.org", title: t(:store), style: "width: auto; min-width: 50%; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;" %>
                               </td>
                             </tr>
                           </table>

--- a/app/views/emailer/email_confirmation_reminder.html.haml
+++ b/app/views/emailer/email_confirmation_reminder.html.haml
@@ -1,0 +1,24 @@
+= render "header"
+
+%p=t :email_confirmation_reminder_please_confirm, site_name: @site.name, vow_or_con: @site.name[0].downcase
+%p{ style: "margin: 30px 0; text-align: center" }
+  = link_to t( "devise.mailer.confirmation_instructions.subject" ), user_confirmation_url( confirmation_token: @user.confirmation_token ), style: "width: auto; min-width: 50%; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; background-color: #74ac00; color: white; border-radius: 50px; padding: 10px; font-size: 15px; text-decoration: none; display: inline-block; text-align: center; letter-spacing: 1px;"
+%p
+  %strong=t :email_confirmation_reminder_account_details
+%p
+  =t :bold_label_colon_value_html, label: t( :login, scope: [:activerecord, :attributes, :user] ), value: @user.login
+  %br
+  =t :bold_label_colon_value_html, label: t( :email, scope: [:activerecord, :attributes, :user] ), value: @user.email
+  %br
+  =t :bold_label_colon_value_html, label: t( :date_joined ), value: l( @user.created_at.to_date, format: :long )
+  %br
+  =t :x_observations, count: @user.observations_count
+  %br
+  =t :x_identifications, count: @identifications_count
+  %br
+  =t :x_comments, count: @user.comments.count
+
+%p=t :email_confirmation_reminder_we_will_require, requirement_date: l( User::EMAIL_CONFIRMATION_REQUIREMENT_DATE, format: :long )
+%p=t :email_confirmation_reminder_any_questions, site_name: @site.name, vow_or_con: @site.name[0].downcase
+
+= render "footer"

--- a/config/initializers/script_find_each.rb
+++ b/config/initializers/script_find_each.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 module ActiveRecord
   module Batches
     # Just like find_each except it writes useful output to STDOUT
-    def script_find_each(options = {})
-      total = self.count
+    def script_find_each( options = {} )
+      total = count
       current = 1
       recent_times = []
-      flush = options.delete(:flush)
-      max_count_width = Math::log( total ) + 2
-      find_each(options) do |record|
+      flush = options.delete( :flush )
+      max_count_width = Math.log( total ) + 2
+      find_each do | record |
         eta = "??????????????????"
         avg = 0
         unless recent_times.blank?
@@ -18,15 +20,15 @@ module ActiveRecord
         end
         pieces = [
           "#{record.class.name} #{record.id}".ljust( max_count_width + record.class.name.size + 5 ),
-          "#{current.to_s.rjust(max_count_width)} / #{total}",
-          "#{(current.to_f / total * 100).round(2)}%",
-          "Avg: #{"#{avg.to_f.round( 4 ).to_s}s".ljust(10)}",
+          "#{current.to_s.rjust( max_count_width )} / #{total}",
+          "#{( current.to_f / total * 100 ).round( 2 )}%",
+          "Avg: #{"#{avg.to_f.round( 4 )}s".ljust( 10 )}",
           "ETA #{eta}"
         ]
         col_size = pieces.sort.last.size + 4
-        msg = pieces.map{|p| p.ljust( col_size )}.join
+        msg = pieces.map {| p | p.ljust( col_size ) }.join
         if flush
-          print msg + "\r"
+          print "#{msg}\r"
           $stdout.flush
         else
           puts msg
@@ -34,7 +36,7 @@ module ActiveRecord
         current += 1
         start = Time.now
         yield record
-        recent_times << Time.now - start
+        recent_times << ( Time.now - start )
         recent_times.unshift if recent_times.size > 10
       end
     end

--- a/config/initializers/script_find_each.rb
+++ b/config/initializers/script_find_each.rb
@@ -18,8 +18,9 @@ module ActiveRecord
             avg * ( total - current )
           ).seconds.from_now )
         end
+        identifier = "#{options[:label]} #{record.class.name} #{record.id}".strip
         pieces = [
-          "#{record.class.name} #{record.id}".ljust( max_count_width + record.class.name.size + 5 ),
+          identifier.ljust( identifier.size + 5 ),
           "#{current.to_s.rjust( max_count_width )} / #{total}",
           "#{( current.to_f / total * 100 ).round( 2 )}%",
           "Avg: #{"#{avg.to_f.round( 4 )}s".ljust( 10 )}",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1920,21 +1920,31 @@ en:
     date anyone who has not confirmed their email address will be unable to
     sign in unless they reset their password. To confirm your email address,
     go to your %{link_start_tag}account settings%{link_end_tag}.
+  # Subject of an email prompting people to confirm their email address before
+  # we start requiring confirmation. @vow_or_con should work for %{site_name}
   email_confirmation_reminder_confirm_your_site_email_address_before_date:
     Confirm your %{site_name} email address before %{date}
-  # @vow_or_con should work for %{site_name}
+  # Paragraph in an email prompting people to confirm their email address before
+  # we start requiring confirmation. @vow_or_con should work for %{site_name}
   email_confirmation_reminder_please_confirm: |
     Please confirm your email address today to ensure that you can continue to
     access your account. %{site_name} and the mobile apps
     iNaturalist and Seek by iNaturalist connect people to nature and each
     other by sharing observations of biodiversity. Thank you for being a part
     of the iNaturalist community!
+  # Paragraph in an email prompting people to confirm their email address before
+  # we start requiring confirmation.
   email_confirmation_reminder_we_will_require: |
     We will require verified email addresses for all accounts starting on
     %{requirement_date}. Please take a moment to confirm it now.
+  # Paragraph in an email prompting people to confirm their email address before
+  # we start requiring confirmation.
   email_confirmation_reminder_any_questions: |
     If you have any questions, please refer to the FAQs. Thank you for taking
     the time to connect with nature and with %{site_name}.
+  # Header in email prompting people to confirm their email address before we
+  # start requiring confirmation. This preceeds some details about the
+  # recipient's account.
   email_confirmation_reminder_account_details: Account Details
   email_copyright: "Copyright &copy; %{x}, all rights reserved"
   email_notifications: Email Notifications

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1920,6 +1920,22 @@ en:
     date anyone who has not confirmed their email address will be unable to
     sign in unless they reset their password. To confirm your email address,
     go to your %{link_start_tag}account settings%{link_end_tag}.
+  email_confirmation_reminder_confirm_your_site_email_address_before_date:
+    Confirm your %{site_name} email address before %{date}
+  # @vow_or_con should work for %{site_name}
+  email_confirmation_reminder_please_confirm: |
+    Please confirm your email address today to ensure that you can continue to
+    access your account. %{site_name} and the mobile apps
+    iNaturalist and Seek by iNaturalist connect people to nature and each
+    other by sharing observations of biodiversity. Thank you for being a part
+    of the iNaturalist community!
+  email_confirmation_reminder_we_will_require: |
+    We will require verified email addresses for all accounts starting on
+    %{requirement_date}. Please take a moment to confirm it now.
+  email_confirmation_reminder_any_questions: |
+    If you have any questions, please refer to the FAQs. Thank you for taking
+    the time to connect with nature and with %{site_name}.
+  email_confirmation_reminder_account_details: Account Details
   email_copyright: "Copyright &copy; %{x}, all rights reserved"
   email_notifications: Email Notifications
   embed: 'Embed'
@@ -8706,17 +8722,17 @@ en:
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
       default: '%Y-%m-%d'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      long: '%B %d, %Y'
+      long: '%B %-d, %Y'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      short: '%b %d'
+      short: '%b %-d'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
       compact: "%b %e"
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      short_with_year: '%b %d, %Y'
+      short_with_year: '%b %-d, %Y'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
       month_year: '%B %Y'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      month_day_year: '%B %d, %Y'
+      month_day_year: '%B %-d, %Y'
     month_names:
       -
       - January
@@ -8861,17 +8877,17 @@ en:
     am: am
     formats:
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      default: '%b. %d, %Y %H:%M:%S %z'
+      default: '%b. %-d, %Y %H:%M:%S %z'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      long: '%B %d, %Y %I:%M %p'
+      long: '%B %-d, %Y %I:%M %p'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      short: '%d %b %H:%M'
+      short: '%-d %b %H:%M'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
       compact: "%I:%M %p"
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
       observed_at: '%I:%M %p %Z'
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
-      day_month_year: "%B %d, %Y"
+      day_month_year: "%B %-d, %Y"
       # See https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-strftime for formatting codes
       hours: "%l:%M %p"
     pm: pm

--- a/test/mailers/previews/emailer_preview.rb
+++ b/test/mailers/previews/emailer_preview.rb
@@ -1,4 +1,5 @@
-#encoding: utf-8
+# frozen_string_literal: true
+
 class EmailerPreview < ActionMailer::Preview
   # Preview at /rails/mailers/emailer/updates_notification
   def updates_notification
@@ -13,9 +14,9 @@ class EmailerPreview < ActionMailer::Preview
       sort: { id: :desc },
       keep_es_source: true
     ).first.es_source.subscriber_ids.first
-    @user = User.find(recently_notified_user_id)
+    @user = User.find( recently_notified_user_id )
     updates = @user.recent_notifications( per_page: 50 )
-    Emailer.updates_notification(@user, updates)
+    Emailer.updates_notification( @user, updates )
   end
 
   def new_message
@@ -25,7 +26,7 @@ class EmailerPreview < ActionMailer::Preview
     # end
     m = Message.where( to_user_id: 1, user_id: 1 ).first
     m ||= Message.last
-    Emailer.new_message(m)
+    Emailer.new_message( m )
   end
 
   def observations_export_notification
@@ -33,8 +34,8 @@ class EmailerPreview < ActionMailer::Preview
     # ft = if (ftid = @rack_env["QUERY_STRING"].to_s[/flow_task_id=([^&]+)/, 1])
     #   FlowTask.find_by_id(ftid)
     # end
-    ft ||= ObservationsExportFlowTask.includes(:outputs).where("flow_task_resources.id IS NOT NULL").last
-    Emailer.observations_export_notification(ft)
+    ft ||= ObservationsExportFlowTask.includes( :outputs ).where( "flow_task_resources.id IS NOT NULL" ).last
+    Emailer.observations_export_notification( ft )
   end
 
   def project_user_invitation
@@ -43,34 +44,34 @@ class EmailerPreview < ActionMailer::Preview
     #   ProjectUserInvitation.find_by_id(id)
     # end
     pui ||= ProjectUserInvitation.last
-    Emailer.project_user_invitation(pui)
+    Emailer.project_user_invitation( pui )
   end
 
   def confirmation_instructions
     # locale is determined by the user's locale
     set_user
     @user ||= User.first
-    DeviseMailer.devise_mail(@user, :confirmation_instructions)
+    DeviseMailer.devise_mail( @user, :confirmation_instructions )
   end
 
   def bulk_observation_success
     set_locale
     @user ||= User.first
-    Emailer.bulk_observation_success(@user, "some_file_name")
+    Emailer.bulk_observation_success( @user, "some_file_name" )
   end
 
   def bulk_observation_error
     set_locale
     @user ||= User.first
-    bof = BulkObservationFile.new(nil, nil, nil, @user)
+    bof = BulkObservationFile.new( nil, nil, nil, @user )
     o = Observation.new
     e = BulkObservationFile::BulkObservationException.new(
-      "failed to process", 
-      1, 
-      [BulkObservationFile::BulkObservationException.new("observation was invalid", 1, o.errors)]
+      "failed to process",
+      1,
+      [BulkObservationFile::BulkObservationException.new( "observation was invalid", 1, o.errors )]
     )
-    errors = bof.collate_errors(e)
-    Emailer.bulk_observation_error(@user, "some_file_name", errors)
+    errors = bof.collate_errors( e )
+    Emailer.bulk_observation_error( @user, "some_file_name", errors )
   end
 
   def parental_consent
@@ -99,7 +100,7 @@ class EmailerPreview < ActionMailer::Preview
   end
 
   def curator_application
-    lorem = <<-EOT
+    lorem = <<-LOREM
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
       veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -107,7 +108,7 @@ class EmailerPreview < ActionMailer::Preview
       velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
       cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
       est laborum.
-    EOT
+    LOREM
     Emailer.curator_application( User.last, {
       explanation: lorem,
       taxonomy_examples: lorem,
@@ -120,7 +121,12 @@ class EmailerPreview < ActionMailer::Preview
     Emailer.welcome( User.last )
   end
 
+  def email_confirmation_reminder
+    Emailer.email_confirmation_reminder( User.last )
+  end
+
   private
+
   def set_user
     # @user = if login = @rack_env["QUERY_STRING"].to_s[/login=([^&]+)/, 1]
     #   User.find_by_login(login)

--- a/tools/email_unconfirmed_users.rb
+++ b/tools/email_unconfirmed_users.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rubygems"
+require "optimist"
+
+@opts = Optimist.options do
+  banner <<~HELP
+    Email unconfirmed users asking them to confirm
+
+    where [options] are:
+  HELP
+  opt :debug, "Print debug statements", type: :boolean, short: "-d"
+  opt :dry, "Dry run, don't make changes, just report", type: :boolean
+  opt :users, "Comma-separated list of user logins or IDs to mail for testing", type: :string
+  opt :english, "Only email en-* locale users"
+  opt :non_english, "Only email NOT en-* locale users"
+end
+
+test_users = @opts.users.to_s.split( "," )
+scope = if test_users.size.positive?
+  test_user_ids = test_users.map do | identifier |
+    if identifier.to_i.positive?
+      identifier
+    else
+      User.find_by_login( identifier ).id
+    end
+  end
+  User.where( id: test_user_ids )
+else
+  User.
+    where( "confirmed_at IS NULL" ).
+    where( "(NOT spammer OR spammer IS NULL)" ).
+    where( "email IS NOT NULL" )
+end
+
+if @opts.english
+  scope = scope.where( "locale LIKE 'en%'" )
+elsif @opts.non_english
+  scope = scope.where( "locale NOT LIKE 'en%'" )
+end
+
+@start = Time.now
+@emailed = 0
+@failed = 0
+@failures_by_user_id = {}
+
+scope.script_find_each do | recipient |
+  next if recipient.email.size.zero?
+  next if recipient.email_suppressed_in_group?(
+    [
+      EmailSuppression::BLOCKS,
+      EmailSuppression::BOUNCES,
+      EmailSuppression::INVALID_EMAILS
+    ]
+  )
+  next if @opts.users.blank? && recipient.confirmed?
+
+  puts "[DEBUG] Emailing recipient: #{recipient}" if @opts.debug
+
+  begin
+    Emailer.email_confirmation_reminder( recipient ).deliver_now unless @opts.dry
+    @emailed += 1
+  rescue => e
+    @failed += 1
+    @failures_by_user_id[recipient.id] = e
+  end
+end
+
+puts
+puts "#{@emailed} users emailed, #{@failed} failed in #{Time.now - @start}s"
+unless @failures_by_user_id.blank?
+  puts "Failure user IDs: #{@failures_by_user_id.keys.join( ', ' )}"
+  puts "First 5 failures:"
+  @failures_by_user_id.to_a[0..5].each do | _user_id, error |
+    puts error
+    puts
+  end
+end
+puts


### PR DESCRIPTION
* Emailer#email_confirmation_reminder to send the email
* tools/email_unconfirmed_users.rb to send the emails
* Enforce User::EMAIL_CONFIRMATION_REQUIREMENT_DATE
* Minor fixes for script_find_each

Open to reviews, but please don't merge until we've had a chance to test this a bit. I want to minimize the churn for translators.