### PR TITLE
Remove ARIA role that interferes w/ VoiceOver control of audio

### DIFF
--- a/app/webpack/observations/show/components/photo_browser.jsx
+++ b/app/webpack/observations/show/components/photo_browser.jsx
@@ -20,6 +20,15 @@ class PhotoBrowser extends React.Component {
     const domNode = ReactDOM.findDOMNode( this );
     // move the add-photo button into the thumbnail list
     $( ".add-photo", domNode ).appendTo( ".image-gallery-thumbnails-container", domNode );
+
+    // Remove the button role from slides that contain audio. This seems to
+    // actually cause Voice Over in Safari to ignore the audio controls
+    // inside of the button
+    $( ".image-gallery-slide", domNode ).each( ( slideIndex, slide ) => {
+      if ( $( "audio", slide ).length > 0 ) {
+        $( slide ).attr( "role", null );
+      }
+    } );
   }
 
   componentDidUpdate( ) {


### PR DESCRIPTION
VoiceOver in Safari doesn't seem to want to focus on an <audio> element controls if it's inside of an element with the button role, so this removes that. I can navigate to the play button with VoiceOver, but it's still pretty bad because Safari seems to read the elapsed time every second, making it impossible to actually hear what's being played.