### PR TITLE
Collapsible Identify Annotations

### DIFF
--- a/app/assets/javascripts/jquery/plugins/inat/generic_autocomplete.js
+++ b/app/assets/javascripts/jquery/plugins/inat/generic_autocomplete.js
@@ -3,6 +3,13 @@
 
 var genericAutocomplete = { };
 
+// keys like arrows, tab, shift, caps-lock, etc. won't change
+// the value of the field so we don't need to reset the selection
+genericAutocomplete.nonCharacters = [
+  9, 16, 17, 18, 19, 20, 27, 33,
+  34, 35, 36, 37, 38, 39, 40, 91, 93, 144, 145
+];
+
 // allow <li class="category"> to be included in the results
 // but do not consider them selectable items
 $.widget( "ui.autocomplete", $.ui.autocomplete, {
@@ -227,16 +234,14 @@ $.fn.genericAutocomplete = function ( acOptions ) {
         return false;
       }
       if ( options.resetOnChange === false ) { return; }
-      // keys like arrows, tab, shift, caps-lock, etc. won't change
-      // the value of the field so we don't need to reset the selection
-      var nonCharacters = [9, 16, 17, 18, 19, 20, 27, 33,
-        34, 35, 36, 37, 38, 39, 40, 91, 93, 144, 145];
-      if ( _.includes( nonCharacters, key ) ) { return; }
+      if ( _.includes( genericAutocomplete.nonCharacters, key ) ) { return; }
       field.trigger( "resetSelection" );
     }
   } );
   field.keyup( function ( e ) {
     if ( !field.val( ) ) {
+      var key = e.keyCode || e.which;
+      if ( _.includes( genericAutocomplete.nonCharacters, key ) ) { return; }
       ac._close( );
       if ( options.resetOnChange !== false ) {
         field.trigger( "resetSelection" );

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,9 @@ class User < ApplicationRecord
   preference :hide_comments_onboarding, default: false
   preference :hide_following_onboarding, default: false
   preference :taxon_page_place_id, :integer
+  preference :hide_identify_annotations, default: false
+  preference :hide_identify_observation_fields, default: false
+  preference :hide_identify_projects, default: false
   preference :hide_obs_show_annotations, default: false
   preference :hide_obs_show_projects, default: false
   preference :hide_obs_show_tags, default: false

--- a/app/views/observations/identify.html.haml
+++ b/app/views/observations/identify.html.haml
@@ -12,9 +12,9 @@
       CURRENT_USER.prefers_identify_side_bar = #{logged_in? && current_user.prefers_identify_side_bar};
       CURRENT_USER.preferred_identify_image_size = #{logged_in? && current_user.preferred_identify_image_size ? current_user.preferred_identify_image_size.inspect.html_safe : "null"};
       CURRENT_USER.curator_projects = #{current_user.project_users.curator_privilege.includes(:project).map{|pu| { id: pu.project_id, slug: pu.project.slug } }.to_json.html_safe};
-      CURRENT_USER.prefers_hide_obs_show_annotations = #{logged_in? && current_user.prefers_hide_obs_show_annotations};
-      CURRENT_USER.prefers_hide_obs_show_projects = #{logged_in? && current_user.prefers_hide_obs_show_projects};
-      CURRENT_USER.prefers_hide_obs_show_observation_fields = #{logged_in? && current_user.prefers_hide_obs_show_observation_fields};
+      CURRENT_USER.prefers_hide_identify_annotations = #{logged_in? && current_user.prefers_hide_identify_annotations};
+      CURRENT_USER.prefers_hide_identify_projects = #{logged_in? && current_user.prefers_hide_identify_projects};
+      CURRENT_USER.prefers_hide_identify_observation_fields = #{logged_in? && current_user.prefers_hide_identify_observation_fields};
     }
   = javascript_include_tag "webpack/runtime-webpack"
   = javascript_include_tag "webpack/react-main-webpack"

--- a/app/webpack/computer_vision/components/obs_card_component.jsx
+++ b/app/webpack/computer_vision/components/obs_card_component.jsx
@@ -123,9 +123,6 @@ class ObsCardComponent extends Component {
             }
             timeZone={obsCard.time_zone}
             onChange={dateString => updateObsCard( { date: dateString } )}
-            onSelection={
-              dateString => updateObsCard( { date: dateString, selected_date: dateString } )
-            }
           />
           <div
             className={`input-group${invalidDate ? " has-error" : ""}`}

--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -1187,43 +1187,33 @@ export function togglePlayFirstSound( ) {
   };
 }
 
-export function toggleAnnotations( ) {
+export function addProjects( ) {
   return ( dispatch, getState ) => {
     const s = getState( );
     const { config } = s;
     if ( !s.currentObservation.observation || s.currentObservation.tab !== "annotations" ) {
       return;
     }
-    dispatch( updateSession( {
-      prefers_hide_identify_annotations: !config.currentUser.prefers_hide_identify_annotations
-    } ) );
+    if ( config.currentUser.prefers_hide_identify_projects ) {
+      dispatch( updateSession( {
+        prefers_hide_identify_projects: false
+      } ) );
+    }
   };
 }
 
-
-export function toggleProjects( ) {
+export function addObservationFields( ) {
   return ( dispatch, getState ) => {
     const s = getState( );
     const { config } = s;
     if ( !s.currentObservation.observation || s.currentObservation.tab !== "annotations" ) {
       return;
     }
-    dispatch( updateSession( {
-      prefers_hide_identify_projects: !config.currentUser.prefers_hide_identify_projects
-    } ) );
-  };
-}
-
-export function toggleObservationFields( ) {
-  return ( dispatch, getState ) => {
-    const s = getState( );
-    const { config } = s;
-    if ( !s.currentObservation.observation || s.currentObservation.tab !== "annotations" ) {
-      return;
+    if ( config.currentUser.prefers_hide_identify_observation_fields ) {
+      dispatch( updateSession( {
+        prefers_hide_identify_observation_fields: false
+      } ) );
     }
-    dispatch( updateSession( {
-      prefers_hide_identify_observation_fields: !config.currentUser.prefers_hide_identify_observation_fields
-    } ) );
   };
 }
 

--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -30,6 +30,7 @@ import {
   updateObservationFieldValue as sharedUpdateObservationFieldValue,
   removeObservationFieldValue as sharedRemoveObservationFieldValue
 } from "../../shared/ducks/observation";
+import { updateSession } from "../../show/ducks/users";
 
 const SHOW_CURRENT_OBSERVATION = "show_current_observation";
 const HIDE_CURRENT_OBSERVATION = "hide_current_observation";
@@ -618,6 +619,9 @@ export function addAnnotation( controlledAttribute, controlledValue ) {
       user: state.config.currentUser,
       api_status: "saving"
     }] );
+    dispatch( updateSession( {
+      prefers_hide_identify_annotations: false
+    } ) );
     dispatch( updateCurrentObservation( { annotations: newAnnotations } ) );
 
     const payload = {
@@ -1180,6 +1184,46 @@ export function togglePlayFirstSound( ) {
     } else {
       player.pause( );
     }
+  };
+}
+
+export function toggleAnnotations( ) {
+  return ( dispatch, getState ) => {
+    const s = getState( );
+    const { config } = s;
+    if ( !s.currentObservation.observation || s.currentObservation.tab !== "annotations" ) {
+      return;
+    }
+    dispatch( updateSession( {
+      prefers_hide_identify_annotations: !config.currentUser.prefers_hide_identify_annotations
+    } ) );
+  };
+}
+
+
+export function toggleProjects( ) {
+  return ( dispatch, getState ) => {
+    const s = getState( );
+    const { config } = s;
+    if ( !s.currentObservation.observation || s.currentObservation.tab !== "annotations" ) {
+      return;
+    }
+    dispatch( updateSession( {
+      prefers_hide_identify_projects: !config.currentUser.prefers_hide_identify_projects
+    } ) );
+  };
+}
+
+export function toggleObservationFields( ) {
+  return ( dispatch, getState ) => {
+    const s = getState( );
+    const { config } = s;
+    if ( !s.currentObservation.observation || s.currentObservation.tab !== "annotations" ) {
+      return;
+    }
+    dispatch( updateSession( {
+      prefers_hide_identify_observation_fields: !config.currentUser.prefers_hide_identify_observation_fields
+    } ) );
   };
 }
 

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -101,6 +101,20 @@ class ObservationModal extends React.Component {
     }
   }
 
+  defaultKeyboardShortcut( shortcut ) {
+    return (
+      <tr
+        className="keyboard-shortcuts"
+        key={`keyboard-shortcuts-${shortcut.keys.join( "-" )}`}
+      >
+        <td>
+          <span dangerouslySetInnerHTML={{ __html: shortcut.keys.map( k => `<kbd>${k}</kbd>` ).join( " + " ) }} />
+        </td>
+        <td>{ shortcut.label }</td>
+      </tr>
+    );
+  }
+
   render( ) {
     const {
       addComment,
@@ -405,17 +419,7 @@ class ObservationModal extends React.Component {
       <tbody>
         {
           defaultShortcuts.map( shortcut => (
-            blind && shortcut.skipBlind ? null : (
-              <tr
-                className="keyboard-shortcuts"
-                key={`keyboard-shortcuts-${shortcut.keys.join( "-" )}`}
-              >
-                <td>
-                  <span dangerouslySetInnerHTML={{ __html: shortcut.keys.map( k => `<kbd>${k}</kbd>` ).join( " + " ) }} />
-                </td>
-                <td>{ shortcut.label }</td>
-              </tr>
-            )
+            blind && shortcut.skipBlind ? null : this.defaultKeyboardShortcut( shortcut )
           ) )
         }
       </tbody>
@@ -454,6 +458,14 @@ class ObservationModal extends React.Component {
           }
         } );
       } );
