### PR TITLE
Require controlled term labels

### DIFF
--- a/app/controllers/controlled_terms_controller.rb
+++ b/app/controllers/controlled_terms_controller.rb
@@ -1,5 +1,4 @@
 class ControlledTermsController < ApplicationController
-
   before_action :authenticate_user!
   before_action :admin_required
 
@@ -8,15 +7,19 @@ class ControlledTermsController < ApplicationController
   end
 
   def create
-    label_attrs = params[:controlled_term].delete(:controlled_term_label)
-    term = ControlledTerm.new(params[:controlled_term])
+    label_attrs = params[:controlled_term].delete( :controlled_term_label )
+    term = ControlledTerm.new( params[:controlled_term] )
+    controlled_term_label = term.labels.build( label_attrs )
     term.user = current_user
     if term.save
       if label_attrs
-        term.labels << ControlledTermLabel.create(label_attrs)
+        term.labels << controlled_term_label
       end
     else
       flash[:error] = term.errors.full_messages.to_sentence
+      if term.errors[:labels] && !controlled_term_label.valid?
+        flash[:error] = controlled_term_label.errors.full_messages.join( ", " )
+      end
     end
 
     redirect_to :controlled_terms

--- a/app/models/controlled_term.rb
+++ b/app/models/controlled_term.rb
@@ -29,6 +29,9 @@ class ControlledTerm < ApplicationRecord
     through: :controlled_term_taxa,
     source: :taxon
 
+  validates_associated :labels
+  validates :labels, presence: true
+
   after_commit :index_attributes
   scope :active, -> { where(active: true) }
   scope :attributes, -> { where(is_value: false) }

--- a/app/models/controlled_term_label.rb
+++ b/app/models/controlled_term_label.rb
@@ -1,8 +1,12 @@
-class ControlledTermLabel < ApplicationRecord
+# frozen_string_literal: true
 
+class ControlledTermLabel < ApplicationRecord
   belongs_to :controlled_term
   belongs_to :valid_within_taxon, foreign_key: :valid_within_clade,
     class_name: "Taxon"
+
+  validates :label, presence: true, on: :create
+  validates :definition, presence: true, on: :create
 
   if CONFIG.usingS3
     has_attached_file :icon,
@@ -24,5 +28,4 @@ class ControlledTermLabel < ApplicationRecord
   end
   validates_attachment_content_type :icon, content_type: [/jpe?g/i, /png/i, /octet-stream/],
     message: "must be JPG or PNG"
-
 end

--- a/app/models/controlled_term_value.rb
+++ b/app/models/controlled_term_value.rb
@@ -1,5 +1,4 @@
 class ControlledTermValue < ApplicationRecord
-
   belongs_to :controlled_attribute, class_name: "ControlledTerm"
   belongs_to :controlled_value, class_name: "ControlledTerm"
   validates_presence_of :controlled_value_id
@@ -12,5 +11,4 @@ class ControlledTermValue < ApplicationRecord
     ControlledTerm.elastic_index!( ids: [controlled_attribute_id, controlled_value_id].compact )
     true
   end
-
 end

--- a/app/views/controlled_term_labels/_form.html.haml
+++ b/app/views/controlled_term_labels/_form.html.haml
@@ -1,10 +1,11 @@
 - label = label || nil
+- no_required_fields ||= nil
 - if @term
   .row
     .form-horizontal
       = form_for label || ControlledTermLabel.new(controlled_term: @term) do |f|
         = f.hidden_field :controlled_term_id, value: @term.id
-        = render partial: "controlled_term_labels/form_fields", locals: { f: f, label: label }
+        = render partial: "controlled_term_labels/form_fields", locals: { f: f, label: label, no_required_fields: no_required_fields }
         .row
           .col-md-12.text-center
             = f.submit class: "btn btn-primary"

--- a/app/views/controlled_term_labels/_form_fields.html.haml
+++ b/app/views/controlled_term_labels/_form_fields.html.haml
@@ -1,17 +1,19 @@
 - label = label || nil
+- no_required_fields ||= nil
 - f = f || nil
 - if f
   .row.labels.form-horizontal
     .col-md-6
       .form-group
-        %label.col-sm-4.control-label Label
+        .col-sm-4.control-label= f.label :label
         .col-sm-8
