### PR TITLE
consistency: :pencil2:  update german translation "Menschen auf iNaturalist" title to match link text

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4964,7 +4964,7 @@ de:
   the_name_of_the_taxon_dashes: Der Name des Taxons, Leerzeichen durch Bindestriche ersetzt.
   the_name_of_the_taxon_underscores: Der Name des Taxons, Leerzeichen durch Unterstriche ersetzt.
   the_observation_was_already_added_to_that_project: Die Beobachtung wurde bereits zu diesem Projekt hinzugefügt.
-  the_people_of_inat: "Menschen auf %{site_name}"
+  the_people_of_inat: "Personen auf %{site_name}"
   the_species_listed_below_were_not_found_in_the_site_database: |
     Die unten aufgeführten Arten wurden in der %{site_name}-Datenbank nicht gefunden.
   the_title_of_the_wikipedia_article_we_use: |


### PR DESCRIPTION
This pull request proposes a minor change to improve consistency for the german language.

Currently, the title for the "People" page reads "Menschen auf iNaturalist," while the link itself displays "Personen." While both translations are technically accurate ("Menschen" being the more general term for "people"), "Personen" better reflects the intended meaning in this context (users on iNaturalist).

This change aligns the title text with the link text, providing a more consistent user experience.

Before change:

![Screenshot 2024-03-27 at 18 03 11](https://github.com/inaturalist/inaturalist/assets/16878981/5c1f2a58-813a-4f69-8426-65ff6086971d)

After change:

![image](https://github.com/inaturalist/inaturalist/assets/16878981/5e66094b-e93e-405a-8106-7135d439c343)