+      annoShortcuts.push( {
+        keys: ["SHIFT", "P"],
+        label: I18n.t( "add_to_project" )
+      } );
+      annoShortcuts.push( {
+        keys: ["SHIFT", "F"],
+        label: I18n.t( "add_observation_fields" )
+      } );
     }
 
     const country = _.find( observation.places || [], p => p.admin_level === 0 );
@@ -463,7 +475,8 @@ class ObservationModal extends React.Component {
         dateTimeObserved = moment( observation.observed_on ).format( I18n.t( "momentjs.month_year" ) );
       } else if ( observation.time_observed_at ) {
         dateTimeObserved = formattedDateTimeInTimeZone(
-          observation.time_observed_at, observation.observed_time_zone
+          observation.time_observed_at,
+          observation.observed_time_zone
         );
       } else {
         dateTimeObserved = moment( observation.observed_on ).format( "LL" );
@@ -548,6 +561,9 @@ class ObservationModal extends React.Component {
                                   <tbody>
                                     {
                                       annoShortcuts.map( shortcut => {
+                                        if ( shortcut.label && !shortcut.attributeLabel ) {
+                                          return this.defaultKeyboardShortcut( shortcut );
+                                        }
                                         // If you add more controlled terms, you'll need to
                                         // add keys like
                                         // add_plant_phenology_flowering_annotation to

--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -843,11 +843,8 @@ class ObservationModal extends React.Component {
               ) }
               { activeTabs.indexOf( "annotations" ) < 0 ? null : (
                 <div className={`inat-tab annotations-tab ${activeTab === "annotations" ? "active" : ""}`} tabIndex="-1">
-                  <div className="column-header">{ I18n.t( "annotations" ) }</div>
                   <AnnotationsContainer />
-                  <div className="column-header">{ I18n.t( "projects" ) }</div>
                   <ProjectsContainer />
-                  <div className="column-header">{ I18n.t( "observation_fields" ) }</div>
                   <ObservationFieldsContainer />
                 </div>
               ) }

--- a/app/webpack/observations/identify/containers/annotations_container.js
+++ b/app/webpack/observations/identify/containers/annotations_container.js
@@ -13,7 +13,7 @@ function mapStateToProps( state ) {
     observation: state.currentObservation.observation,
     config: state.config,
     controlledTerms: state.controlledTerms.allTerms,
-    collapsible: false
+    context: "identify"
   };
 }
 

--- a/app/webpack/observations/identify/containers/observation_fields_container.js
+++ b/app/webpack/observations/identify/containers/observation_fields_container.js
@@ -11,8 +11,8 @@ function mapStateToProps( state ) {
   return {
     observation: state.currentObservation.observation,
     config: state.config,
-    collapsible: false,
-    placeholder: I18n.t( "add_a_field" )
+    placeholder: I18n.t( "add_a_field" ),
+    context: "identify"
   };
 }
 

--- a/app/webpack/observations/identify/containers/projects_container.js
+++ b/app/webpack/observations/identify/containers/projects_container.js
@@ -15,8 +15,8 @@ function mapStateToProps( state ) {
   return {
     observation: state.currentObservation.observation,
     config: state.config,
-    collapsible: false,
-    placeholder: I18n.t( "add_a_field" )
+    placeholder: I18n.t( "add_a_field" ),
+    context: "identify"
   };
 }
 

--- a/app/webpack/observations/identify/keyboard_shortcuts.js
+++ b/app/webpack/observations/identify/keyboard_shortcuts.js
@@ -17,9 +17,8 @@ import {
   showPrevTab,
   showNextTab,
   toggleKeyboardShortcuts,
-  toggleAnnotations,
-  toggleProjects,
-  toggleObservationFields
+  addProjects,
+  addObservationFields
 } from "./actions";
 import { increaseBrightness, decreaseBrightness } from "./ducks/brightnesses";
 
@@ -216,9 +215,8 @@ const setupKeyboardShortcuts = dispatch => {
   bindShortcut( "shift+right", showNextTab, dispatch );
   bindShortcut( ["command+up", "alt+up"], increaseBrightness, dispatch );
   bindShortcut( ["command+down", "alt+down"], decreaseBrightness, dispatch );
-  bindShortcut( "shift+a", toggleAnnotations, dispatch );
-  bindShortcut( "shift+p", toggleProjects, dispatch, { callback: focusProjects } );
-  bindShortcut( "shift+f", toggleObservationFields, dispatch, { callback: focusObservationFields } );
+  bindShortcut( "shift+p", addProjects, dispatch, { callback: focusProjects } );
+  bindShortcut( "shift+f", addObservationFields, dispatch, { callback: focusObservationFields } );
   _.forEach( annotationShortcuts, as => {
     bind( as.shortcut, ( ) => {
       dispatch( addAnnotationFromKeyboard( as.term, as.value ) );

--- a/app/webpack/observations/identify/keyboard_shortcuts.js
+++ b/app/webpack/observations/identify/keyboard_shortcuts.js
@@ -16,7 +16,10 @@ import {
   showNextPhoto,
   showPrevTab,
   showNextTab,
-  toggleKeyboardShortcuts
+  toggleKeyboardShortcuts,
+  toggleAnnotations,
+  toggleProjects,
+  toggleObservationFields
 } from "./actions";
 import { increaseBrightness, decreaseBrightness } from "./ducks/brightnesses";
 
@@ -176,6 +179,26 @@ const focusCommentIDInput = ( ) => {
     .focus( );
 };
 
+const focusProjects = ( ) => {
+  setTimeout( ( ) => {
+    $( ".Projects .panel-collapse" )
+      .not( "[aria-expanded=false]" )
+      .find( ".ac-chooser input" )
+      .first( )
+      .focus( );
+  }, 200 );
+};
+
+const focusObservationFields = ( ) => {
+  setTimeout( ( ) => {
+    $( ".ObservationFields .panel-collapse" )
+      .not( "[aria-expanded=false]" )
+      .find( ".ac-chooser input" )
+      .first( )
+      .focus( );
+  }, 200 );
+};
+
 const setupKeyboardShortcuts = dispatch => {
   bindShortcut( "right", showNextObservation, dispatch, { eventType: "keyup" } );
   bindShortcut( "left", showPrevObservation, dispatch, { eventType: "keyup" } );
@@ -193,6 +216,9 @@ const setupKeyboardShortcuts = dispatch => {
   bindShortcut( "shift+right", showNextTab, dispatch );
   bindShortcut( ["command+up", "alt+up"], increaseBrightness, dispatch );
   bindShortcut( ["command+down", "alt+down"], decreaseBrightness, dispatch );
+  bindShortcut( "shift+a", toggleAnnotations, dispatch );
+  bindShortcut( "shift+p", toggleProjects, dispatch, { callback: focusProjects } );
+  bindShortcut( "shift+f", toggleObservationFields, dispatch, { callback: focusObservationFields } );
   _.forEach( annotationShortcuts, as => {
     bind( as.shortcut, ( ) => {
       dispatch( addAnnotationFromKeyboard( as.term, as.value ) );

--- a/app/webpack/observations/show/components/observation_field_input.jsx
+++ b/app/webpack/observations/show/components/observation_field_input.jsx
@@ -269,13 +269,6 @@ class ObservationFieldInput extends React.Component {
             this.setState( { observationFieldValue: dateString } );
             this.onChangeHandler( dateString );
           }}
-          onSelection={dateString => {
-            this.setState( {
-              observationFieldValue: dateString,
-              observationFieldSelectedDate: dateString
-            } );
-            this.onChangeHandler( dateString );
-          }}
         />
         <input
           type="text"

--- a/app/webpack/observations/show/components/observation_fields.jsx
+++ b/app/webpack/observations/show/components/observation_fields.jsx
@@ -8,7 +8,7 @@ import ObservationFieldInput from "./observation_field_input";
 class ObservationFields extends React.Component {
   constructor( props ) {
     super( props );
-    const { config, observation } = props;
+    const { config, observation, context } = props;
     this.observerPrefersFieldsBy = (
       observation.user
       && observation.user.preferences
@@ -17,10 +17,25 @@ class ObservationFields extends React.Component {
       ? observation.user.preferences.prefers_observation_fields_by
       : "anyone";
     const currentUser = config && config.currentUser;
+    this.collapsePreference = `prefers_hide_${context}_observation_fields`;
     this.state = {
-      open: currentUser ? !currentUser.prefers_hide_obs_show_observation_fields : true,
+      open: currentUser ? !currentUser[this.collapsePreference] : true,
       editingFieldValue: null
     };
+  }
+
+  componentDidUpdate( prevProps, prevState ) {
+    if ( prevState.open === this.state.open ) {
+      this.setOpenStateOnConfigUpdate( );
+    }
+  }
+
+  setOpenStateOnConfigUpdate( ) {
+    const { config } = this.props;
+    if ( config.currentUser
+      && config.currentUser[this.collapsePreference] === this.state.open ) {
+      this.setState( { open: !config.currentUser[this.collapsePreference] } );
+    }
   }
 
   render( ) {
@@ -30,7 +45,6 @@ class ObservationFields extends React.Component {
       addObservationFieldValue,
       removeObservationFieldValue,
       updateObservationFieldValue,
-      collapsible,
       updateSession
     } = this.props;
     const {
@@ -120,14 +134,6 @@ class ObservationFields extends React.Component {
       </div>
     );
 
-    if ( !collapsible ) {
-      return (
-        <div className="ObservationFields">
-          { panelContent }
-        </div>
-      );
-    }
-
     const count = sortedFieldValues.length > 0 ? `(${sortedFieldValues.length})` : "";
     return (
       <div className="ObservationFields collapsible-section">
@@ -136,7 +142,7 @@ class ObservationFields extends React.Component {
           onClick={( ) => {
             if ( loggedIn ) {
               updateSession( {
-                prefers_hide_obs_show_observation_fields: open
+                [this.collapsePreference]: open
               } );
             }
             this.setState( { open: !open } );
@@ -147,7 +153,7 @@ class ObservationFields extends React.Component {
           { " " }
           { count }
         </h4>
-        <Panel expanded={open} onToggle={() => {}}>
+        <Panel id="observation-fields-panel" expanded={open} onToggle={() => {}}>
           <Panel.Collapse>{ panelContent }</Panel.Collapse>
         </Panel>
       </div>
@@ -162,11 +168,11 @@ ObservationFields.propTypes = {
   removeObservationFieldValue: PropTypes.func,
   updateObservationFieldValue: PropTypes.func,
   updateSession: PropTypes.func,
-  collapsible: PropTypes.bool
+  context: PropTypes.string
 };
 
 ObservationFields.defaultProps = {
-  collapsible: true
+  context: "obs_show"
 };
 
 export default ObservationFields;

--- a/app/webpack/observations/show/components/projects.jsx
+++ b/app/webpack/observations/show/components/projects.jsx
@@ -15,9 +15,11 @@ class Projects extends React.Component {
 
   constructor( props ) {
     super( props );
+    const { context } = props;
     const currentUser = props.config && props.config.currentUser;
+    this.collapsePreference = `prefers_hide_${context}_projects`;
     this.state = {
-      open: currentUser ? !currentUser.prefers_hide_obs_show_projects : true
+      open: currentUser ? !currentUser[this.collapsePreference] : true
     };
     this.setUpProjectAutocomplete = this.setUpProjectAutocomplete.bind( this );
   }
@@ -26,8 +28,19 @@ class Projects extends React.Component {
     this.setUpProjectAutocomplete( );
   }
 
-  componentDidUpdate( ) {
+  componentDidUpdate( prevProps, prevState ) {
     this.setUpProjectAutocomplete( );
+    if ( prevState.open === this.state.open ) {
+      this.setOpenStateOnConfigUpdate( );
+    }
+  }
+
+  setOpenStateOnConfigUpdate( ) {
+    const { config } = this.props;
+    if ( config.currentUser
+      && config.currentUser[this.collapsePreference] === this.state.open ) {
+      this.setState( { open: !config.currentUser[this.collapsePreference] } );
+    }
   }
 
   setUpProjectAutocomplete( ) {
@@ -66,7 +79,6 @@ class Projects extends React.Component {
     const {
       observation,
       config,
-      collapsible,
       updateSession
     } = this.props;
     const { open } = this.state;
@@ -138,13 +150,6 @@ class Projects extends React.Component {
         ) ) }
       </div>
     );
-    if ( !collapsible ) {
-      return (
-        <div className="Projects">
-          { panelContent }
-        </div>
-      );
-    }
 
     const count = projectsOrProjObs.length > 0
       ? `(${projectsOrProjObs.length})`
@@ -155,7 +160,7 @@ class Projects extends React.Component {
           className="collapsible"
           onClick={( ) => {
             if ( loggedIn ) {
-              updateSession( { prefers_hide_obs_show_projects: open } );
+              updateSession( { [this.collapsePreference]: open } );
             }
             this.setState( { open: !open } );
           }}
@@ -183,11 +188,11 @@ Projects.propTypes = {
   setErrorModalState: PropTypes.func,
   updateSession: PropTypes.func,
   showProjectFieldsModal: PropTypes.func,
-  collapsible: PropTypes.bool
+  context: PropTypes.string
 };
 
 Projects.defaultProps = {
-  collapsible: true
+  context: "obs_show"
 };
 
 export default Projects;

--- a/app/webpack/observations/show/ducks/users.js
+++ b/app/webpack/observations/show/ducks/users.js
@@ -21,18 +21,17 @@ export function setSubscriptions( subscriptions ) {
 
 export function updateSession( params ) {
   return ( dispatch, getState ) => {
-    const config = getState( ).config;
+    const { config } = getState( );
     if ( !config || !config.currentUser ) { return null; }
-    return inatjs.users.update_session( params ).then( ( ) => {
-      const updatedUser = Object.assign( { }, config.currentUser, params );
-      dispatch( setConfig( { currentUser: updatedUser } ) );
-    } ).catch( e => { } );
+    const updatedUser = Object.assign( { }, config.currentUser, params );
+    dispatch( setConfig( { currentUser: updatedUser } ) );
+    return inatjs.users.update_session( params ).catch( e => { } );
   };
 }
 
 export function leaveTestGroup( group ) {
   return ( dispatch, getState ) => {
-    const config = getState( ).config;
+    const { config } = getState( );
     if ( !config || !config.currentUser ) { return null; }
     const csrfParam = $( "meta[name=csrf-param]" ).attr( "content" );
     const csrfToken = $( "meta[name=csrf-token]" ).attr( "content" );

--- a/app/webpack/observations/uploader/components/date_time_field_wrapper.jsx
+++ b/app/webpack/observations/uploader/components/date_time_field_wrapper.jsx
@@ -86,7 +86,6 @@ class DateTimeFieldWrapper extends Component {
 DateTimeFieldWrapper.propTypes = {
   inputProps: PropTypes.object,
   onChange: PropTypes.func,
-  onSelection: PropTypes.func,
   reactKey: PropTypes.string,
   defaultText: PropTypes.string,
   mode: PropTypes.string,

--- a/app/webpack/observations/uploader/components/left_menu.jsx
+++ b/app/webpack/observations/uploader/components/left_menu.jsx
@@ -144,15 +144,16 @@ class LeftMenu extends SelectionBasedComponent {
         <DateTimeFieldWrapper
           ref="datetime"
           inputFormat={inputFormat}
-          key={`multidate${commonSelectedDate}`}
-          reactKey={`multidate${commonSelectedDate}`}
+          key={`multidate${commonSelectedDate ? "" : "empty"}`}
+          reactKey={`multidate${commonSelectedDate ? "" : "empty"}`}
           dateTime={commonSelectedDate
             ? moment( commonSelectedDate, inputFormat ).format( "x" )
             : undefined
           }
           onChange={
             dateString => updateSelectedObsCards( {
-              date: dateString
+              date: dateString,
+              selected_date: dateString
             } )
           }
         />

--- a/app/webpack/observations/uploader/components/left_menu.jsx
+++ b/app/webpack/observations/uploader/components/left_menu.jsx
@@ -155,12 +155,6 @@ class LeftMenu extends SelectionBasedComponent {
               date: dateString
             } )
           }
-          onSelection={
-            dateString => updateSelectedObsCards( {
-              date: dateString,
-              selected_date: dateString
-            } )
-          }
         />
         <div
           className={`input-group${invalidDate ? " has-error" : ""}`}

--- a/app/webpack/observations/uploader/components/obs_card_component.jsx
+++ b/app/webpack/observations/uploader/components/obs_card_component.jsx
@@ -325,20 +325,21 @@ class ObsCardComponent extends Component {
               config={config}
             />
             <DateTimeFieldWrapper
-              key={`datetime${obsCard.selected_date}`}
-              reactKey={`datetime${obsCard.selected_date}`}
+              key={`datetime${obsCard.selected_date ? "" : "empty"}`}
+              reactKey={`datetime${obsCard.selected_date ? "" : "empty"}`}
               ref="datetime"
               inputFormat={inputFormat}
-              dateTime={obsCard.selected_date
-                ? moment( obsCard.selected_date, inputFormat ).format( "x" )
-                : undefined
+              dateTime={
+                obsCard.selected_date
+                  ? moment( obsCard.selected_date, inputFormat ).format( "x" )
+                  : undefined
               }
-              onChange={dateString => updateObsCard( obsCard, { date: dateString } )}
-              onSelection={
-                dateString => updateObsCard(
-                  obsCard, { date: dateString, selected_date: dateString }
-                )
-              }
+              onChange={dateString => {
+                updateObsCard( obsCard, {
+                  date: dateString,
+                  selected_date: dateString
+                } );
+              }}
             />
             <div
               className={`input-group${dateValidationError ? " has-error" : ""}`}

--- a/app/webpack/observations/uploader/components/observation_fields_chooser.jsx
+++ b/app/webpack/observations/uploader/components/observation_fields_chooser.jsx
@@ -179,10 +179,6 @@ class LeftMenu extends SelectionBasedComponent {
             : undefined }
           onChange={ dateString =>
             this.props.setState( { observationFieldValue: dateString } ) }
-          onSelection={ dateString =>
-            this.props.setState( { observationFieldValue: dateString,
-              observationFieldSelectedDate: dateString } )
-          }
         />
         <input
           type="text"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -421,6 +421,7 @@ en:
   add_notes_about_this_taxon: Add notes about this taxon in this place, e.g. where and when it occurs.
   add_obs_from_a_link: "Add Obs from list: %{link}"
   add_obs_from_a_list: Add Obs from a List
+  add_observation_fields: Add Observation Fields
   add_observations: Add Observations
   add_observations_by_checking_off: Add observations by checking off species from a list.
   add_observations_project: Add Observations to This Project

--- a/package-lock.json
+++ b/package-lock.json
@@ -4388,8 +4388,8 @@
       }
     },
     "node_modules/inaturalistjs": {
-      "version": "2.8.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/inaturalistjs.git#1255de846c5a4d8089a8a7ea5f5fae861082078f",
+      "version": "2.10.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/inaturalistjs.git#9951a0507da318ba9d7f9464e465d9868d4101da",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",
@@ -10275,7 +10275,7 @@
       "dev": true
     },
     "inaturalistjs": {
-      "version": "git+ssh://git@github.com/inaturalist/inaturalistjs.git#1255de846c5a4d8089a8a7ea5f5fae861082078f",
+      "version": "git+ssh://git@github.com/inaturalist/inaturalistjs.git#9951a0507da318ba9d7f9464e465d9868d4101da",
       "from": "inaturalistjs@github:inaturalist/inaturalistjs",
       "requires": {
         "cross-fetch": "^3.1.5",


### PR DESCRIPTION
- Annotation sections on Identify can be collapsed, and the collapse preferences are separate from those on Observation show pages
- Adds keyboard shortcuts on Identify to open and focus on Projects and ObservationFields
- Keeps the list of ObservationFields offered by default Identify and ObsShow up-to-date with fields added while page is loaded
- Also fixes a bug with the datepicker on the upload page where it was not resetting the date to today when the date was deleted