### PR TITLE
3743 user settings relationships sort

### DIFF
--- a/app/webpack/users/edit/containers/blocked_muted_users_container.js
+++ b/app/webpack/users/edit/containers/blocked_muted_users_container.js
@@ -6,7 +6,7 @@ import {
   muteUser,
   unblockUser,
   unmuteUser
-} from "../ducks/relationships";
+} from "../ducks/blocked_muted_users";
 import { showAlert } from "../../../shared/ducks/alert_modal";
 
 function mapStateToProps( state ) {

--- a/app/webpack/users/edit/ducks/blocked_muted_users.js
+++ b/app/webpack/users/edit/ducks/blocked_muted_users.js
@@ -1,0 +1,38 @@
+import inatjs from "inaturalistjs";
+import { fetchUserSettings } from "./user_settings";
+
+export function muteUser( id ) {
+  const params = { id };
+  return dispatch => inatjs.users.mute( params ).then( ( ) => {
+    dispatch( fetchUserSettings( false, true ) );
+  } ).catch( e => console.log( `Failed to mute user: ${e}` ) );
+}
+
+export function unmuteUser( id ) {
+  const params = { id };
+  return dispatch => inatjs.users.unmute( params ).then( ( ) => {
+    dispatch( fetchUserSettings( false, true ) );
+  } ).catch( e => console.log( `Failed to unmute user: ${e}` ) );
+}
+
+export function blockUser( id ) {
+  const params = { id };
+  return dispatch => inatjs.users.block( params ).then( ( ) => {
+    dispatch( fetchUserSettings( false, true ) );
+  } ).catch( e => {
+    e.response.json( ).then( json => {
+      const baseErrors = _.get( json, "error.original.errors.base", [] );
+      if ( baseErrors.length > 0 ) {
+        alert( baseErrors.join( "; " ) );
+      }
+    } );
+    console.log( `Failed to block user: ${e}` );
+  } );
+}
+
+export function unblockUser( id ) {
+  const params = { id };
+  return dispatch => inatjs.users.unblock( params ).then( ( ) => {
+    dispatch( fetchUserSettings( false, true ) );
+  } ).catch( e => console.log( `Failed to unblock user: ${e}` ) );
+}

--- a/app/webpack/users/edit/ducks/relationships.js
+++ b/app/webpack/users/edit/ducks/relationships.js
@@ -1,8 +1,6 @@
 import _ from "lodash";
 import inatjs from "inaturalistjs";
 
-import { fetchUserSettings } from "./user_settings";
-
 const SET_RELATIONSHIPS = "user/edit/SET_RELATIONSHIPS";
 const SET_RELATIONSHIP_TO_DELETE = "user/edit/SET_RELATIONSHIP_TO_DELETE";
 const SET_USER_AUTOCOMPLETE = "user/edit/SET_USER_AUTOCOMPLETE";
@@ -261,40 +259,4 @@ export function deleteRelationship( ) {
       dispatch( fetchRelationships( ) );
     } ).catch( e => console.log( `Failed to delete relationships: ${e}` ) );
   };
-}
-
-export function muteUser( id ) {
-  const params = { id };
-  return dispatch => inatjs.users.mute( params ).then( ( ) => {
-    dispatch( fetchUserSettings( false, true ) );
-  } ).catch( e => console.log( `Failed to mute user: ${e}` ) );
-}
-
-export function unmuteUser( id ) {
-  const params = { id };
-  return dispatch => inatjs.users.unmute( params ).then( ( ) => {
-    dispatch( fetchUserSettings( false, true ) );
-  } ).catch( e => console.log( `Failed to unmute user: ${e}` ) );
-}
-
-export function blockUser( id ) {
-  const params = { id };
-  return dispatch => inatjs.users.block( params ).then( ( ) => {
-    dispatch( fetchUserSettings( false, true ) );
-  } ).catch( e => {
-    e.response.json( ).then( json => {
-      const baseErrors = _.get( json, "error.original.errors.base", [] );
-      if ( baseErrors.length > 0 ) {
-        alert( baseErrors.join( "; " ) );
-      }
-    } );
-    console.log( `Failed to block user: ${e}` );
-  } );
-}
-
-export function unblockUser( id ) {
-  const params = { id };
-  return dispatch => inatjs.users.unblock( params ).then( ( ) => {
-    dispatch( fetchUserSettings( false, true ) );
-  } ).catch( e => console.log( `Failed to unblock user: ${e}` ) );
 }

--- a/app/webpack/users/edit/ducks/relationships.js
+++ b/app/webpack/users/edit/ducks/relationships.js
@@ -16,7 +16,7 @@ export default function reducer( state = {
   filters: {
     following: "any",
     trusted: "any",
-    order_by: "users.login",
+    order_by: "friendships.id",
     order: "desc"
   },
   relationships: []


### PR DESCRIPTION
https://github.com/inaturalist/inaturalist/issues/3743

Before:
`users/edit#relationships` displays relationships sorted by friend's login desc upon page load

![user-edit-relationships-before](https://github.com/inaturalist/inaturalist/assets/2458971/39dd355f-85fe-460b-a395-f6e1e5e7d7c9)

After:
`users/edit#relationships` displays relationships sorted by friend's database id desc upon page load. I didn't sort by the Friendship created_at column b/c the existing frontend relies on the Friendship id.

![user-edit-relationships-after](https://github.com/inaturalist/inaturalist/assets/2458971/94cc8788-d6c7-4dfe-982f-55e20f275a03)

This PR also contains a second commit to address a circular dependency identified by eslint.