### PR TITLE
Localize doorkeeper devise auth failure

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -238,6 +238,7 @@ Devise.setup do | config |
     manager.default_strategies( scope: :user ).unshift :ajwt
     manager.strategies.add( :jwt, Devise::Strategies::JsonWebToken )
     manager.default_strategies( scope: :user ).unshift :jwt
+    manager.failure_app = InatDeviseFailureApp
   end
 
   # ==> Mountable engine configurations

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -25,3 +25,35 @@ I18n.extend( I18nExtensions )
 I18n::Backend::Simple.include I18nCustomBackend
 
 I18n::JS.export_i18n_js_dir_path = "app/assets/javascripts"
+
+def normalize_locale( locale )
+  return if locale.blank?
+
+  locale = locale.split( /[;,]/ ).grep( /^[a-z-]+$/i ).first
+  return if locale.blank?
+
+  lang, region = locale.split( "-" ).map( &:downcase )
+  return lang if region.blank?
+
+  # These re-mappings will cause problem if these regions ever get
+  # translated, so be warned. Showing zh-TW for people in Hong Kong is
+  # *probably* fine, but Brazilian Portuguese for people in Portugal might
+  # be a bigger problem.
+  if lang == "es" && region == "xl"
+    region = "mx"
+  elsif lang == "zh"
+    if region == "hk" || region.downcase == "hant"
+      region = "tw"
+    elsif region.downcase == "hans"
+      region = "cn"
+    end
+  end
+  return "pt" if lang == "pt" && region == "pt"
+
+  locale = "#{lang.downcase}-#{region.upcase}"
+  if I18N_SUPPORTED_LOCALES.include?( locale )
+    locale
+  elsif I18N_SUPPORTED_LOCALES.include?( lang )
+    lang
+  end
+end

--- a/lib/inat_devise_failure_app.rb
+++ b/lib/inat_devise_failure_app.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Override of the Devise class to localize error responses based on HTTP headers
+class InatDeviseFailureApp < Devise::FailureApp
+  def i18n_options( options )
+    options.merge( locale: normalize_locale( request_accept_language ) )
+  end
+
+  def request_accept_language
+    if request.respond_to?( :headers ) && request.headers.respond_to?( :[] )
+      return request.headers["Accept-Language"]
+    end
+
+    if request.respond_to? :get_header
+      return request.get_header( "Accept-Language" )
+    end
+
+    request.env["Accept-Language"]
+  end
+end

--- a/lib/inat_devise_failure_app.rb
+++ b/lib/inat_devise_failure_app.rb
@@ -3,7 +3,8 @@
 # Override of the Devise class to localize error responses based on HTTP headers
 class InatDeviseFailureApp < Devise::FailureApp
   def i18n_options( options )
-    options.merge( locale: normalize_locale( request_accept_language ) )
+    I18n.locale = normalize_locale( request_accept_language )
+    options
   end
 
   def request_accept_language


### PR DESCRIPTION
This *attempts* to set the I18n.locale correctly before Doorkeeper / Devise / Warden set error messages. It works locally in a dev and prod envs, but not on staging, so I'm curious if it will work in production.