### PR TITLE
fix: zoom taxon detail history chart to last 10 years

### DIFF
--- a/app/webpack/taxa/show/components/charts.jsx
+++ b/app/webpack/taxa/show/components/charts.jsx
@@ -2,9 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import _ from "lodash";
-import bb, { areaSpline, spline } from "billboard.js";
+import bb, { areaSpline, spline, zoom } from "billboard.js";
 import { schemeCategory10 } from "d3";
-import moment from "moment";
 import { Modal } from "react-bootstrap";
 import { objectToComparable } from "../../../shared/util";
 
@@ -298,6 +297,7 @@ class Charts extends React.Component {
     } = this.props;
     // const dates = this.props.historyKeys;
     const years = _.uniq( dates.map( d => new Date( d ).getFullYear( ) ) ).sort( );
+    const formattedYears = years.map((y) => `${y}-06-15`);
     const chunks = _.chunk( years, 2 );
     const that = this;
     const regions = chunks.map( pair => (
@@ -327,15 +327,13 @@ class Charts extends React.Component {
           type: "timeseries",
           tick: {
             culling: true,
-            values: years.map( y => `${y}-06-15` ),
+            values: formattedYears,
             format: "%Y"
           },
-          extent: [moment( ).subtract( 10, "years" ).toDate( ), new Date( )]
         }
       },
       zoom: {
-        enabled: true,
-        rescale: true
+        enabled: zoom(),
       },
       tooltip: {
         contents: ( d, defaultTitleFormat, defaultValueFormat, color ) => that.tooltipContent(
@@ -349,6 +347,7 @@ class Charts extends React.Component {
     } );
     const mountNode = $( ".HistoryChart", ReactDOM.findDOMNode( this ) ).get( 0 );
     this.historyChart = bb.generate( Object.assign( { bindto: mountNode }, config ) );
+    this.historyChart.zoom([formattedYears[formattedYears.length - 11], formattedYears[formattedYears.length - 1]]);
   }
 
   render( ) {


### PR DESCRIPTION
This a WIP and a workaround to make the history chart show the last 10 years data by default.

The zoom was enable but didn't work since the migration from C3.  I made it work back.

The option `axis.x.extent` use for creating a default zoom/subchart doesn't seems to work or I am missing something. I have created an [issue](https://github.com/naver/billboard.js/issues/3768) on billboard.js for it.

To workaround this option I forced a zoom on the chart after the initialization. It's working when the Taxon has recent observation but I think it won't work when the last observation is too old.

This solution is only a Frontend solution. 

It would probably be better that the server is sending only the 10 years data to the client. Since I don't know how it was working before I preferred to let all the data available to the client.