### PR TITLE
Add upsert behavior for POST /relationships

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -9,7 +9,7 @@ class FriendshipsController < ApplicationController
 
   def index
     @friendships = current_user.friendships.page( params[:page] )
-    if @q = params[:q]
+    if ( @q = params[:q] )
       @friendships = @friendships.joins( :friend ).where( "users.login ilike ?", "%#{@q}%" )
     end
     @trusted = params[:trusted]
@@ -54,7 +54,7 @@ class FriendshipsController < ApplicationController
           flash[:error] = @friendship.errors.full_messages.to_sentence
           redirect_back_or_default( person_path( current_user ) )
         end
-        format.json { render status: :unprocessable_entity, json: @friendship.errors.full_messages.to_sentence }
+        format.json { render status: :unprocessable_entity, json: @friendship.errors }
       end
     end
   end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,13 +4,18 @@
 # model name Friendship
 class RelationshipsController < FriendshipsController
   def create
-    @relationship = current_user.friendships.new( approved_create_params )
+    if ( existing = current_user.friendships.where( friend_id: approved_create_params[:friend_id] ).first )
+      @relationship = existing
+      @relationship.assign_attributes( approved_create_params )
+    else
+      @relationship = current_user.friendships.new( approved_create_params )
+    end
     respond_to do | format |
       format.json do
         if @relationship.save
           render json: { relationship: @relationship }
         else
-          render status: :unprocessable_entity, json: @relationship.errors.full_messages.to_sentence
+          render status: :unprocessable_entity, json: @relationship.errors
         end
       end
     end

--- a/spec/controllers/relationships_controller_api_spec.rb
+++ b/spec/controllers/relationships_controller_api_spec.rb
@@ -28,6 +28,13 @@ shared_examples_for "a RelationshipsController" do
       user.reload
       expect( user.friendships.count ).to eq( friendships_count + 1 )
     end
+    it "should upsert" do
+      friendship = user.friendships.create( friend_id: friend.id, trust: false )
+      post :create, format: :json, params: { relationship: { friend_id: friend.id, trust: true } }
+      expect( response ).to be_successful
+      friendship.reload
+      expect( friendship ).to be_trust
+    end
   end
   describe "update" do
     let( :relationship ) { Friendship.make!( user: user ) }


### PR DESCRIPTION
For context, iNat Next is running into a problem where the "follow" button on the user profile is appearing when a friendship with the `following` attribute exists, but otherwise shows an "unfollow" button, but if a relationship exists but does not have the `following == true`, it gets an error from POST /relationships when it tries to create a new friendship, because a record with that friend_id already exists. This will make it so those requests will succeed b/c the record the app is trying to create doesn't need to be created again, just updated with the following attribute.

The thing that might be worth reviewing is changing the shape of the error response for this endpoint. Previous it was returning non-JSON, just a string of concatenated error messages. This will make it return actual JSON that should pass more useful data back through node and to the client. However, it does change the API response, albeit not anything that's documented.