### PR TITLE
#3931: Give currentUser props to taxonomic_branch component

### DIFF
--- a/app/webpack/observations/identify/components/suggestions.jsx
+++ b/app/webpack/observations/identify/components/suggestions.jsx
@@ -422,6 +422,7 @@ class Suggestions extends React.Component {
                   <TaxonomicBranch
                     taxon={detailTaxon}
                     chooseTaxon={t => setDetailTaxon( t )}
+                    currentUser={config.currentUser}
                     noHideable
                   />
                 </div>


### PR DESCRIPTION
Compare modal wasn't honoring the user preference for Taxo naming. currentUser wasn't transmitted to the taxonomic_branch from the suggestion component