-          = f.text_field :label, class: "form-control"
+          = f.text_field :label, class: "form-control", required: !no_required_fields, label: false
       .form-group
         %label.col-sm-4.control-label Label Locale
         .col-sm-8
           = f.text_field :locale, class: "form-control",
-            value: label && label.locale ? label.locale : (current_user.locale || "en")
+            value: label && label.locale ? label.locale : (current_user.locale || "en"),
+            label: false
       .form-group
         %label.col-sm-4.control-label Label Valid Within Clade
         .col-sm-8
@@ -21,10 +23,10 @@
       .form-group
         %label.col-sm-2.control-label Definition
         .col-sm-10
-          = f.text_area :definition, class: "form-control"
+          = f.text_area :definition, class: "form-control", required: !no_required_fields, label: false
       .form-group
         %label.col-sm-2.control-label Icon
         .col-sm-10
-          = f.file_field :icon, accept: "image/jpg,image/jpeg,image/png,image/gif"
+          = f.file_field :icon, accept: "image/jpg,image/jpeg,image/png,image/gif", label: false
           - if label && label.icon.exists?
             = image_tag label.icon.url, style: "max-width: 250px; max-height: 250px;"

--- a/app/views/controlled_terms/_controlled_term_taxon_fields.html.haml
+++ b/app/views/controlled_terms/_controlled_term_taxon_fields.html.haml
@@ -4,8 +4,7 @@
     = f.hidden_field :taxon_id
   .checkbox
     %label
-      = f.check_box :exception
-      Exception
+      = f.check_box :exception, label: "Exception"
   .form-group
     = link_to_remove_association "Remove", f, class: "btn btn-danger btn-sm"
   = f.hidden_field :controlled_term_id

--- a/app/views/controlled_terms/_form.html.haml
+++ b/app/views/controlled_terms/_form.html.haml
@@ -3,8 +3,8 @@
 - new_term ||= false
 .container
   .row
-    = form_for term do |f|
-      = f.fields_for primary_term_label do |ctl_f|
+    = form_for term, builder: BootstrapFormBuilder do |f|
+      = f.fields_for primary_term_label, builder: BootstrapFormBuilder do |ctl_f|
         = ctl_f.hidden_field :id, value: primary_term_label.id
         = render partial: "controlled_term_labels/form_fields", locals: { f: ctl_f, label: primary_term_label }
       .row.form-horizontal
@@ -12,26 +12,26 @@
           .form-group
             %label.col-sm-2.control-label Ontology URI
             .col-sm-10
-              = f.text_field :ontology_uri, class: "form-control"
+              = f.text_field :ontology_uri, class: "form-control", label: false
           .form-group
             %label.col-sm-2.control-label URI
             .col-sm-10
-              = f.text_field :uri, class: "form-control"
+              = f.text_field :uri, class: "form-control", label: false
           .form-group
             .col-sm-offset-2.col-sm-10
               .checkbox
                 %label
-                  = f.check_box :is_value
+                  = f.check_box :is_value, skip_builder: true
                   Is a value?
                 - unless term.is_value?
                   %label
-                    = f.check_box :multivalued
+                    = f.check_box :multivalued, skip_builder: true
                     Multivalued?
                 %label
-                  = f.check_box :blocking
+                  = f.check_box :blocking, skip_builder: true
                   Blocks annotations of other values?
                 %label
-                  = f.check_box :active
+                  = f.check_box :active, skip_builder: true
                   Active?
       .row
         .col-sm-2.form-horizontal
@@ -61,17 +61,17 @@
       - term.controlled_term_value_attrs.each do |ctv|
         .row
           .form-group
-            %label.col-sm-2.control-label= ctv.controlled_attribute.label
-            .col-sm-10
+            %label.col-sm-3.control-label= ctv.controlled_attribute.label
+            .col-sm-9
               = button_to "remove association", ctv, method: :delete, data: { confirm: t(:are_you_sure?) }, class: "btn btn-danger"
       - if term.possible_attribute_associates.any?
         .row
           = form_for ControlledTermValue.new do |f|
             = f.hidden_field :controlled_value_id, value: term.id
             .form-group
-              %label.col-sm-2.control-label
-                = f.select :controlled_attribute_id, term.possible_attribute_associates, class: "form-control"
-              .col-sm-10
+              %label.col-sm-3.control-label
+                = f.select :controlled_attribute_id, term.possible_attribute_associates, class: "form-control", label: false
+              .col-sm-9
                 = f.submit "Create attribute association", class: "btn btn-primary"
 
     - term.labels.where("id != ?", primary_term_label).order(:id).each do |l|
