### PR TITLE
feat: :sparkles: add new default export field uuid

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -199,6 +199,7 @@ class Observation < ApplicationRecord
   ]
   BASIC_COLUMNS = [
     "id",
+    "uuid",
     "observed_on_string",
     "observed_on",
     "time_observed_at",


### PR DESCRIPTION
Closes https://github.com/inaturalist/inaturalist/issues/4086

In this update, I have added the UUID to the basic columns for the export, positioning it as the second column. This placement is consistent with the default basic export, and it aligns with the position of the ID column, given that the list is not in alphabetical order.

~~The spec test did report some errors, but I believe it is not related to the update, as they are all some geoprivacy problems.~~ (only local issue as the CI did not complain)
`bundle exec rspec spec/models/observations_Export_flow_task_spec.rb`


![interface](https://github.com/inaturalist/inaturalist/assets/16878981/5b57e35b-7c6a-4477-b584-941b508d7046)

<img width="698" alt="generated csv" src="https://github.com/inaturalist/inaturalist/assets/16878981/443a3ead-e12c-442e-9fa2-b4550d510a0e">



