### PR TITLE
I18n iconic taxon changes

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2396,13 +2396,21 @@ class Observation < ApplicationRecord
   def scientific_name
     taxon.scientific_name.name if taxon && taxon.scientific_name
   end
-  
-  def common_name(options = {})
+
+  def common_name( options = {} )
     options[:locale] ||= localize_locale
     options[:place] ||= localize_place
-    taxon.common_name(options).name if taxon && taxon.common_name(options)
+    name_from_taxon_names = taxon&.common_name( options )&.name
+    return name_from_taxon_names if name_from_taxon_names
+    return unless taxon&.is_iconic? || taxon&.root?
+
+    I18n.t(
+      taxon.name.parameterize.underscore,
+      scope: :all_taxa,
+      locale: options[:locale] || user.try( :locale )
+    )
   end
-  
+
   def url
     uri
   end

--- a/app/views/taxa/_taxon.txt.erb
+++ b/app/views/taxa/_taxon.txt.erb
@@ -2,14 +2,15 @@
 place ||= @place
 no_common ||= false
 viewer ||= ( defined?( current_user ) ? current_user : nil ) rescue nil
-comname = common_taxon_name(
+comname = common_taxon_names(
   taxon,
   place: place || @site.try(:place),
   user: viewer
-).try(:name)
-comname = capitalize_name( comname ) if comname
+).first
 if taxon.rank == 'species' or taxon.rank == 'infraspecies'
   sciname = taxon.name
+elsif taxon.name == "Life"
+  sciname = t(:rank_sciname, rank: t( "ranks.#{taxon.rank}", default: taxon.rank ), name: comname )
 else
   sciname = t(:rank_sciname, rank: t( "ranks.#{taxon.rank}", default: taxon.rank ), name: taxon.name )
 end

