### PR TITLE
417 last ip

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -27,6 +27,8 @@ module Logstasher
 
   def self.ip_from_request_env( request_env )
     # try a few params for IP. Proxies will shuffle around requester IP
+    # we use first HTTP_X_FORWARDED_ORIGINAL_FOR which is set by our nginx proxy
+    # with the real client IP, in "client browser --> node --> rails" scenario
     %w(HTTP_X_FORWARDED_ORIGINAL_FOR HTTP_X_FORWARDED_FOR HTTP_X_CLUSTER_CLIENT_IP REMOTE_ADDR).each do | param |
       return request_env[param] unless request_env[param].blank?
     end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -9,12 +9,13 @@ module Logstasher
     "HTTP_X_FORWARDED_FOR", "HTTP_X_FORWARDED_PROTO", "ORIGINAL_FULLPATH",
     "HTTP_ACCEPT_LANGUAGE", "HTTP_REFERER", "REMOTE_ADDR", "REQUEST_METHOD",
     "SERVER_ADDR", "CONTENT_LENGTH", "HTTP_ORIGIN", "HTTP_AUTHORIZATION",
-    "HTTP_SSLSESSIONID", "X_MOBILE_DEVICE", "HTTP_X_COUNTRY_CODE", "HTTP_DNT"
+    "HTTP_SSLSESSIONID", "X_MOBILE_DEVICE", "HTTP_X_COUNTRY_CODE", "HTTP_DNT",
+    "HTTP_X_FORWARDED_ORIGINAL_FOR"
   ].freeze
 
   IP_PARAMS = [
     "HTTP_X_CLUSTER_CLIENT_IP", "HTTP_X_FORWARDED_FOR", "REMOTE_ADDR",
-    "SERVER_ADDR", "clientip"
+    "SERVER_ADDR", "clientip", "HTTP_X_FORWARDED_ORIGINAL_FOR"
   ].freeze
 
   def self.logger
@@ -26,7 +27,7 @@ module Logstasher
 
   def self.ip_from_request_env( request_env )
     # try a few params for IP. Proxies will shuffle around requester IP
-    %w(HTTP_X_FORWARDED_FOR HTTP_X_CLUSTER_CLIENT_IP REMOTE_ADDR).each do | param |
+    %w(HTTP_X_FORWARDED_ORIGINAL_FOR HTTP_X_FORWARDED_FOR HTTP_X_CLUSTER_CLIENT_IP REMOTE_ADDR).each do | param |
       return request_env[param] unless request_env[param].blank?
     end
     nil


### PR DESCRIPTION
Regarding this issue: https://github.com/inaturalist/iNaturalistAPI/issues/417

When the client browser is calling NodeJs which is then calling Rails (ex: /v1/annotations), the client IP is lost, replaced by the NodeJs internal IP (10.0.0.x). This is visible in the last_ip column and in the clientip field in Kibana logs.

NodeJs app is correctly setting the initial client IP when calling Rails, in the `x-forwarded-for` header:

https://github.com/inaturalist/iNaturalistAPI/blob/main/lib/inaturalist_api.js#L712
https://github.com/inaturalist/iNaturalistAPI/blob/main/lib/inaturalist_api.js#L725
==> options.remote_ip

https://github.com/inaturalist/inaturalistjs/blob/9951a0507da318ba9d7f9464e465d9868d4101da/lib/inaturalist_api.js#L146
==> headers["x-forwarded-for"]

Then, our Rails nginx proxy is passing this value into `X-Forwarded-Original-For`:
`proxy_set_header X-Forwarded-Original-For $http_x_forwarded_for;`

That's why, the solution, in `logstasher.rb` was to check first the header `X-Forwarded-Original-For`

According to my tests on smilax, it's solving both database last_ip and kibana clientip logs, in the /v1/annotations scenario.