### PR TITLE
fix: :bug: fix autocomplete leaving window on upload page

### DIFF
--- a/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
@@ -265,7 +265,10 @@ class TaxonAutocomplete extends React.Component {
       appendTo: this.idElement( ).parent( ),
       minLength: 0,
       renderMenu: renderMenuWithCategories,
-      menuClass: "taxon-autocomplete"
+      menuClass: "taxon-autocomplete",
+      position: {
+        collision: "flipfit",
+      },
     } );
     this.inputElement( ).genericAutocomplete( opts );
     this.fetchTaxon( );


### PR DESCRIPTION
Currently the autocomplete popup will leave the visible window space if no space is left on the left side, which causes a scrollbar to appear.

jQuery UI has a build-in option to mitigate this problem (https://api.jqueryui.com/position/):

> "flipfit": First applies the flip logic, placing the element on whichever side allows more of the element to be visible. Then the fit logic is applied to ensure as much of the element is visible as possible.

I stumble quite often over this "small issue" as I upload frequently multiple images and though this simple fix could be a good addition. 

## Original behaviour

<img src='https://github.com/inaturalist/inaturalist/assets/16878981/10fd2853-2cfd-40de-8070-4042eb01b9a3' width='250'>

## After fix behaviour

<img src='https://github.com/inaturalist/inaturalist/assets/16878981/6714d9a9-99d1-473c-89f7-e86559ca3604' width='250'>

PS: Don't know if I should write an exception for RTL as with my current implementation the RTL style would not be applied.
PPS: I was to lazy to look into the VisionAPI therefore I don't know if everything is ok when the results come in, but I would expect there is no manual css manipulation on the container.


Cheers
Hannes

