### PR TITLE
Improved error message after confirmation requirement

### DIFF
--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -41,5 +41,15 @@ class OauthTokensController < Doorkeeper::TokensController
       error: "invalid_grant",
       error_description: I18n.t( "devise.failure.unconfirmed" )
     }.to_json
+  rescue INat::Auth::UnconfirmedAfterGracePeriodError
+    headers.delete "WWW-Authenticate"
+    self.status = 400
+    self.response_body = {
+      error: "invalid_grant",
+      error_description: I18n.t(
+        :email_conf_required_after_grace_period,
+        requirement_date: I18n.l( User::EMAIL_CONFIRMATION_REQUIREMENT_DATE, format: :long )
+      )
+    }.to_json
   end
 end

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -68,6 +68,15 @@ class ProviderOauthController < ApplicationController
         error_description: t( "devise.failure.unconfirmed" )
       }
       return
+    rescue INat::Auth::UnconfirmedAfterGracePeriodError
+      render status: :bad_request, json: {
+        error: "invalid_grant",
+        error_description: I18n.t(
+          :email_conf_required_after_grace_period,
+          requirement_date: I18n.l( User::EMAIL_CONFIRMATION_REQUIREMENT_DATE, format: :long )
+        )
+      }
+      return
     end
 
     if access_token
@@ -273,6 +282,7 @@ class ProviderOauthController < ApplicationController
     unless user.active_for_authentication?
       raise INat::Auth::SuspendedError if user.suspended?
       raise INat::Auth::ChildWithoutPermissionError if user.child_without_permission?
+      raise INat::Auth::UnconfirmedAfterGracePeriodError if user.unconfirmed_grace_period_expired?
       raise INat::Auth::UnconfirmedError if !user.confirmed? || confirmation_sent_at.blank?
     end
     access_token = Doorkeeper::AccessToken.

--- a/app/controllers/shared/filters_module.rb
+++ b/app/controllers/shared/filters_module.rb
@@ -1,63 +1,70 @@
-module Shared::FiltersModule
-  private
+# frozen_string_literal: true
 
-  def set_request_locale
-    # use params[:locale] for single-request locale settings,
-    # otherwise use the session, user's preferred, or site default,
-    # or application default locale
-    locale = params[:locale]
-    locale = current_user.try(:locale) if locale.blank?
-    locale = session[:locale] if locale.blank?
-    locale = @site.locale if @site && locale.blank?
-    locale = locale_from_header if locale.blank?
-    locale = I18n.default_locale if locale.blank?
-    if locale =~ /\-[a-z]/
-      pieces = locale.split( "-" )
-      locale = "#{pieces[0].downcase}-#{pieces[1].upcase}"
-    end
-    I18n.locale = locale
-    if I18n.locale.to_s == "iw"
-      I18n.locale = I18n.locale.to_s.sub( "iw", "he" ).to_sym
-    end
-    unless I18N_SUPPORTED_LOCALES.include?( I18n.locale.to_s )
-      I18n.locale = I18n.default_locale
-    end
-    @rtl = params[:test] == "rtl" && ["ar", "fa", "he"].include?( I18n.locale.to_s )
-    true
-  end
+module Shared
+  module FiltersModule
+    private
 
