### PR TITLE
Announcement clients

### DIFF
--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -1,20 +1,20 @@
 /* global _ */
 /* global I18n */
-/* global PLACEMENT_PLATFORMS */
+/* global PLACEMENT_CLIENTS */
 
 $( function ( ) {
   $( "#announcement_placement" ).change( function ( ) {
     var placement = $( "#announcement_placement" ).val( );
-    var platformsSelect = $( "#announcement_platforms" );
-    platformsSelect.empty( );
-    platformsSelect.append( $( "<option value>" + I18n.t( "all" ) + "</option>" ) );
-    if ( PLACEMENT_PLATFORMS[placement] ) {
-      _.each( PLACEMENT_PLATFORMS[placement], function ( placementPlatform ) {
-        platformsSelect.append( $( "<option value='" + placementPlatform + "'>" + placementPlatform + "</option>" ) );
+    var clientsSelect = $( "#announcement_clients" );
+    clientsSelect.empty( );
+    clientsSelect.append( $( "<option value>" + I18n.t( "all" ) + "</option>" ) );
+    if ( PLACEMENT_CLIENTS[placement] ) {
+      _.each( PLACEMENT_CLIENTS[placement], function ( placementClient ) {
+        clientsSelect.append( $( "<option value='" + placementClient + "'>" + placementClient + "</option>" ) );
       } );
-      platformsSelect.attr( "size", _.min( [_.size( PLACEMENT_PLATFORMS[placement] ) + 1, 5] ) );
+      clientsSelect.attr( "size", _.min( [_.size( PLACEMENT_CLIENTS[placement] ) + 1, 5] ) );
     } else {
-      platformsSelect.attr( "size", 1 );
+      clientsSelect.attr( "size", 1 );
     }
   } );
 } );

--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -1,0 +1,20 @@
+/* global _ */
+/* global I18n */
+/* global PLACEMENT_PLATFORMS */
+
+$( function ( ) {
+  $( "#announcement_placement" ).change( function ( ) {
+    var placement = $( "#announcement_placement" ).val( );
+    var platformsSelect = $( "#announcement_platforms" );
+    platformsSelect.empty( );
+    platformsSelect.append( $( "<option value>" + I18n.t( "all" ) + "</option>" ) );
+    if ( PLACEMENT_PLATFORMS[placement] ) {
+      _.each( PLACEMENT_PLATFORMS[placement], function ( placementPlatform ) {
+        platformsSelect.append( $( "<option value='" + placementPlatform + "'>" + placementPlatform + "</option>" ) );
+      } );
+      platformsSelect.attr( "size", _.min( [_.size( PLACEMENT_PLATFORMS[placement] ) + 1, 5] ) );
+    } else {
+      platformsSelect.attr( "size", 1 );
+    }
+  } );
+} );

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -7,7 +7,7 @@ class Announcement < ApplicationRecord
     welcome/index
     mobile/home
   ).freeze
-  PLATFORMS = {
+  CLIENTS = {
     "mobile/home" => %w(
       inat-ios
       inat-android
@@ -17,7 +17,7 @@ class Announcement < ApplicationRecord
   }.freeze
   has_and_belongs_to_many :sites
   validates_presence_of :placement, :start, :end, :body
-  validate :valid_placement_platforms
+  validate :valid_placement_clients
 
   preference :target_staff, :boolean
   preference :target_unconfirmed_users, :boolean
@@ -31,13 +31,13 @@ class Announcement < ApplicationRecord
   }
 
   before_save :compact_locales
-  before_validation :compact_platforms
+  before_validation :compact_clients
 
-  def valid_placement_platforms
-    if platforms.any? do |platform|
-      !Announcement::PLATFORMS[placement] || !Announcement::PLATFORMS[placement].include?( platform )
+  def valid_placement_clients
+    if clients.any? do |client|
+      !Announcement::CLIENTS[placement] || !Announcement::CLIENTS[placement].include?( client )
     end
-      errors.add( :platforms, :must_be_valid_for_specified_placement )
+      errors.add( :clients, :must_be_valid_for_specified_placement )
     end
   end
 
@@ -49,8 +49,8 @@ class Announcement < ApplicationRecord
     self.locales = ( locales || [] ).reject( &:blank? ).compact
   end
 
-  def compact_platforms
-    self.platforms = ( platforms || [] ).reject( &:blank? ).compact
+  def compact_clients
+    self.clients = ( clients || [] ).reject( &:blank? ).compact
   end
 
   def dismissed_by?( user )

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -7,8 +7,17 @@ class Announcement < ApplicationRecord
     welcome/index
     mobile/home
   ).freeze
+  PLATFORMS = {
+    "mobile/home" => %w(
+      inat-ios
+      inat-android
+      seek
+      inatrn
+    )
+  }.freeze
   has_and_belongs_to_many :sites
   validates_presence_of :placement, :start, :end, :body
+  validate :valid_placement_platforms
 
   preference :target_staff, :boolean
   preference :target_unconfirmed_users, :boolean
@@ -22,6 +31,15 @@ class Announcement < ApplicationRecord
   }
 
   before_save :compact_locales
+  before_validation :compact_platforms
+
+  def valid_placement_platforms
+    if platforms.any? do |platform|
+      !Announcement::PLATFORMS[placement] || !Announcement::PLATFORMS[placement].include?( platform )
+    end
+      errors.add( :platforms, :must_be_valid_for_specified_placement )
+    end
+  end
 
   def session_key
     "user-seen-ann-#{id}"
@@ -29,6 +47,10 @@ class Announcement < ApplicationRecord
 
   def compact_locales
     self.locales = ( locales || [] ).reject( &:blank? ).compact
+  end
+
+  def compact_platforms
+    self.platforms = ( platforms || [] ).reject( &:blank? ).compact
   end
 
   def dismissed_by?( user )
@@ -40,10 +62,10 @@ class Announcement < ApplicationRecord
   end
 
   def targeted_to_user?( user )
+    return false if prefers_target_staff && ( user.blank? || !user.is_admin? )
     if prefers_target_unconfirmed_users
       return user && !user.confirmed?
     end
-
     true
   end
 

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -5,9 +5,18 @@
       width: 100%;
       min-height: 300px;
     }
