### PR TITLE
Ancestor disagreement change

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1837,6 +1837,9 @@ class Observation < ApplicationRecord
           if (
             i.disagreement? &&
             i.previous_observation_taxon &&
+            # if all ids with the previous_observation_taxon have been withdrawn, treat
+            # the ancestor id as a non-disagreement
+            ( working_idents.map( &:taxon_id ).include? i.previous_observation_taxon.id ) &&
             ( base_index = i.previous_observation_taxon.ancestor_ids.index( i.taxon_id ) )
           )
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1837,9 +1837,9 @@ class Observation < ApplicationRecord
           if (
             i.disagreement? &&
             i.previous_observation_taxon &&
-            # if all ids with the previous_observation_taxon have been withdrawn, treat
+            # if all ids of/descending from previous_observation_taxon have been withdrawn, treat
             # the ancestor id as a non-disagreement
-            ( working_idents.map( &:taxon_id ).include? i.previous_observation_taxon.id ) &&
+            working_idents.any? {| j | j.taxon.self_and_ancestor_ids.include?( i.previous_observation_taxon.id ) } &&
             ( base_index = i.previous_observation_taxon.ancestor_ids.index( i.taxon_id ) )
           )
 


### PR DESCRIPTION
Addresses this issue
https://github.com/inaturalist/inaturalist/issues/4018
which was discussed with the community here 
https://www.inaturalist.org/posts/25514-clarifying-ancestor-disagreements#activity_comment_29df9130-3fa0-49bb-84c3-d6666ca08b05

It is a minor tweak to how the Community Taxon is calculated that treats Ancestor Disagreements as Ancestor Non-Disagreements when the taxon being disagreed to (previous_observation_taxon) is no longer represented in IDs or as the ancestor of IDs (because they were withdrawn or deleted)