--- a/app/webpack/lifelists/show/components/details_view.jsx
+++ b/app/webpack/lifelists/show/components/details_view.jsx
@@ -129,17 +129,18 @@ const DetailsView = ( {
     if ( lifelist.speciesPlaceFilter ) {
       searchLoaded = inatAPIsearch && inatAPIsearch.searchResponse;
     }
-    // TODO iconic_taxon_name doesn't actually seem to be present on this
-    // taxon, but we'll want it to be if we want this to be translated
-    // properly in languages that have different rank names for different
-    // groups
     stats = (
       <div className="stats">
         <span className="stat">
           <span className="attr">
             { I18n.t( "views.lifelists.observed_rank", {
-              rank: rankLabel( { rank: lifelist.speciesViewRankFilter, withLeaves: false } ),
-              iconic_taxon: lifelist.detailsTaxon?.iconic_taxon_name
+              rank: rankLabel( {
+                rank: lifelist.speciesViewRankFilter,
+                withLeaves: false,
+                iconicTaxonName: lifelist.detailsTaxon
+                  ? lifelist.detailsTaxon.iconic_taxon_name
+                  : null
+              } )
             } ) }
           </span>
           <span className="value">

--- a/app/webpack/lifelists/show/components/details_view.jsx
+++ b/app/webpack/lifelists/show/components/details_view.jsx
@@ -129,12 +129,18 @@ const DetailsView = ( {
     if ( lifelist.speciesPlaceFilter ) {
       searchLoaded = inatAPIsearch && inatAPIsearch.searchResponse;
     }
+    // TODO iconic_taxon_name doesn't actually seem to be present on this
+    // taxon, but we'll want it to be if we want this to be translated
+    // properly in languages that have different rank names for different
+    // groups
     stats = (
       <div className="stats">
         <span className="stat">
           <span className="attr">
-            { I18n.t( "views.lifelists.observed_rank",
-              { rank: rankLabel( { rank: lifelist.speciesViewRankFilter, withLeaves: false } ) } ) }
+            { I18n.t( "views.lifelists.observed_rank", {
+              rank: rankLabel( { rank: lifelist.speciesViewRankFilter, withLeaves: false } ),
+              iconic_taxon: lifelist.detailsTaxon?.iconic_taxon_name
+            } ) }
           </span>
           <span className="value">
             { searchLoaded

--- a/app/webpack/lifelists/show/components/species_noapi.jsx
+++ b/app/webpack/lifelists/show/components/species_noapi.jsx
@@ -121,9 +121,12 @@ class SpeciesNoAPI extends Component {
 
     const rankOptions = (
       <DropdownButton
-        title={`${I18n.t( "views.lifelists.dropdowns.show" )}: ${rankLabel(
-          { rank: lifelist.speciesViewRankFilter }
-        )}`}
+        title={`${I18n.t( "views.lifelists.dropdowns.show" )}: ${rankLabel( {
+          rank: lifelist.speciesViewRankFilter,
+          iconicTaxonName: detailsTaxon
+            ? detailsTaxon.iconic_taxon_name
+            : null
+        } )}`}
         id="rankDropdown"
         onSelect={key => setRankFilter( key )}
       >
@@ -147,7 +150,12 @@ class SpeciesNoAPI extends Component {
                 && ( detailsTaxon.rank_level <= 20 || detailsTaxon.rank_level <= r.rank_level )}
               className={lifelist.speciesViewRankFilter === r.filter ? "selected" : null}
             >
-              { I18n.t( `ranks.x_${r.filter}`, { count: 2 } ) }
+              { I18n.t( `ranks.x_${r.filter}`, {
+                count: 2,
+                iconic_taxon: detailsTaxon
+                  ? detailsTaxon.iconic_taxon_name
+                  : null
+              } ) }
             </MenuItem>
         ) )}
         <MenuItem

--- a/app/webpack/lifelists/show/util.js
+++ b/app/webpack/lifelists/show/util.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 function nodeObsCount( lifelist, search ) {
   return function ( node ) {
     if ( lifelist.speciesPlaceFilter
@@ -56,11 +58,13 @@ function filteredNodes( lifelist, search ) {
   }
   if ( !nodeShouldDisplay ) return null;
 
-  return _.filter( lifelist.taxa,
-    t => nodeIsDescendant( t ) && nodeShouldDisplay( t ) && obsCount( t ) );
+  return _.filter(
+    lifelist.taxa,
+    t => nodeIsDescendant( t ) && nodeShouldDisplay( t ) && obsCount( t )
+  );
 }
 
-function rankLabel( { rank: filter, withLeaves = true } = {} ) {
+function rankLabel( { rank: filter, withLeaves = true, iconicTaxonName = null } = {} ) {
   switch ( filter ) {
     case "kingdoms":
     case "phyla":
@@ -69,7 +73,7 @@ function rankLabel( { rank: filter, withLeaves = true } = {} ) {
     case "families":
     case "genera":
     case "species":
-      return I18n.t( `ranks.x_${filter}`, { count: 2 } );
+      return I18n.t( `ranks.x_${filter}`, { count: 2, iconic_taxon: iconicTaxonName } );
     case "leaves":
       return ( withLeaves ? I18n.t( "ranks.leaves" ) : I18n.t( "ranks.x_species", { count: 2 } ) );
     default:

--- a/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
@@ -205,10 +205,12 @@ class TaxonAutocomplete extends React.Component {
             const labelInEnglish = I18n.t( `were_pretty_sure_this_is_in_the_${snakeCaseRank}`, { locale: "en" } );
             const labelInLocaleFallback = I18n.t( "were_pretty_sure_this_is_in_the_rank", {
               rank: I18n.t( `ranks_lowercase_${snakeCaseRank}`, { defaultValue: item.rank } ),
-              gender: snakeCaseRank
+              gender: snakeCaseRank,
+              iconic_taxon: item.iconic_taxon_name
             } );
             const labelInLocale = I18n.t( `were_pretty_sure_this_is_in_the_${snakeCaseRank}`, {
-              defaultValue: labelInLocaleFallback
+              defaultValue: labelInLocaleFallback,
+              iconic_taxon: item.iconic_taxon_name
             } );
             let label = labelInLocale;
             if ( I18n.locale !== "en" && label === labelInEnglish ) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9770,6 +9770,20 @@ en:
         variety: "@n"
         # Default gender for nouns that aren't listed here
         default: "@n"
+      "@iconic_taxon":
+        Animalia: Animalia
+        Actinopterygii: Actinopterygii
+        Aves: Aves
+        Reptilia: Reptilia
+        Amphibia: Amphibia
+        Mammalia: Mammalia
+        Arachnida: Arachnida
+        Insecta: Insecta
+        Plantae: Plantae
+        Fungi: Fungi
+        Protozoa: Protozoa
+        Mollusca: Mollusca
+        Chromista: Chromista
   # Title of a section warning the user about something
   warning_title: Warning
   wikimedia: Wikimedia

--- a/lib/tasks/inaturalist.rake
+++ b/lib/tasks/inaturalist.rake
@@ -398,7 +398,8 @@ namespace :inaturalist do
       "yellow",
       "you_are_setting_this_project_to_aggregate",
       "i18n.inflections.@gender",
-      "i18n.inflections.@vow_or_con"
+      "i18n.inflections.@vow_or_con",
+      "i18n.inflections.@iconic_taxon"
     ]
     %w(
       all_rank_added_to_the_database

--- a/spec/helpers/taxa_helper_spec.rb
+++ b/spec/helpers/taxa_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TaxaHelper do
+  describe "common_taxon_names" do
+    it "should return a name from translations if taxon is iconic and there are no other valid names" do
+      life = create( :taxon, name: "Life", rank: Taxon::STATEOFMATTER )
+      expect( life ).not_to be_blank
+      expect( life.taxon_names.where( lexicon: TaxonName::HUNGARIAN ) ).not_to exist
+      name_from_translations = I18n.t( :life, scope: "all_taxa", locale: "hu" )
+      expect( name_from_translations ).not_to be_blank
+      expect( common_taxon_names( life, locale: "hu" ).first ).to eq name_from_translations
+    end
+  end
+end


### PR DESCRIPTION
* Use translated iconic taxon name as a fallback source of common names when TaxonName records are absent, particularly important for Life, which in theory does not support any taxon names
* Allow use of `@iconic_taxon` inflection in translations keys where the translation might vary depending on taxonomic context, e.g. in East Slavic languages where words like "phylum" will be different for plants and animals

Depends on https://github.com/inaturalist/iNaturalistAPI/pull/414