### PR TITLE
Detect iNatRN requests, make responses headless and responsive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,9 @@ Metrics/PerceivedComplexity:
 Naming/AccessorMethodName:
   Enabled: false
 
+Naming/PredicateName:
+  Enabled: false
+
 Naming/VariableNumber:
   Enabled: false
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -608,9 +608,11 @@ class ApplicationController < ActionController::Base
   end
 
   def remove_header_and_footer_for_apps
-    return true unless is_android_app? || is_iphone_app?
+    return true unless is_android_app? || is_iphone_app? || is_inatrn_app?
+
     @headless = true
     @footless = true
+    @responsive = true if is_inatrn_app?
     true
   end
   

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -22,6 +22,21 @@
     <!-- Bootstrap -->
     <%= stylesheet_link_tag 'bootstrap_bundle' %>
     <%= stylesheet_link_tag 'bootstrap-rtl' if @rtl %>
+    <% # Bump font size so Safari doesn't auto-zoom on input selection. %>
+    <% if is_inatrn_app? %>
+      <style type="text/css">
+        body,
+        .bootstrap,
+        .bootstrap .form-control {
+          font-size: 16px;
+        }
+      </style>
+    <% end -%>
+    <% if params[:noh1] %>
+      <style type="text/css">
+        h1 { display: none; }
+      </style>
+    <% end -%>
     <%= csrf_meta_tag %>
     <meta name="config:inaturalist_api_url" content="<%= CONFIG.public_node_api_url || CONFIG.node_api_url %>">
     <% if logged_in? -%>

--- a/lib/ambidextrous.rb
+++ b/lib/ambidextrous.rb
@@ -53,7 +53,7 @@ module Ambidextrous
   def is_mobile_app?
     return false if is_inaturalistjs_request?
 
-    is_android_app? || is_iphone_app? || inatrn_app?
+    is_android_app? || is_iphone_app? || is_inatrn_app?
   end
 
   # haml agreesively removes whitespace in ugly mode. This forces it to look the way you meant it to look

--- a/lib/ambidextrous.rb
+++ b/lib/ambidextrous.rb
@@ -4,6 +4,7 @@ module Ambidextrous
   IPHONE_APP_USER_AGENT_PATTERN = /#{IPHONE_APP_USER_AGENT_PATTERN_1}|#{IPHONE_APP_USER_AGENT_PATTERN_2}/
   IPHONE_APP_USER_AGENT_PATTERNS = [IPHONE_APP_USER_AGENT_PATTERN, IPHONE_APP_USER_AGENT_PATTERN_2]
   ANDROID_APP_USER_AGENT_PATTERN = /^iNaturalist\/\d+.+Android/i
+  INATRN_APP_USER_AGENT_PATTERN = /^iNaturalistRN/
   MOBILE_APP_USER_AGENT_PATTERNS = [IPHONE_APP_USER_AGENT_PATTERNS, ANDROID_APP_USER_AGENT_PATTERN].flatten
 
   FISHTAGGER_APP_USER_AGENT_PATTERN = /fishtagger/i
@@ -31,21 +32,28 @@ module Ambidextrous
     return false if is_inaturalistjs_request?
     !(request.user_agent =~ ANDROID_APP_USER_AGENT_PATTERN).nil?
   end
-  
+
   def is_iphone_app?
     return false if is_inaturalistjs_request?
     !(request.user_agent =~ IPHONE_APP_USER_AGENT_PATTERN).nil? ||
       !(request.user_agent =~ IPHONE_APP_USER_AGENT_PATTERN_2).nil?
   end
-  
+
   def is_iphone_app_2?
     return false if is_inaturalistjs_request?
     !(request.user_agent =~ IPHONE_APP_USER_AGENT_PATTERN_2).nil?
   end
-  
+
+  def is_inatrn_app?
+    return false if is_inaturalistjs_request?
+
+    !( request.user_agent =~ INATRN_APP_USER_AGENT_PATTERN ).nil?
+  end
+
   def is_mobile_app?
     return false if is_inaturalistjs_request?
-    is_android_app? || is_iphone_app?
+
+    is_android_app? || is_iphone_app? || inatrn_app?
   end
 
   # haml agreesively removes whitespace in ugly mode. This forces it to look the way you meant it to look


### PR DESCRIPTION
This makes a few changes to accommodate the embedded webview showing account settings in the iNatRN app. Some of the assumptions here may not prove to be tenable.

- Removes header and footer for iNatRN requests
- Sets mobile viewport for iNatRN requests for the entire site... even though the entire site is not genuinely responsive
- Bumps up the font size for bootstrap layouts to prevent Safari from auto-zooming in on form inputs that it deems to have inaccessibly small font sizes
- Adds a `noh1` param to remove titles from pages that the requester may already handle, e.g. w/ a nav header in a mobile app

These are all a bit hacky, but they work for now.