+- content_for :extrajs do
+  :javascript
+    var PLACEMENT_PLATFORMS = #{ Announcement::PLATFORMS.to_json.html_safe }
+  = javascript_include_tag "announcements/form"
 = form_for @announcement, :builder => DefaultFormBuilder do |f|
   = f.error_messages
   = f.select :placement, Announcement::PLACEMENTS
+  - platforms = Announcement::PLATFORMS[@announcement.placement] || []
+  = f.select :platforms, platforms, { include_blank: t( :all ) }, {  |
+    multiple: true,                                                  |
+    description: t( "views.announcements.platforms_desc" ),          |
+    size: [platforms.length + 1, 5].min }                            |
   :ruby
     month_names = I18n.t( "date.month_names" )
     if month_names.is_a?( Hash )

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -7,16 +7,16 @@
     }
 - content_for :extrajs do
   :javascript
-    var PLACEMENT_PLATFORMS = #{ Announcement::PLATFORMS.to_json.html_safe }
+    var PLACEMENT_CLIENTS = #{ Announcement::CLIENTS.to_json.html_safe }
   = javascript_include_tag "announcements/form"
 = form_for @announcement, :builder => DefaultFormBuilder do |f|
   = f.error_messages
   = f.select :placement, Announcement::PLACEMENTS
-  - platforms = Announcement::PLATFORMS[@announcement.placement] || []
-  = f.select :platforms, platforms, { include_blank: t( :all ) }, {  |
+  - clients = Announcement::CLIENTS[@announcement.placement] || []
+  = f.select :clients, clients, { include_blank: t( :all ) }, {      |
     multiple: true,                                                  |
-    description: t( "views.announcements.platforms_desc" ),          |
-    size: [platforms.length + 1, 5].min }                            |
+    description: t( "views.announcements.clients_desc" ),            |
+    size: [clients.length + 1, 5].min }                              |
   :ruby
     month_names = I18n.t( "date.month_names" )
     if month_names.is_a?( Hash )

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -39,7 +39,11 @@
           - @announcements.each do |announcement|
             %tr
               %td= link_to announcement.id, announcement
-              %td= h announcement.placement
+              %td
+                = h announcement.placement
+                - if announcement.platforms.any?
+                  .platforms
+                    = announcement.platforms.join( ", " )
               %td= announcement.site_ids.empty? ? t(:all)  : announcement.sites.map(&:name).join(", ")
               %td=l announcement.start
               %td

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -41,9 +41,9 @@
               %td= link_to announcement.id, announcement
               %td
                 = h announcement.placement
-                - if announcement.platforms.any?
-                  .platforms
-                    = announcement.platforms.join( ", " )
+                - if announcement.clients.any?
+                  .clients
+                    = announcement.clients.join( ", " )
               %td= announcement.site_ids.empty? ? t(:all)  : announcement.sites.map(&:name).join(", ")
               %td=l announcement.start
               %td

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -7,7 +7,7 @@
         = link_to t(:back), announcements_path, class: "back crumb"
       %h2=t :bold_label_colon_value_html, label: t( "activerecord.models.announcement" ), value: @announcement.id
       %table.table.table-bordered
