### PR TITLE
Allow `week` to be passed as a search param for `/observations`

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -2140,6 +2140,7 @@ class ObservationsController < ApplicationController
     @observed_on = search_params[:observed_on]
     @observed_on_year = search_params[:observed_on_year]
     @observed_on_month = [ search_params[:observed_on_month] ].flatten.first
+    @observed_on_week = search_params[:observed_on_week]
     @observed_on_day = search_params[:observed_on_day]
     @ofv_params = search_params[:ofv_params]
     @site_uri = params[:site] unless params[:site].blank?

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -619,6 +619,7 @@ class Observation < ApplicationRecord
     # params to search based on value
     [ { http_param: :rank, es_field: "taxon.rank" },
       { http_param: :observed_on_day, es_field: "observed_on_details.day" },
+      { http_param: :observed_on_week, es_field: "observed_on_details.week" },
       { http_param: :observed_on_month, es_field: "observed_on_details.month" },
       { http_param: :observed_on_year, es_field: "observed_on_details.year" },
       { http_param: :day, es_field: "observed_on_details.day" },

--- a/lib/observation_search.rb
+++ b/lib/observation_search.rb
@@ -353,6 +353,7 @@ module ObservationSearch
       end
       p[:observed_on_year] ||= p[:year].to_i unless p[:year].blank?
       p[:observed_on_month] ||= p[:month].to_i unless p[:month].blank? || p[:month].is_a?(Array)
+      p[:observed_on_week] ||= p[:week].to_i unless p[:week].blank?
       p[:observed_on_day] ||= p[:day].to_i unless p[:day].blank?
 
       # observation fields


### PR DESCRIPTION
Akin to the other date filtering parameters (`observed_on`, `year`, `month`, and `day`), this rounds out these options with the `week` option which is already part of the ES observation index.

The use case for this is for <https://naturalists.nyc/>, where we have a eBird-esque bar visual that shows observation frequency for that week, as seen here:

<img width="340" alt="Screenshot 2024-03-19 at 2 22 11 PM" src="https://github.com/inaturalist/inaturalist/assets/416575/261e4463-2c64-4cde-b36c-90f424a88486">

What we'd like is the ability to have each bar link to the iNaturalist observation page for the corresponding week across all years.

Thank you for your consideration!
