### PR TITLE
Add find_in_batches_in_subsets method

### DIFF
--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -354,7 +354,8 @@ class TaxonChange < ApplicationRecord
     #     page += 1
     #   end
     elsif reflection.klass == Identification
-      Identification.where( taxon_id: input_taxon_ids, current: true ).find_in_batches do |batch|
+      Identification.where( taxon_id: input_taxon_ids, current: true ).
+        find_in_batches_in_subsets do |batch|
         yield batch
       end
     elsif reflection.klass == ObservationFieldValue

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -299,7 +299,7 @@ class TaxonChange < ApplicationRecord
         ],
         user: [:stored_preferences]
       } ).
-      find_in_batches( batch_size: 100 ) do | batch |
+      find_in_batches_in_subsets( batch_size: 100 ) do | batch |
       batch.each do | observation |
         observation.set_community_taxon
         if observation.changed?

--- a/config/initializers/find_in_batches_in_subsets.rb
+++ b/config/initializers/find_in_batches_in_subsets.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # this wrapper method around `find_in_batches` accepts the same parameters
+  # and block, and ultimately calls `find_in_batches` with them. For models that
+  # have a single primary key named `id` with ruby type `:integer`, this method
+  # will first split the query into smaller chunks based on ID range, and run
+  # the `find_in_batches` query against each chunk separately. This can be more
+  # performant when the main query involves very large tables with very large
+  # indices, or when the main query is otherwise inefficient
+  class Relation
+    def find_in_batches_in_subsets( **args, &block )
+      if klass.primary_key != "id" || klass.columns_hash["id"]&.type != :integer
+        raise "Models cannot use `find_in_batches_in_subsets` unless they have an integer `id` primary_key"
+      end
+
+      maximum_id = klass.maximum( :id )
+      unless maximum_id
+        find_in_batches( **args, &block )
+        return
+      end
+
+      chunk_start_id = 1
+      search_chunk_size = 200_000
+      while chunk_start_id <= maximum_id
+        where( "id >= ?", chunk_start_id ).
+          where( "id < ?", chunk_start_id + search_chunk_size ).
+          find_in_batches( **args, &block )
+        chunk_start_id += search_chunk_size
+      end
+    end
+  end
+end

--- a/spec/initializers/find_in_batches_in_subsets.rb
+++ b/spec/initializers/find_in_batches_in_subsets.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ActiveRecord::Relation" do
+  describe "find_in_batches_in_subsets" do
+    it "raises an error on models without and integer id primary key" do
+      expect do
+        ObservationsPlace.where( "id > 0" ).find_in_batches_in_subsets {| _batch | next }
+      end.to raise_error(
+        "Models cannot use `find_in_batches_in_subsets` unless they have an integer `id` primary_key"
+      )
+    end
+
+    it "loops through all results of the query" do
+      obs1 = Observation.make!( id: 1 )
+      obs2 = Observation.make!( id: 10_000_100 )
+      ids_returned = []
+      Observation.where( "id > 0" ).find_in_batches_in_subsets do | batch |
+        ids_returned += batch.map( &:id )
+      end
+      expect( ids_returned ).to include( obs1.id )
+      expect( ids_returned ).to include( obs2.id )
+    end
+
+    it "properly passes on query clauses" do
+      obs1 = Observation.make!( id: 1 )
+      obs2 = Observation.make!( id: 10_000_100 )
+      ids_returned = []
+      Observation.where( "id = ?", obs2.id ).find_in_batches_in_subsets do | batch |
+        ids_returned += batch.map( &:id )
+      end
+      expect( ids_returned ).not_to include( obs1.id )
+      expect( ids_returned ).to include( obs2.id )
+    end
+
+    it "properly passes on preloading includes" do
+      Observation.make!( id: 1 )
+      Observation.make!( id: 10_000_100 )
+      ids_returned = []
+      Observation.includes( :user ).where( "id > 0" ).find_in_batches_in_subsets do | batch |
+        batch.each do | obs |
+          ids_returned << obs.id
+          expect( obs.association( :user ).loaded? ).to be true
+        end
+      end
+      expect( ids_returned.length ).to eq 2
+
+      ids_returned = []
+      Observation.where( "id > 0" ).find_in_batches_in_subsets do | batch |
+        batch.each do | obs |
+          ids_returned << obs.id
+          expect( obs.association( :user ).loaded? ).to be false
+        end
+      end
+      expect( ids_returned.length ).to eq 2
+    end
+
+    it "makes multiple calls to find_in_batches" do
+      Observation.make!( id: 1 )
+      Observation.make!( id: 10_000_100 )
+      call_count = 0
+      allow_any_instance_of( ActiveRecord::Relation ).to receive( :find_in_batches ) do
+        call_count += 1
+      end
+      Observation.where( "id > 0" ).find_in_batches_in_subsets {| _batch | next }
+      expect( call_count ).to eq 51
+    end
+  end
+end


### PR DESCRIPTION
Adds a find_in_batches_in_subsets wrapper method that limits query scope. This method is a wrapper of `find_in_batches`. It adds query clauses to search in a 200k ID range at one time, resulting in more efficient querying for _some_ queries on some very large tables