### PR TITLE
inaturalist#3988: Add species rank for capitalizing name

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -760,7 +760,7 @@ class Taxon < ApplicationRecord
   def self.capitalize_scientific_name( name, rank )
     return name.capitalize if rank.blank?
 
-    if [GENUS, GENUSHYBRID].include?( rank ) && name =~ /^(x|×)\s+?(.+)/
+    if [GENUS, GENUSHYBRID, SPECIES].include?( rank ) && name =~ /^(x|×)\s+?(.+)/
       _full_name, x, genus_name = name.match( /^(x|×)\s+?(.+)/ ).to_a
       "#{x} #{genus_name.capitalize}"
     elsif [GENUS, GENUSHYBRID].include?( rank ) && name =~ /^\w+\s+(x|×)\s+\w+$/

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -108,6 +108,11 @@ describe Taxon, "creation" do
     expect( taxon.name ).to eq "× Chitalpa"
   end
 
+  it "should capitalize hybrid names for species rank" do
+    taxon = Taxon.make!( name: "× chitalpa", rank: Taxon::SPECIES )
+    expect( taxon.name ).to eq "× Chitalpa"
+  end
+
   it "should capitalize Foo x Bar style genushybrids correctly" do
     taxon = Taxon.make!( name: "foo × bar", rank: Taxon::GENUSHYBRID )
     expect( taxon.name ).to eq "Foo × Bar"


### PR DESCRIPTION
This fix is only solving the issue for the species rank. I don't have enough knowledge to know if this kind of situation can happen on other rank.

If it can then it would be better to improve the `capitalize_scientific_name` method in `Taxon` model.

I could work on it if needed.

Also after deploying this PR, every taxon that was created before it the should be forced capitalized and reindexed. 
Something like this can be enough, just need to manage the case where `×` is used with a real `x` 

```
Taxon.where("name LIKE '%×%'").each(&:save)
```

I don't know if I have to do a script, a task or a migration for it.