### PR TITLE
Display only the month and year for obscured or private Latest Observations on Taxon page

### DIFF
--- a/app/webpack/taxa/show/containers/last_observation_container.js
+++ b/app/webpack/taxa/show/containers/last_observation_container.js
@@ -1,6 +1,13 @@
 import { connect } from "react-redux";
 import LeaderItem from "../components/leader_item";
 
+function dateFormat( observation ) {
+  if ( observation.obscured || observation.private_geojson ) {
+    return "date.formats.month_year";
+  }
+  return "date.formats.month_day_year";
+}
+
 function mapStateToProps( state ) {
   const { last } = state.observations;
   const props = {
@@ -16,9 +23,10 @@ function mapStateToProps( state ) {
   if ( !last ) {
     return props;
   }
+
   return Object.assign( props, {
     noContent: false,
-    name: I18n.localize( "date.formats.month_day_year", last.observed_on ),
+    name: I18n.localize( dateFormat( last ), last.observed_on ),
     imageUrl: last.photos[0] ? last.photos[0].photoUrl( "square" ) : null,
     linkUrl: `/observations/${last.id}`,
     linkText: I18n.t( "view_observation" ),


### PR DESCRIPTION
Addresses https://github.com/inaturalist/inaturalist/issues/3736

Before

![taxa-detail-before](https://github.com/inaturalist/inaturalist/assets/2458971/bc434c98-8b75-4a55-99e5-fd38e795e30c)

After

![taxa-detail-after](https://github.com/inaturalist/inaturalist/assets/2458971/53b50bba-c5ca-49ec-b4b5-262076cfd02b)
