### PR TITLE
Wrong value for logged_in field in Rails logs

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -83,6 +83,8 @@ module Logstasher
     if hash.key?( :request )
       if hash[:request].is_a?( ActionDispatch::Request )
         hash.merge!( Logstasher.payload_from_request( hash[:request] ) )
+        # set default value to logged_in if no value was set
+        hash[:logged_in] = false if hash[:logged_in].nil?
       end
       hash.delete( :request )
     end
@@ -99,8 +101,6 @@ module Logstasher
       end
       hash.delete( :user )
     end
-    # set default value to logged_in if no value was set
-    hash[:logged_in] = false if hash[:logged_in].nil?
     hash
   end
 

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -55,8 +55,6 @@ module Logstasher
     payload[:x_via] = request.headers["X-Via"]
     payload[:ssl] = request.ssl?.to_s
     payload[:bot] = Logstasher.user_agent_a_bot?( request.user_agent )
-    # this can be overwritten by merging Logstasher.payload_from_user
-    payload[:logged_in] = false
     payload[:i18n_locale] = I18n.locale.to_s.downcase
     payload[:http_locale_matches_i18n] = payload[:i18n_locale] == payload[:http_languages]
     payload[:http_lang_matches_i18n] = payload[:i18n_locale] &&
@@ -101,6 +99,8 @@ module Logstasher
       end
       hash.delete( :user )
     end
+    # set default value to logged_in if no value was set
+    hash[:logged_in] = false if hash[:logged_in].nil?
     hash
   end
 


### PR DESCRIPTION
I removed this initialization to false in `payload_from_request`, because otherwise it overwrites the setting done here: https://github.com/inaturalist/inaturalist/blob/main/app/controllers/application_controller.rb#L787 