### PR TITLE
Make GBIF layer on taxon page sticky

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1271,6 +1271,7 @@ protected
       :prefers_captive_obs_maps,
       :prefers_comment_email_notification,
       :prefers_forum_topics_on_dashboard,
+      :prefers_gbif_layer_maps,
       :prefers_identification_email_notification,
       :prefers_identify_side_bar,
       :prefers_message_email_notification,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,7 @@ class User < ApplicationRecord
   preference :no_place, :boolean, default: false
   preference :medialess_obs_maps, :boolean, default: false
   preference :captive_obs_maps, :boolean, default: false
+  preference :gbif_layer_maps, :boolean, default: false
   preference :forum_topics_on_dashboard, :boolean, default: true
   preference :monthly_supporter_badge, :boolean, default: false
   preference :map_tile_test, :boolean, default: false

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -227,6 +227,7 @@
           icon_url: '<%= current_user.icon.file? ? current_user.icon.url(:medium) : "null" %>',
           roles: <%= current_user.roles.map(&:name).to_json.html_safe %>,
           prefers_scientific_name_first: <%= current_user.prefers_scientific_name_first %>,
+          prefers_gbif_layer_maps: <%= current_user.prefers_gbif_layer_maps %>,
           prefers_medialess_obs_maps: <%= current_user.prefers_medialess_obs_maps %>,
           prefers_captive_obs_maps: <%= current_user.prefers_captive_obs_maps %>,
           preferred_observations_search_map_type: "<%= current_user.preferred_observations_search_map_type %>",

--- a/app/views/observations/show.html.haml
+++ b/app/views/observations/show.html.haml
@@ -48,6 +48,7 @@
         prefers_hide_obs_show_expanded_cid: current_user.prefers_hide_obs_show_expanded_cid,
         prefers_medialess_obs_maps: current_user.prefers_medialess_obs_maps,
         prefers_captive_obs_maps: current_user.prefers_captive_obs_maps,
+        prefers_gbif_layer_maps: current_user.prefers_gbif_layer_maps,
         preferred_observation_license: (current_user.preferred_observation_license || "").downcase,
         preferred_observations_search_map_type: current_user.preferred_observations_search_map_type,
         prefers_scientific_name_first: current_user.prefers_scientific_name_first,

--- a/app/webpack/taxa/shared/util.js
+++ b/app/webpack/taxa/shared/util.js
@@ -156,10 +156,15 @@ const taxonLayerForTaxon = ( taxon, options = {} ) => {
     updateCurrentUser,
     observation
   } = options;
-  const currentUserPrefersMedialessObs = currentUser
-    && currentUser.prefers_medialess_obs_maps;
-  const currentUserPrefersCaptiveObs = currentUser
-    && currentUser.prefers_captive_obs_maps;
+  const {
+    prefers_captive_obs_maps: currentUserPrefersCaptiveObs,
+    prefers_gbif_layer_maps: currentUserPrefersGbifLayer,
+    prefers_medialess_obs_maps: currentUserPrefersMedialessObs,
+  } = currentUser || {
+    prefers_captive_obs_maps: false,
+    prefers_gbif_layer_maps: false,
+    prefers_medialess_obs_maps: false,
+  };
   return {
     taxon,
     observationLayers: [
@@ -196,7 +201,11 @@ const taxonLayerForTaxon = ( taxon, options = {} ) => {
           && ( e => updateCurrentUser( { prefers_captive_obs_maps: e.target.checked } ) )
       }
     ],
-    gbif: { disabled: true, legendColor: "#F7005A" },
+    gbif: {
+      disabled: !currentUserPrefersGbifLayer,
+      legendColor: "#F7005A",
+      onChange: currentUser && ( e => updateCurrentUser( { prefers_gbif_layer_maps: e.target.checked } ) ),
+    },
     places: true,
     ranges: true
   };

--- a/app/webpack/taxa/show/components/taxon_page_map.jsx
+++ b/app/webpack/taxa/show/components/taxon_page_map.jsx
@@ -55,6 +55,7 @@ const TaxonPageMap = ( {
           gestureHandling="auto"
           currentUser={config.currentUser}
           updateCurrentUser={updateCurrentUser}
+          reloadKey={`taxa-show-map-${taxon.id}`}
           showLegend
         />
       </ErrorBoundary>


### PR DESCRIPTION
Implements: #3633 

Does this impact the right set of pages? I see maps on the "suggestions" tab on the identify page can have GBIF layers; should this affect them? Are there other pages with GBIF layers?