-  def locale_from_header
-    return if request.env["HTTP_ACCEPT_LANGUAGE"].blank?
-    http_locale = request.env["HTTP_ACCEPT_LANGUAGE"].
-      split(/[;,]/).select{ |l| l =~ /^[a-z-]+$/i }.first
-    return if http_locale.blank?
-    lang, region = http_locale.split( "-" ).map(&:downcase)
-    return lang if region.blank?
-    # These re-mappings will cause problem if these regions ever get
-    # translated, so be warned. Showing zh-TW for people in Hong Kong is
-    # *probably* fine, but Brazilian Portuguese for people in Portugal might
-    # be a bigger problem.
-    if lang == "es" && region == "xl"
-      region = "mx"
-    elsif lang == "zh" && region == "hk"
-      region = "tw"
-    elsif lang == "pt" && region == "pt"
-      region = "br"
+    def set_request_locale
+      # use params[:locale] for single-request locale settings,
+      # otherwise use the session, user's preferred, or site default,
+      # or application default locale
+      locale = params[:locale]
+      locale = current_user.try( :locale ) if locale.blank?
+      locale = session[:locale] if locale.blank?
+      locale = @site.locale if @site && locale.blank?
+      locale = locale_from_header if locale.blank?
+      locale = I18n.default_locale if locale.blank?
+      if locale =~ /-[a-z]/
+        pieces = locale.split( "-" )
+        locale = "#{pieces[0].downcase}-#{pieces[1].upcase}"
+      end
+      I18n.locale = locale
+      if I18n.locale.to_s == "iw"
+        I18n.locale = I18n.locale.to_s.sub( "iw", "he" ).to_sym
+      end
+      unless I18N_SUPPORTED_LOCALES.include?( I18n.locale.to_s )
+        I18n.locale = I18n.default_locale
+      end
+      @rtl = params[:test] == "rtl" && ["ar", "fa", "he"].include?( I18n.locale.to_s )
+      true
     end
-    locale = "#{lang.downcase}-#{region.upcase}"
-    if I18N_SUPPORTED_LOCALES.include?( locale )
-      locale
-    elsif I18N_SUPPORTED_LOCALES.include?( lang )
-      lang
-    end
-  end
 
-  def set_site
-    if params[:inat_site_id]
-      @site ||= Site.find_by_id( params[:inat_site_id] )
+    def locale_from_header
+      return if request.env["HTTP_ACCEPT_LANGUAGE"].blank?
+
+      http_locale = request.env["HTTP_ACCEPT_LANGUAGE"].
+        split( /[;,]/ ).grep( /^[a-z-]+$/i ).first
+      return if http_locale.blank?
+
+      lang, region = http_locale.split( "-" ).map( &:downcase )
+      return lang if region.blank?
+
+      # These re-mappings will cause problem if these regions ever get
+      # translated, so be warned. Showing zh-TW for people in Hong Kong is
+      # *probably* fine, but Brazilian Portuguese for people in Portugal might
+      # be a bigger problem.
+      if lang == "es" && region == "xl"
+        region = "mx"
+      elsif lang == "zh" && region == "hk"
+        region = "tw"
+      elsif lang == "pt" && region == "pt"
+        region = "br"
+      end
+      locale = "#{lang.downcase}-#{region.upcase}"
+      if I18N_SUPPORTED_LOCALES.include?( locale )
+        locale
+      elsif I18N_SUPPORTED_LOCALES.include?( lang )
+        lang
+      end
     end
-    @site ||= Site.where( "url LIKE '%#{request.host}%'" ).first
-    @site ||= Site.default
-    @site
+
+    def set_site
+      if params[:inat_site_id]
+        @site ||= Site.find_by_id( params[:inat_site_id] )
+      end
+      @site ||= Site.where( "url LIKE '%#{request.host}%'" ).first
+      @site ||= Site.default
+      @site
+    end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -29,6 +29,7 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   private
+
   def set_flash_message(key, kind, options = {})
     if @legacy_authentication_successful
       flash[:notice] = I18n.t(:legacy_authentication_notice_html, :url => generic_edit_user_url)

--- a/config/initializers/inat_auth.rb
+++ b/config/initializers/inat_auth.rb
@@ -1,16 +1,27 @@
+# frozen_string_literal: true
+
 # Some common errors we use for various auth strategies
 module INat
   module Auth
     # When username and password don't match a user
     class BadUsernamePasswordError < StandardError; end
+
     # When a user tries to signup without an email, e.g. via third party
     class MissingEmailError < StandardError; end
+
     # User is suspended
     class SuspendedError < StandardError; end
+
     # User is a known child without parental permission
     class ChildWithoutPermissionError < StandardError; end
+
     # User has not confirmed their email address yet
     class UnconfirmedError < StandardError; end