-        - %w(created_at updated_at placement platforms start end site_ids locales prefers_target_staff prefers_target_unconfirmed_users).each do |a|
+        - %w(created_at updated_at placement clients start end site_ids locales prefers_target_staff prefers_target_unconfirmed_users).each do |a|
           %tr
             %th=t "activerecord.attributes.announcement.#{a}", default: t( "#{a}_", default: t( a ) )
             %td= @announcement.send( a )

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -7,7 +7,7 @@
         = link_to t(:back), announcements_path, class: "back crumb"
       %h2=t :bold_label_colon_value_html, label: t( "activerecord.models.announcement" ), value: @announcement.id
       %table.table.table-bordered
-        - %w(created_at updated_at placement start end site_ids locales prefers_target_staff prefers_target_unconfirmed_users).each do |a|
+        - %w(created_at updated_at placement platforms start end site_ids locales prefers_target_staff prefers_target_unconfirmed_users).each do |a|
           %tr
             %th=t "activerecord.attributes.announcement.#{a}", default: t( "#{a}_", default: t( a ) )
             %td= @announcement.send( a )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6347,6 +6347,9 @@ en:
         you chose en it will not appear for people who have chosen en-US. If you
         want to target both, choose both. If you want to show an announcement
         for all members of a site, just leave this blank.
+      platforms_desc: |
+        CMD- or SHIFT-click to select multiple. Not selecting any will show the
+        announcement to all users regardless of platform.
     content_freeze:
       content_freeze: Content Freeze
       during_this_time: |
@@ -9108,6 +9111,7 @@ en:
         # Preference for an announcement that is only shown to users who have
         # not confirmed their email address
         prefers_target_unconfirmed_users: Target unconfirmed users
+        platforms: Platforms
       assessment:
         description: Description
       assessment_section:
@@ -9342,6 +9346,14 @@ en:
           one: "%{count} error prohibited this %{model} from being saved"
           other: '%{count} errors prohibited this %{model} from being saved'
       models:
+        announcement:
+          attributes:
+            platforms:
+              must_be_valid_for_specified_placement:
+                # Error message shown when an Announcement has a value in the
+                # platforms attribute that is not a valid platform for the
+                # annoumcement's placement attribute
+                must be valid for specified placement
         application:
           attributes:
             redirect_uri:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6347,9 +6347,9 @@ en:
         you chose en it will not appear for people who have chosen en-US. If you
         want to target both, choose both. If you want to show an announcement
         for all members of a site, just leave this blank.
-      platforms_desc: |
+      clients_desc: |
         CMD- or SHIFT-click to select multiple. Not selecting any will show the
-        announcement to all users regardless of platform.
+        announcement to all users regardless of client.
     content_freeze:
       content_freeze: Content Freeze
       during_this_time: |
@@ -9111,7 +9111,7 @@ en:
         # Preference for an announcement that is only shown to users who have
         # not confirmed their email address
         prefers_target_unconfirmed_users: Target unconfirmed users
-        platforms: Platforms
+        clients: Clients
       assessment:
         description: Description
       assessment_section:
@@ -9348,10 +9348,10 @@ en:
       models:
         announcement:
           attributes:
-            platforms:
+            clients:
               must_be_valid_for_specified_placement:
                 # Error message shown when an Announcement has a value in the
-                # platforms attribute that is not a valid platform for the
+                # clients attribute that is not a valid client for the
                 # annoumcement's placement attribute
                 must be valid for specified placement
         application:

--- a/db/migrate/20231017190352_add_clients_to_announcements.rb
+++ b/db/migrate/20231017190352_add_clients_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddClientsToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :clients, :text, array: true, default: []
+  end
+end

--- a/db/migrate/20231017190352_add_platforms_to_announcements.rb
+++ b/db/migrate/20231017190352_add_platforms_to_announcements.rb
@@ -1,5 +1,0 @@
-class AddPlatformsToAnnouncements < ActiveRecord::Migration[6.1]
-  def change
-    add_column :announcements, :platforms, :text, array: true, default: []
-  end
-end