@@ -88,5 +88,5 @@
     %hr
     .row
       %h3 Create a New Label
-      = render partial: "controlled_term_labels/form"
+      = render "controlled_term_labels/form", no_required_fields: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1295,10 +1295,12 @@ en:
     cannot_be_determined: Cannot be determined from the evidence provided
     dead: Organism is dead or shows signs of imminent death
     feather: One or more feathers not attached to an organism
+    female: Evidence indicates that organism can produce ova for use in sexual reproduction
     flower_budding: Flower buds are visible but not open
     flowering: Flowers visible, open, and still attached to the plant
     fruiting: Fruit visible and still attached to the plant
     gall: Deformed plant tissue outgrowth caused by a parasitic organism
+    male: Evidence indicates that organism can produce sperm for use in sexual reproduction
     molt: Discarded skin or exoskeleton
     no_evidence_of_flowering: Media provides no evidence of reproductive structures
     organism: Whole or partial organism

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -8,8 +8,8 @@ Announcement.blueprint do
   placement { "users/dashboard#sidebar" }
 end
 Annotation.blueprint do
-  controlled_attribute { ControlledTerm.make! }
-  controlled_value { ControlledTerm.make! }
+  controlled_attribute { make_controlled_term_with_label }
+  controlled_value { make_controlled_value_with_label( nil, controlled_attribute ) }
   resource { Observation.make! }
 end
 
@@ -69,7 +69,6 @@ ConservationStatus.blueprint do
 end
 
 ControlledTerm.blueprint do
-  labels { [ControlledTermLabel.make!] }
 end
 
 ControlledTermLabel.blueprint do
@@ -78,13 +77,13 @@ ControlledTermLabel.blueprint do
 end
 
 ControlledTermTaxon.blueprint do
-  controlled_term { ControlledTerm.make! }
+  controlled_term { make_controlled_term_with_label }
   taxon { Taxon.make! }
 end
 
 ControlledTermValue.blueprint do
-  controlled_attribute { ControlledTerm.make! }
-  controlled_value { ControlledTerm.make!(is_value: true) }
+  controlled_attribute { make_controlled_term_with_label }
+  controlled_value { ControlledTerm.make( is_value: true ) }
 end
 
 DataPartner.blueprint do

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -69,6 +69,7 @@ ConservationStatus.blueprint do
 end
 
 ControlledTerm.blueprint do
+  labels { [ControlledTermLabel.make!] }
 end
 
 ControlledTermLabel.blueprint do

--- a/spec/controllers/annotations_controller_api_spec.rb
+++ b/spec/controllers/annotations_controller_api_spec.rb
@@ -1,17 +1,20 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+# frozen_string_literal: true
+
+require "#{File.dirname( __FILE__ )}/../spec_helper"
 
 shared_examples_for "a AnnotationsController" do
-  let(:user) { User.make! }
-  let(:observation) { Observation.make! }
+  let( :user ) { User.make! }
+  let( :observation ) { Observation.make! }
 
   describe "create" do
     it "should return a UUID" do
-      ctv = ControlledTermValue.make!
+      controlled_attribute = make_controlled_term_with_label
+      controlled_value = make_controlled_value_with_label( nil, controlled_attribute )
       post :create, format: :json, params: { annotation: {
         resource_type: "Observation",
         resource_id: observation.id,
-        controlled_attribute_id: ctv.controlled_attribute.id,
-        controlled_value_id: ctv.controlled_value.id
+        controlled_attribute_id: controlled_attribute.id,
+        controlled_value_id: controlled_value.id
       } }
       expect( response ).to be_successful
       json = JSON.parse( response.body )
@@ -21,15 +24,17 @@ shared_examples_for "a AnnotationsController" do
 end
 
 describe AnnotationsController, "oauth authentication" do
-  let(:token) {
-    double acceptable?: true,
-    accessible?: true,
-    resource_owner_id: user.id,
-    application: OauthApplication.make!
-  }
+  let( :token ) do
+    double(
+      acceptable?: true,
+      accessible?: true,
+      resource_owner_id: user.id,
+      application: OauthApplication.make!
+    )
+  end
   before do
     request.env["HTTP_AUTHORIZATION"] = "Bearer xxx"