+
+    # User that registered before confirmation was required has failed to
+    # confirm after the grace period has expired
+    class UnconfirmedAfterGracePeriodError < StandardError; end
+
     # User has tried to use the oauth assertion flow with a bad assertion type
     class BadAssertionTypeError < StandardError; end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1914,6 +1914,10 @@ en:
   email_conf_banner_we_delivered_todos: |
     We delivered a confirmation email to you on %{date}. If you did not
     receive it, here are some things you can do:
+  email_conf_required_after_grace_period: |
+    Email confirmation is required as of %{requirement_date} and you did not
+    confirm your email address before the cutoff. Please reset your password
+    to access your account.
   email_confirmation_banner_html: |
     <strong>%{link_start_tag}Please confirm your email address%{link_end_tag}</strong>.
     All users must confirm their email address by %{date}. After that

--- a/tools/email_unconfirmed_users.rb
+++ b/tools/email_unconfirmed_users.rb
@@ -32,6 +32,7 @@ scope = if test_users.size.positive?
 else
   User.
     where( "confirmed_at IS NULL" ).
+    where( "suspended_at IS NULL" ).
     where( "(NOT spammer OR spammer IS NULL)" ).
     where( "email IS NOT NULL" )
 end

--- a/tools/email_unconfirmed_users.rb
+++ b/tools/email_unconfirmed_users.rb
@@ -51,7 +51,7 @@ end
 num_processes = @opts.num_processes
 min_id = @opts.min_id
 max_id = @opts.max_id || scope.calculate( :maximum, :id ).to_i
-offset = max_id / num_processes
+offset = ( max_id - min_id ) / num_processes
 debug = @opts.debug
 dry = @opts.dry
 custom_users_requested = @opts.users.blank?
@@ -61,7 +61,9 @@ if @opts.debug
 end
 
 results = Parallel.map( 0...num_processes, in_processes: num_processes ) do | process_index |
-  start = offset * process_index
+  valid_domains = {}
+  invalid_domains = {}
+  start = min_id + ( offset * process_index )
   limit = process_index == ( num_processes - 1 ) ? max_id : start + offset - 1
   scope = scope.where( "users.id BETWEEN ? AND ? AND users.id > ?", start, limit, min_id )
   process_emailed = 0
@@ -81,6 +83,30 @@ results = Parallel.map( 0...num_processes, in_processes: num_processes ) do | pr
     )
     next if !custom_users_requested && recipient.confirmed?
 
+    # Perform some pre-checks on the email address
+    recipient.email_will_change!
+
+    # If there's something there but it doesn't look like an email address
+    next unless Devise.email_regexp.match( recipient.email )
+
+    # This checks banned domains
+    recipient.validate_email_pattern
+    next unless recipient.errors[:email].blank?
+
+    # Ensure email domain is there (try to only check each domain once)
+    domain = recipient.email.split( "@" )[1].strip
+    next if invalid_domains[domain]
+
+    unless valid_domains[domain]
+      recipient.validate_email_domain_exists
+      if recipient.errors[:email].blank?
+        valid_domains[domain] = true
+      else
+        invalid_domains[domain] = true
+        next
+      end
+    end
+
     puts "[DEBUG] Emailing recipient: #{recipient}" if debug
 
     begin
@@ -94,6 +120,8 @@ results = Parallel.map( 0...num_processes, in_processes: num_processes ) do | pr
       process_failures_by_user_id[recipient.id] = e
     end
   end
+  puts "Proc #{process_index} (#{start} - #{limit}, min_id: #{min_id}) finished, " \
+    "#{invalid_domains.size} invalid domains: #{invalid_domains.keys}"
   { emailed: process_emailed, failed: process_failed, failures_by_user_id: process_failures_by_user_id }
 end
 


### PR DESCRIPTION
This changes the error message unconfirmed people will see when they try to sign in after we require email confirmation for everyone. Before it just assumed you'd just signed up and asked you to check your email, but now it will show a different message to people who signed up before we required confirmation for signup instructing them to reset their password.