--- a/db/migrate/20231017190352_add_platforms_to_announcements.rb
+++ b/db/migrate/20231017190352_add_platforms_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddPlatformsToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :platforms, :text, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -322,7 +322,8 @@ CREATE TABLE public.announcements (
     updated_at timestamp without time zone,
     locales text[] DEFAULT '{}'::text[],
     dismiss_user_ids integer[] DEFAULT '{}'::integer[],
-    dismissible boolean DEFAULT false
+    dismissible boolean DEFAULT false,
+    platforms text[] DEFAULT '{}'::text[]
 );
 
 
@@ -10385,6 +10386,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230504154236'),
 ('20230504154248'),
 ('20230504154302'),
-('20230907210748');
+('20230907210748'),
+('20231017190352');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -323,7 +323,7 @@ CREATE TABLE public.announcements (
     locales text[] DEFAULT '{}'::text[],
     dismiss_user_ids integer[] DEFAULT '{}'::integer[],
     dismissible boolean DEFAULT false,
-    platforms text[] DEFAULT '{}'::text[]
+    clients text[] DEFAULT '{}'::text[]
 );
 
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -8,21 +8,21 @@ describe Announcement do
   it { is_expected.to validate_presence_of :end }
   it { is_expected.to validate_presence_of :body }
 
-  it "validates placement platforms" do
+  it "validates placement clients" do
     expect{
-      Announcement.make!( placement: "users/dashboard#sidebar", platforms: ["inat-ios"] )
-    }.to raise_error(ActiveRecord::RecordInvalid, /Platforms must be valid for specified placement/)
+      Announcement.make!( placement: "users/dashboard#sidebar", clients: ["inat-ios"] )
+    }.to raise_error(ActiveRecord::RecordInvalid, /Clients must be valid for specified placement/)
     expect{
-      Announcement.make!( placement: "users/dashboard#sidebar", platforms: [] )
+      Announcement.make!( placement: "users/dashboard#sidebar", clients: [] )
     }.not_to raise_error
     expect{
-      Announcement.make!( placement: "mobile/home", platforms: ["inat-ios"] )
+      Announcement.make!( placement: "mobile/home", clients: ["inat-ios"] )
     }.not_to raise_error
     expect{
-      Announcement.make!( placement: "mobile/home", platforms: ["nonsense"] )
-    }.to raise_error(ActiveRecord::RecordInvalid, /Platforms must be valid for specified placement/)
+      Announcement.make!( placement: "mobile/home", clients: ["nonsense"] )
+    }.to raise_error(ActiveRecord::RecordInvalid, /Clients must be valid for specified placement/)
     expect{
-      Announcement.make!( placement: "mobile/home", platforms: [] )
+      Announcement.make!( placement: "mobile/home", clients: [] )
     }.not_to raise_error
   end
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -7,4 +7,38 @@ describe Announcement do
   it { is_expected.to validate_presence_of :start }
   it { is_expected.to validate_presence_of :end }
   it { is_expected.to validate_presence_of :body }
+
+  it "validates placement platforms" do
+    expect{
+      Announcement.make!( placement: "users/dashboard#sidebar", platforms: ["inat-ios"] )
+    }.to raise_error(ActiveRecord::RecordInvalid, /Platforms must be valid for specified placement/)
+    expect{
+      Announcement.make!( placement: "users/dashboard#sidebar", platforms: [] )
+    }.not_to raise_error
+    expect{
+      Announcement.make!( placement: "mobile/home", platforms: ["inat-ios"] )
+    }.not_to raise_error
+    expect{
+      Announcement.make!( placement: "mobile/home", platforms: ["nonsense"] )
+    }.to raise_error(ActiveRecord::RecordInvalid, /Platforms must be valid for specified placement/)
+    expect{
+      Announcement.make!( placement: "mobile/home", platforms: [] )
+    }.not_to raise_error
+  end
+
+  describe "targeted_to_user" do
+    it "targets admins with prefers_target_staff" do
+      a = Announcement.make!( prefers_target_staff: true )
+      expect( a.targeted_to_user?( make_admin ) ).to be true
+      expect( a.targeted_to_user?( make_curator ) ).to be false
+      expect( a.targeted_to_user?( User.make! ) ).to be false
+    end
+
+    it "targets unconfirmed users" do
+      a = Announcement.make!( prefers_target_unconfirmed_users: true )
+      expect( a.targeted_to_user?( User.make!( confirmed_at: Time.now ) ) ).to be false
+      expect( a.targeted_to_user?( User.make!( confirmed_at: nil ) ) ).to be true
+    end
+  end
+
 end


### PR DESCRIPTION
- Adds a new array column `clients` to announcements
- Allows admins to specify the client to which announcement applies #3896
- Fixes staff targeting for web announcements #3888