-    allow(controller).to receive(:doorkeeper_token) { token }
+    allow( controller ).to receive( :doorkeeper_token ) { token }
   end
   before { ActionController::Base.allow_forgery_protection = true }
   after { ActionController::Base.allow_forgery_protection = false }

--- a/spec/controllers/controlled_terms_controller_spec.rb
+++ b/spec/controllers/controlled_terms_controller_spec.rb
@@ -22,7 +22,15 @@ describe ControlledTermsController do
     it "allows admins to create terms" do
       sign_in( make_admin )
       expect do
-        post :create, params: { controlled_term: { uri: "adminterm" } }
+        post :create, params: {
+          controlled_term: {
+            uri: "adminterm",
+            controlled_term_label: {
+              label: "foo",
+              definition: "bar"
+            }
+          }
+        }
       end.to change( ControlledTerm, :count ).by( 1 )
       expect( ControlledTerm.last.uri ).to eq "adminterm"
     end

--- a/spec/lib/darwin_core/archive_spec.rb
+++ b/spec/lib/darwin_core/archive_spec.rb
@@ -622,6 +622,9 @@ describe DarwinCore::Archive, "make_occurrence_data" do
       )
       @unannotated_o = make_research_grade_observation
       @sex_annotated_o = make_research_grade_observation
