### PR TITLE
Replace Conabio description service

### DIFF
--- a/app/assets/stylesheets/taxa/show.scss
+++ b/app/assets/stylesheets/taxa/show.scss
@@ -625,6 +625,11 @@ $introducedColor: #E4007C;
     font-style: italic;
     margin-top: 20px;
   }
+  &.conabio_description {
+    .form-group.row {
+      display: none;
+    }
+  }
 }
 .ArticlesTab .taxon_description_header {
   display: none;

--- a/app/assets/stylesheets/taxa/show/wikipedia.scss
+++ b/app/assets/stylesheets/taxa/show/wikipedia.scss
@@ -1,4 +1,4 @@
-.wikipedia_description {
+.wikipedia_description, .wikipedia_es_description {
   overflow: hidden;
   width: 100%;
   line-height: 1.6em;

--- a/app/webpack/taxa/shared/ducks/taxon.js
+++ b/app/webpack/taxa/shared/ducks/taxon.js
@@ -377,12 +377,13 @@ export function fetchDescription( ) {
     }
     fetch( url ).then(
       response => {
-        const source = response.headers.get( "X-Describer-Name" );
+        const sourceName = response.headers.get( "X-Describer-Name" );
+        const sourceURL = response.headers.get( "X-Describer-URL" );
         // the URL is being sent in an HTTP header, which does not support UTF-8, so force encoding
-        const describerUrl = utf8.decode( response.headers.get( "X-Describer-URL" ) );
+        const describerUrl = _.isEmpty( sourceURL ) ? null : utf8.decode( sourceURL );
         response.text( ).then( body => {
           if ( body && body.length > 0 ) {
-            dispatch( setDescription( source, describerUrl, body ) );
+            dispatch( setDescription( sourceName, describerUrl, body ) );
           }
         } );
       },

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -83,7 +83,12 @@ class MetaService
         request_url: options[:request_uri].to_s
       )
       return if api_endpoint_cache.in_progress?
+
       if api_endpoint_cache.cached? && !options[:force_update]
+        if options[:raw_response]
+          return api_endpoint_cache.response
+        end
+
         return Nokogiri::XML( api_endpoint_cache.response )
       end
     end
@@ -110,6 +115,10 @@ class MetaService
       success: !response.body.blank?,
       response: response.body
     )
+    if options[:raw_response]
+      return response.body
+    end
+
     Nokogiri::XML( response.body )
   end
 

--- a/lib/taxon_describers/lib/taxon_describers/conabio.rb
+++ b/lib/taxon_describers/lib/taxon_describers/conabio.rb
@@ -1,15 +1,18 @@
+# frozen_string_literal: true
+
 module TaxonDescribers
   class Conabio < Base
     def self.describer_name
-      'CONABIO'
+      "CONABIO"
     end
 
-    def self.describe(taxon)
-      page = conabio_service.search(taxon.name)
+    def self.describe( taxon )
+      page = conabio_service.search( taxon.name )
       page.blank? ? nil : page
     end
 
     private
+
     def conabio_service
       @conabio_service = ConabioService.new
     end

--- a/lib/taxon_describers/lib/taxon_describers/wikipedia.rb
+++ b/lib/taxon_describers/lib/taxon_describers/wikipedia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TaxonDescribers
   class Wikipedia < Base
     def initialize( options = {} )
@@ -54,7 +56,8 @@ module TaxonDescribers
         ".mw-editsection",
         ".navbar",
         ".taxobox",
-        ".taxobox_v3"
+        ".taxobox_v3",
+        "table.infobox"
       ]
       if options[:strip_references]
         selectors_to_remove << ".reference"

--- a/lib/taxon_describers/lib/taxon_describers/wikipedia_es.rb
+++ b/lib/taxon_describers/lib/taxon_describers/wikipedia_es.rb
@@ -1,18 +1,15 @@
-require ::File.expand_path('../wikipedia', __FILE__)
+# frozen_string_literal: true
+
+require ::File.expand_path( "../wikipedia", __FILE__ )
+
 module TaxonDescribers
-  
   class WikipediaEs < Wikipedia
     def wikipedia
-      @wikipedia ||= WikipediaService.new(:locale => "es")
+      @wikipedia ||= WikipediaService.new( locale: "es" )
     end
 
     def self.describer_name
       "Wikipedia (ES)"
     end
-
-    def page_url(taxon)
-      "http://es.wikipedia.org/wiki/#{taxon.wikipedia_title || taxon.name}"
-    end
   end
-
 end


### PR DESCRIPTION
* Replaces old Conabio taxon description service with two new endpoints
* Fixes ES Wikipedia styling to better match EN styling
* Fixes a bug fetch taxon descriptions from taxon pages