+      @sex_attribute.reload
+      @life_stage_attribute.reload
+      @unrecognized_attribute.reload
       Annotation.make!(
         resource: @sex_annotated_o,
         controlled_attribute: @sex_attribute,

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,11 +1,13 @@
-require "spec_helper.rb"
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe Annotation do
   elastic_models( ControlledTerm )
 
   it { is_expected.to belong_to :resource }
-  it { is_expected.to belong_to(:controlled_attribute).class_name "ControlledTerm" }
-  it { is_expected.to belong_to(:controlled_value).class_name "ControlledTerm" }
+  it { is_expected.to belong_to( :controlled_attribute ).class_name "ControlledTerm" }
+  it { is_expected.to belong_to( :controlled_value ).class_name "ControlledTerm" }
   it { is_expected.to belong_to :user }
   it { is_expected.to belong_to :observation_field_value }
 
@@ -13,118 +15,128 @@ describe Annotation do
   it { is_expected.to validate_presence_of :controlled_attribute }
 
   it do
-    is_expected.to validate_uniqueness_of(:controlled_value_id)
-                     .scoped_to :resource_type, :resource_id, :controlled_attribute_id
+    is_expected.to validate_uniqueness_of( :controlled_value_id ).
+      scoped_to :resource_type, :resource_id, :controlled_attribute_id
   end
 
   it "validates existence of resource" do
-    expect{
-      Annotation.make!(resource: nil, resource_type: "Observation", resource_id: 9999)
-    }.to raise_error(ActiveRecord::RecordInvalid, /Resource can't be blank/)
+    expect do
+      Annotation.make!( resource: nil, resource_type: "Observation", resource_id: 9999 )
+    end.to raise_error( ActiveRecord::RecordInvalid, /Resource can't be blank/ )
   end
 
   it "validates attribute is an attribute" do
-    atr = ControlledTerm.make!(is_value: true)
-    expect{ Annotation.make!(controlled_attribute: atr) }.to raise_error(
-      ActiveRecord::RecordInvalid, /Controlled attribute must be an attribute/)
+    atr = make_controlled_term_with_label( nil, is_value: true )
+    expect { Annotation.make!( controlled_attribute: atr ) }.to raise_error(
+      ActiveRecord::RecordInvalid, /Controlled attribute must be an attribute/
+    )
   end
 
   it "validates value is a value" do
-    val = ControlledTerm.make!
-    expect{ Annotation.make!(controlled_value: val) }.to raise_error(
-      ActiveRecord::RecordInvalid, /Controlled value must be a value/)
+    val = make_controlled_term_with_label( nil )
+    expect { Annotation.make!( controlled_value: val ) }.to raise_error(
+      ActiveRecord::RecordInvalid, /Controlled value must be a value/
+    )
   end
 
   it "validates attribute belongs to value" do
-    expect{
+    expect do
       Annotation.make!(
-        controlled_attribute: ControlledTerm.make!,
-        controlled_value: ControlledTerm.make!(is_value: true)
+        controlled_attribute: make_controlled_term_with_label,
+        controlled_value: make_controlled_term_with_label( nil, is_value: true )
       )
-    }.to raise_error(ActiveRecord::RecordInvalid, /Controlled value must belong to attribute/)
+    end.to raise_error( ActiveRecord::RecordInvalid, /Controlled value must belong to attribute/ )
   end
 
   it "validates attribute belongs to taxon" do
-    animalia = Taxon.make!(name: "Animalia", rank: Taxon::KINGDOM)
-    mammalia = Taxon.make!(name: "Mammalia", parent: animalia, rank: Taxon::CLASS)
-    obs = Observation.make!(taxon: animalia)
-    atr = ControlledTermTaxon.make!( taxon: mammalia ).controlled_term
-    ctv = ControlledTermValue.make!(controlled_attribute: atr)
-    expect{
+    animalia = Taxon.make!( name: "Animalia", rank: Taxon::KINGDOM )
+    mammalia = Taxon.make!( name: "Mammalia", parent: animalia, rank: Taxon::CLASS )
+    obs = Observation.make!( taxon: animalia )
+    atr = make_controlled_term_with_label
+    ControlledTermTaxon.make!( taxon: mammalia, controlled_term: atr )
+    make_controlled_value_with_label( nil, atr )
+    expect do
       Annotation.make!(
         resource: obs,
         controlled_attribute: atr,
         controlled_value: atr.values.first
       )
-    }.to raise_error(ActiveRecord::RecordInvalid, /Controlled attribute must belong to taxon/)
+    end.to raise_error( ActiveRecord::RecordInvalid, /Controlled attribute must belong to taxon/ )
   end
 
   it "validates value belongs to taxon" do
-    animalia = Taxon.make!(name: "Animalia", rank: Taxon::KINGDOM)
-    mammalia = Taxon.make!(name: "Mammalia", parent: animalia, rank: Taxon::CLASS)
-    obs = Observation.make!(taxon: animalia)
-    atr = ControlledTerm.make!
-    val = ControlledTerm.make!( is_value: true )
+    animalia = Taxon.make!( name: "Animalia", rank: Taxon::KINGDOM )
+    mammalia = Taxon.make!( name: "Mammalia", parent: animalia, rank: Taxon::CLASS )
+    obs = Observation.make!( taxon: animalia )
+    atr = make_controlled_term_with_label
+    val = make_controlled_term_with_label( nil, is_value: true )
     ControlledTermTaxon.make!( taxon: mammalia, controlled_term: val )
-    ctv = ControlledTermValue.make!(controlled_attribute: atr, controlled_value: val)
-    expect{
+    ControlledTermValue.make!( controlled_attribute: atr, controlled_value: val )
+    atr.reload
+    val.reload
+    expect do
       Annotation.make!(
         resource: obs,
         controlled_attribute: atr,
         controlled_value: val
       )
-    }.to raise_error(ActiveRecord::RecordInvalid, /Controlled value must belong to taxon/)
+    end.to raise_error( ActiveRecord::RecordInvalid, /Controlled value must belong to taxon/ )
   end
 
   it "validates against presence of another annotation of a blocking value" do
     obs = Observation.make!
-    atr = ControlledTerm.make!( multivalued: true )
-    val = ControlledTerm.make!( is_value: true )
+    atr = make_controlled_term_with_label( nil, multivalued: true )
+    val = make_controlled_term_with_label( nil, is_value: false )
     atr.controlled_term_values.create( controlled_value: val )
-    blocking_val = ControlledTerm.make!( is_value: true, blocking: true )
+    blocking_val = make_controlled_term_with_label( nil, is_value: true, blocking: true )
     atr.controlled_term_values.create( controlled_value: blocking_val )
-    blocking_annotation = Annotation.make!(
+    atr.reload
+    _blocking_annotation = Annotation.make!(
       controlled_attribute: atr,
       controlled_value: blocking_val,
       resource: obs
     )
-    expect {
+    expect do
       Annotation.make!(
         controlled_attribute: atr,
         controlled_value: val,
         resource: obs
       )
-    }.to raise_error( ActiveRecord::RecordInvalid, /blocked by another value/ )
+    end.to raise_error( ActiveRecord::RecordInvalid, /blocked by another value/ )
   end
 
   it "validates against presence of another annotation if this is a blocking value" do
     obs = Observation.make!
-    atr = ControlledTerm.make!( multivalued: true )
-    val = ControlledTerm.make!( is_value: true )
+    atr = make_controlled_term_with_label( nil, multivalued: true )
+    val = make_controlled_term_with_label( nil, is_value: true )
     atr.controlled_term_values.create( controlled_value: val )
-    blocking_val = ControlledTerm.make!( is_value: true, blocking: true )
+    blocking_val = make_controlled_term_with_label( nil, is_value: true, blocking: true )
     atr.controlled_term_values.create( controlled_value: blocking_val )
+    atr.reload
+    val.reload
+    blocking_val.reload
     Annotation.make!(
       controlled_attribute: atr,
       controlled_value: val,
       resource: obs
     )
-    expect {
+    expect do
       Annotation.make!(
         controlled_attribute: atr,
         controlled_value: blocking_val,
         resource: obs
       )
-    }.to raise_error( ActiveRecord::RecordInvalid, /is blocking but another annotation already added/ )
+    end.to raise_error( ActiveRecord::RecordInvalid, /is blocking but another annotation already added/ )
   end
 
   it "validates for multivalued term on update" do
     obs = Observation.make!
-    atr = ControlledTerm.make!( multivalued: true )
-    val1 = ControlledTerm.make!( is_value: true )
-    val2 = ControlledTerm.make!( is_value: true )
+    atr = make_controlled_term_with_label( nil, multivalued: true )
+    val1 = make_controlled_term_with_label( nil, is_value: true )
+    val2 = make_controlled_term_with_label( nil, is_value: true )
     atr.controlled_term_values.create( controlled_value: val1 )
     atr.controlled_term_values.create( controlled_value: val2 )
+    atr.reload
     a1 = Annotation.make!(
       controlled_attribute: atr,
       controlled_value: val1,
@@ -142,55 +154,57 @@ describe Annotation do
   end
 
   it "creates valid instances" do
-    atr = ControlledTerm.make!
-    val = ControlledTerm.make!(is_value: true)
-    atr.controlled_term_values.create(controlled_value: val)
-    # ctv = ControlledTermValue.make!(controlled_attribute: atr, controlled_value: val)
-    expect{
+    controlled_attribute = make_controlled_term_with_label
+    controlled_value = make_controlled_value_with_label( nil, controlled_attribute )
+    expect do
       Annotation.make!(
-        controlled_attribute: atr,
-        controlled_value: val
+        controlled_attribute: controlled_attribute,
+        controlled_value: controlled_value
       )
-    }.to_not raise_error
-    expect(Annotation.count).to eq 1
+    end.to_not raise_error
+    expect( Annotation.count ).to eq 1
   end
 
   it "does not allow multiple values per attribute unless specified" do
-    atr = ControlledTerm.make!(multivalued: false)
-    val1 = ControlledTerm.make!(is_value: true)
-    val2 = ControlledTerm.make!(is_value: true)
-    atr.controlled_term_values.create(controlled_value: val1)
-    atr.controlled_term_values.create(controlled_value: val2)
+    atr = make_controlled_term_with_label( nil, multivalued: false )
+    val1 = make_controlled_term_with_label( nil, is_value: true )
+    val2 = make_controlled_term_with_label( nil, is_value: true )
+    atr.controlled_term_values.create( controlled_value: val1 )
+    atr.controlled_term_values.create( controlled_value: val2 )
+    atr.reload
     original = Annotation.make!(
       controlled_attribute: atr,
       controlled_value: val1
     )
-    expect{
+    expect do
       Annotation.make!(
         resource: original.resource,
         controlled_attribute: atr,
         controlled_value: val2
       )
-    }.to raise_error(ActiveRecord::RecordInvalid, /Controlled attribute cannot have multiple values/)
+    end.to raise_error( ActiveRecord::RecordInvalid, /Controlled attribute cannot have multiple values/ )
   end
 
   it "does allow multiple values per attribute if specified" do
-    atr = ControlledTerm.make!(multivalued: true)
-    val1 = ControlledTerm.make!(is_value: true)
-    val2 = ControlledTerm.make!(is_value: true)
-    atr.controlled_term_values.create(controlled_value: val1)
-    atr.controlled_term_values.create(controlled_value: val2)
+    atr = make_controlled_term_with_label( nil, multivalued: true )
+    val1 = make_controlled_term_with_label( nil, is_value: true )
+    val2 = make_controlled_term_with_label( nil, is_value: true )
+    atr.controlled_term_values.create( controlled_value: val1 )
+    atr.controlled_term_values.create( controlled_value: val2 )
+    atr.reload
+    val1.reload
+    val1.reload
     original = Annotation.make!(
       controlled_attribute: atr,
       controlled_value: val1
     )
-    expect{
+    expect do
       Annotation.make!(
         resource: original.resource,
         controlled_attribute: atr,
         controlled_value: val2
       )
-    }.to_not raise_error
+    end.to_not raise_error
   end
 
   describe "creation" do
@@ -218,8 +232,8 @@ describe Annotation do
 
   describe "deletion after" do
     before do
-      @attribute = ControlledTerm.make!
-      @value = ControlledTerm.make!( is_value: true )  
+      @attribute = make_controlled_term_with_label
+      @value = make_controlled_term_with_label( nil, is_value: true )
       @attribute.controlled_term_values << ControlledTermValue.new(
         controlled_attribute: @attribute,
         controlled_value: @value
@@ -229,6 +243,8 @@ describe Annotation do
       @species = Taxon.make!( rank: Taxon::SPECIES, parent: @genus )
       @attribute.controlled_term_taxa.create!( taxon: @family )
 
+      @value.reload
+      @attribute.reload
       @observation = Observation.make!( taxon: @genus )
       @annotation = Annotation.make!(
         resource: @observation,

--- a/spec/models/controlled_term_label_spec.rb
+++ b/spec/models/controlled_term_label_spec.rb
@@ -1,6 +1,9 @@
-require "spec_helper.rb"
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe ControlledTermLabel do
   it { is_expected.to belong_to :controlled_term }
-  it { is_expected.to belong_to(:valid_within_taxon).with_foreign_key(:valid_within_clade).class_name "Taxon" }
+  it { is_expected.to belong_to( :valid_within_taxon ).with_foreign_key( :valid_within_clade ).class_name "Taxon" }
+  it { is_expected.to validate_presence_of( :definition ).on( :create ) }
 end

--- a/spec/models/controlled_term_spec.rb
+++ b/spec/models/controlled_term_spec.rb
@@ -41,10 +41,10 @@ describe ControlledTerm do
 
   describe "values" do
     it "returns all values for a term" do
-      atr = ControlledTerm.make!
-      ControlledTermValue.make!(controlled_attribute: atr)
-      ControlledTermValue.make!(controlled_attribute: atr)
-      expect(atr.values.count).to eq 2
+      atr = make_controlled_term_with_label
+      make_controlled_value_with_label( nil, atr )
+      make_controlled_value_with_label( nil, atr )
+      expect( atr.values.count ).to eq 2
     end
   end
 
@@ -56,7 +56,7 @@ describe ControlledTerm do
   
     describe "for_taxon" do
       it "returns terms for taxa and their ancestors" do
-        ControlledTerm.make!
+        make_controlled_term_with_label
         [mammalia, primates, plantae].each do |t|
           ControlledTermTaxon.make!( taxon: t )
         end
@@ -94,7 +94,7 @@ describe ControlledTerm do
         expect( animalia_ct.applicable_to_taxon( mammalia ) ).to be false
       end
       it "should be true for any taxon if the term has no associated taxa" do
-        ct = ControlledTerm.make!
+        ct = make_controlled_term_with_label
         expect( ct.applicable_to_taxon( mammalia ) ).to be true
       end
     end
@@ -102,10 +102,10 @@ describe ControlledTerm do
 
   describe "unassigned_values" do
     it "returns an array of value terms not associated with an attribute" do
-      atr = ControlledTerm.make!
-      val = ControlledTerm.make!(is_value: true)
-      ControlledTermValue.make!(controlled_attribute: atr, controlled_value: val)
-      unassigned = ControlledTerm.make!(is_value: true)
+      atr = make_controlled_term_with_label
+      val = make_controlled_term_with_label( nil, is_value: true )
+      ControlledTermValue.make!( controlled_attribute: atr, controlled_value: val )
+      unassigned = make_controlled_term_with_label( nil, is_value: true )
       expect(ControlledTerm.unassigned_values.count).to eq 1
       expect(ControlledTerm.unassigned_values.first).to eq unassigned
     end

--- a/spec/models/controlled_term_spec.rb
+++ b/spec/models/controlled_term_spec.rb
@@ -29,6 +29,15 @@ describe ControlledTerm do
                                             .through(:controlled_term_taxa).source :taxon
   end
 
+  it "validates labels" do
+    expect( ControlledTerm.new ).not_to be_valid
+    invalid_label = ControlledTermLabel.new
+    expect( invalid_label ).not_to be_valid
+    expect( ControlledTerm.new( labels: [invalid_label] ) ).not_to be_valid
+    valid_label = ControlledTermLabel.new( label: "foo", definition: "bar" )
+    expect( valid_label ).to be_valid
+    expect( ControlledTerm.new( labels: [valid_label] ) ).to be_valid
+  end
 
   describe "values" do
     it "returns all values for a term" do

--- a/spec/models/observation_field_value_spec.rb
+++ b/spec/models/observation_field_value_spec.rb
@@ -267,33 +267,20 @@ describe ObservationFieldValue do
 
   describe "annotation_attribute_and_value" do
     before( :all ) do
-      @alive_or_dead = ControlledTerm.make!( active: true )
-      ControlledTermLabel.make!( controlled_term: @alive_or_dead, label: "Alive or Dead" )
-      @alive = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @alive, label: "Alive")
-      @dead = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @dead, label: "Dead" )
-      @cannot_be_determined = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @cannot_be_determined, label: "Cannot Be Determined" )
-      @alive_or_dead.controlled_term_values.create( controlled_value: @alive )
-      @alive_or_dead.controlled_term_values.create( controlled_value: @dead )
-      @alive_or_dead.controlled_term_values.create( controlled_value: @cannot_be_determined )
+      @alive_or_dead = make_controlled_term_with_label( "Alive or Dead", active: true)
+      @alive = make_controlled_value_with_label( "Alive", @alive_or_dead )
+      @dead = make_controlled_value_with_label( "Dead", @alive_or_dead )
+      @cannot_be_determined = make_controlled_value_with_label( "Cannot Be Determined", @alive_or_dead )
       @dead_or_alive_field = ObservationField.make!( name: "Dead or alive", allowed_values: "dead|alive|moribund|not sure" )
-      @evidence = ControlledTerm.make!( active: true )
-      ControlledTermLabel.make!( controlled_term: @evidence, label: "Evidence of Presence" )
-      # @dead = ControlledTerm.make!( is_value: true, active: true )
-      # ControlledTermLabel.make!( controlled_term: @dead, label: "Dead" )
-      @track = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @track, label: "Track" )
-      @scat = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @scat, label: "Scat" )
-      @feather = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @feather, label: "Feather" )
-      @molt = ControlledTerm.make!( is_value: true, active: true )
-      ControlledTermLabel.make!( controlled_term: @molt, label: "Molt" )
+      @evidence = make_controlled_term_with_label( "Evidence of Presence", active: true )
+      @track = make_controlled_value_with_label( "Track", @evidence )
+      @scat = make_controlled_value_with_label( "Scat", @evidence )
+      @feather = make_controlled_value_with_label( "Feather", @evidence )
+      @molt = make_controlled_value_with_label( "Molt", @evidence )
       @evidence_field = ObservationField.make!(
-          name: "Animal Sign and Song",
-          allowed_values: "None Recorded|Tracks|Scat|Remains|Call/Song|Evidence of Feeding|Evidence of Egg Laying|Smell|Scratching/Scent Post|Nest|Burrow/Den|Web|Fur/Feathers|Shell/Exoskeleton|Shed skin|Window print"
+        name: "Animal Sign and Song",
+        allowed_values: "None Recorded|Tracks|Scat|Remains|Call/Song|Evidence of Feeding|Evidence of Egg Laying|" \
+          "Smell|Scratching/Scent Post|Nest|Burrow/Den|Web|Fur/Feathers|Shell/Exoskeleton|Shed skin|Window print"
       )
     end
 


### PR DESCRIPTION
Requires the presence of a label for new controlled terms and validates that all new labels have the `label` and `description` attributes.

This kind of throws testing for a loop since to make a valid controlled term you now need to build out an associate, so I'm open to ideas about how to make that better.