### PR TITLE
Interpolate your own missing coordinates

### DIFF
--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -785,14 +785,16 @@ time {
     background: #f8f8f8;
     height: 230px;
     text-align: center;
-    font-size: 18px;
-    color: $text-grey;
     padding-top: 75px;
     border-bottom: 1px solid $border-grey;;
     .fa {
       display: block;
       font-size: 60px;
       color: #ccc;
+    }
+    span {
+      font-size: 18px;
+      color: $text-grey;
     }
   }
   .map_details {

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -1109,6 +1109,9 @@ class Observation < ApplicationRecord
     if p[:id_below]
       search_filters << { range: { id: { lt: p[:id_below] } } }
     end
+    if p[:not_id].to_i.positive?
+      inverse_filters << { term: { id: p[:not_id].to_i } }
+    end
 
     { filters: search_filters,
       inverse_filters: inverse_filters,

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -1109,8 +1109,13 @@ class Observation < ApplicationRecord
     if p[:id_below]
       search_filters << { range: { id: { lt: p[:id_below] } } }
     end
-    if p[:not_id].to_i.positive?
-      inverse_filters << { term: { id: p[:not_id].to_i } }
+    if p[:not_id]
+      not_ids = [p[:not_id]].flatten.
+        map {| id | id.to_s.split( "," ).map( &:to_i ) }.
+        flatten.compact
+      if not_ids.size.positive?
+        inverse_filters << { terms: { id: not_ids } }
+      end
     end
 
     { filters: search_filters,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -3188,31 +3188,40 @@ class Observation < ApplicationRecord
 
   def interpolate_coordinates
     return unless time_observed_at
-    scope = user.observations.where("latitude IS NOT NULL or private_latitude IS NOT NULL")
-    prev_obs = scope.where("time_observed_at < ?", time_observed_at).order("time_observed_at DESC").first
-    next_obs = scope.where("time_observed_at > ?", time_observed_at).order("time_observed_at ASC").first
+
+    scope = user.observations.where( "latitude IS NOT NULL or private_latitude IS NOT NULL" )
+    prev_obs = scope.where( "time_observed_at < ?", time_observed_at ).order( "time_observed_at DESC" ).first
+    next_obs = scope.where( "time_observed_at > ?", time_observed_at ).order( "time_observed_at ASC" ).first
     return unless prev_obs && next_obs
+
     prev_lat = prev_obs.private_latitude || prev_obs.latitude
     prev_lon = prev_obs.private_longitude || prev_obs.longitude
     next_lat = next_obs.private_latitude || next_obs.latitude
     next_lon = next_obs.private_longitude || next_obs.longitude
 
     # time-weighted interpolation between prev and next observations
-    weight = (next_obs.time_observed_at - time_observed_at) / (next_obs.time_observed_at-prev_obs.time_observed_at)
-    new_lat = (1-weight)*next_lat + weight*prev_lat
-    new_lon = (1-weight)*next_lon + weight*prev_lon
+    weight = (
+      ( next_obs.time_observed_at - time_observed_at ) /
+      ( next_obs.time_observed_at - prev_obs.time_observed_at )
+    )
+    new_lat = ( ( 1 - weight ) * next_lat ) + ( weight * prev_lat )
+    new_lon = ( ( 1 - weight ) * next_lon ) + ( weight * prev_lon )
     self.latitude = new_lat
     self.longitude = new_lon
 
     # we can only set a new uncertainty if the uncertainty of the two points are known
-    if prev_obs.positional_accuracy && next_obs.positional_accuracy
-      f = RGeo::Geographic.simple_mercator_factory
-      prev_point = f.point(prev_lon, prev_lat)
-      next_point = f.point(next_lon, next_lat)
-      interpolation_uncertainty = prev_point.distance(next_point)/2.0
-      new_acc = Math.sqrt(interpolation_uncertainty**2 + prev_obs.positional_accuracy**2 + next_obs.positional_accuracy**2)
-      self.positional_accuracy = new_acc
-    end
+    return unless prev_obs.positional_accuracy && next_obs.positional_accuracy
+
+    f = RGeo::Geographic.simple_mercator_factory
+    prev_point = f.point( prev_lon, prev_lat )
+    next_point = f.point( next_lon, next_lat )
+    interpolation_uncertainty = prev_point.distance( next_point ) / 2.0
+    new_acc = Math.sqrt(
+      ( interpolation_uncertainty**2 ) +
+      ( prev_obs.positional_accuracy**2 ) +
+      ( next_obs.positional_accuracy**2 )
+    )
+    self.positional_accuracy = new_acc
   end
 
   def self.as_csv(scope, methods, options = {})

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -3189,9 +3189,9 @@ class Observation < ApplicationRecord
   def interpolate_coordinates
     return unless time_observed_at
 
-    scope = user.observations.where( "latitude IS NOT NULL or private_latitude IS NOT NULL" )
-    prev_obs = scope.where( "time_observed_at < ?", time_observed_at ).order( "time_observed_at DESC" ).first
-    next_obs = scope.where( "time_observed_at > ?", time_observed_at ).order( "time_observed_at ASC" ).first
+    base_params = { user_id: user.id, with_geo: true, order_by: "observed_on", not_id: id }
+    prev_obs = Observation.elastic_query( base_params.merge( d2: time_observed_at, order: "desc" ) ).first
+    next_obs = Observation.elastic_query( base_params.merge( d1: time_observed_at, order: "asc" ) ).first
     return unless prev_obs && next_obs
 
     prev_lat = prev_obs.private_latitude || prev_obs.latitude

--- a/app/webpack/observations/show/components/app.jsx
+++ b/app/webpack/observations/show/components/app.jsx
@@ -220,6 +220,8 @@ const App = ( {
                         deleteObservation( );
                       } else if ( key === "license" ) {
                         setLicensingModalState( { show: true } );
+                      } else if ( key === "interpolate" ) {
+                        window.location = `/observations/${observation.id}/edit?interpolate_coordinates=true`;
                       }
                     }}
                   >
@@ -241,6 +243,12 @@ const App = ( {
                       <i className="fa fa-copyright" />
                       { I18n.t( "edit_license" ) }
                     </MenuItem>
+                    { !observation.latitude && (
+                      <MenuItem eventKey="interpolate">
+                        <i className="fa fa-map-marker" />
+                        { I18n.t( "interpolate_coordinates" ) }
+                      </MenuItem>
+                    ) }
                     <li role="separator" className="divider" />
                     <MenuItem eventKey="delete">
                       <i className="fa fa-trash" />

--- a/app/webpack/observations/show/components/app.jsx
+++ b/app/webpack/observations/show/components/app.jsx
@@ -220,8 +220,6 @@ const App = ( {
                         deleteObservation( );
                       } else if ( key === "license" ) {
                         setLicensingModalState( { show: true } );
-                      } else if ( key === "interpolate" ) {
-                        window.location = `/observations/${observation.id}/edit?interpolate_coordinates=true`;
                       }
                     }}
                   >
@@ -243,12 +241,6 @@ const App = ( {
                       <i className="fa fa-copyright" />
                       { I18n.t( "edit_license" ) }
                     </MenuItem>
-                    { !observation.latitude && (
-                      <MenuItem eventKey="interpolate">
-                        <i className="fa fa-map-marker" />
-                        { I18n.t( "interpolate_coordinates" ) }
-                      </MenuItem>
-                    ) }
                     <li role="separator" className="divider" />
                     <MenuItem eventKey="delete">
                       <i className="fa fa-trash" />

--- a/app/webpack/observations/show/components/app.jsx
+++ b/app/webpack/observations/show/components/app.jsx
@@ -48,6 +48,7 @@ import ObservationModalContainer from "../containers/observation_modal_container
 import TestGroupToggle from "../../../shared/components/test_group_toggle";
 import RtlTestGroupToggle from "../../../shared/components/rtl_test_group_toggle";
 import FlashMessage from "./flash_message";
+import AssessmentLazyLoad from "./assessment_lazy_load";
 
 moment.updateLocale( "en", {
   relativeTime: {
@@ -68,7 +69,10 @@ moment.updateLocale( "en", {
 } );
 
 const App = ( {
-  observation, config, controlledTerms, deleteObservation, setLicensingModalState
+  observation,
+  config,
+  deleteObservation,
+  setLicensingModalState
 } ) => {
   if ( _.isEmpty( observation ) || _.isEmpty( observation.user ) ) {
     return (
@@ -109,7 +113,8 @@ const App = ( {
     isoDateObserved = observedAt.format( "YYYY-MM" );
   } else if ( observation.time_observed_at ) {
     formattedDateObserved = formattedDateTimeInTimeZone(
-      observation.time_observed_at, observation.observed_time_zone
+      observation.time_observed_at,
+      observation.observed_time_zone
     );
   } else if ( observation.observed_on ) {
     formattedDateObserved = moment( observation.observed_on ).format( "ll" );
@@ -123,19 +128,22 @@ const App = ( {
     formattedDateAdded = createdAt.format( I18n.t( "momentjs.month_year" ) );
     isoDateAdded = createdAt.format( "YYYY-MM" );
   }
-  const description = observation.description ? (
-    <Row>
-      <Col xs={12}>
-        <h3>
-          {
-            I18n.t( "notes", {
-              defaultValue: I18n.t( "activerecord.attributes.observation.description" )
-            } )
-          }
-        </h3>
-        <UserText text={observation.description} />
-      </Col>
-    </Row> ) : "";
+  const description = observation.description
+    ? (
+      <Row>
+        <Col xs={12}>
+          <h3>
+            {
+              I18n.t( "notes", {
+                defaultValue: I18n.t( "activerecord.attributes.observation.description" )
+              } )
+            }
+          </h3>
+          <UserText text={observation.description} />
+        </Col>
+      </Row>
+    )
+    : "";
   const qualityGrade = observation.quality_grade === "research"
     ? "research_grade"
     : observation.quality_grade;
@@ -147,24 +155,7 @@ const App = ( {
   } else {
     qualityGradeTooltipHtml = I18n.t( "research_grade_tooltip_html" );
   }
-  // Custom lazyload component for the DQA, where we want lazy loading to apply
-  // inside of the collapsible element
-  const AssessmentLazyLoad = props => (
-    <LazyLoad
-      debounce={false}
-      height={
-        !config.currentUser || !config.currentUser.prefers_hide_obs_show_quality_metrics
-          ? 670
-          : 70
-      }
-      verticalOffset={500}
-    >
-      {
-        // eslint-disable-next-line react/prop-types
-        props.children
-      }
-    </LazyLoad>
-  );
+
   return (
     <div id="ObservationShow">
       { config && config.testingApiV2 && (
@@ -434,8 +425,6 @@ const App = ( {
 
 App.propTypes = {
   config: PropTypes.object,
-  controlledTerms: PropTypes.array,
-  // leaveTestGroup: PropTypes.func,
   observation: PropTypes.object,
   deleteObservation: PropTypes.func,
   setLicensingModalState: PropTypes.func

--- a/app/webpack/observations/show/components/assessment.jsx
+++ b/app/webpack/observations/show/components/assessment.jsx
@@ -90,7 +90,7 @@ class Assessment extends React.Component {
           </div>
           <Panel expanded={open} onToggle={() => {}}>
             <Panel.Collapse>
-              <InnerWrapper>
+              <InnerWrapper config={config}>
                 <Row>
                   <Col xs={7}>
                     <QualityMetricsContainer />

--- a/app/webpack/observations/show/components/assessment_lazy_load.jsx
+++ b/app/webpack/observations/show/components/assessment_lazy_load.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import LazyLoad from "react-lazy-load";
+
+// Custom lazyload component for the DQA, where we want lazy loading to apply
+// inside of the collapsible element
+const AssessmentLazyLoad = ( {
+  config,
+  children
+} ) => (
+  <LazyLoad
+    debounce={false}
+    height={
+      !config.currentUser || !config.currentUser.prefers_hide_obs_show_quality_metrics
+        ? 670
+        : 70
+    }
+    verticalOffset={500}
+  >
+    { children }
+  </LazyLoad>
+);
+
+AssessmentLazyLoad.propTypes = {
+  children: PropTypes.any,
+  config: PropTypes.object
+};
+
+export default AssessmentLazyLoad;

--- a/app/webpack/observations/show/components/map.jsx
+++ b/app/webpack/observations/show/components/map.jsx
@@ -7,7 +7,6 @@ import SplitTaxon from "../../../shared/components/split_taxon";
 import { urlForTaxon, taxonLayerForTaxon } from "../../../taxa/shared/util";
 import TaxonMap from "../../identify/components/taxon_map";
 import MapDetails from "./map_details";
-import ErrorBoundary from "../../../shared/components/error_boundary";
 
 /* global LIFE_TAXON */
 
@@ -22,12 +21,14 @@ class Map extends React.Component {
     const {
       observation,
       observationPlaces,
+      canInterpolate,
       config,
       updateCurrentUser
     } = this.props;
     let geoprivacyIconClass = "fa fa-map-marker";
     let geoprivacyTitle = I18n.t( "location_is_public" );
     let geoprivacyLabel = I18n.t( "location_unknown" );
+    let interpolateButton;
     // Note this is based on the currently confusing nature of obscured, which
     // at present means coordinates_obscured? OR geoprivacy == "obscured", so if
     // there are no coordinates and geoprivacy is obscured, we set the
@@ -55,6 +56,18 @@ class Map extends React.Component {
     } else if ( !observation.latitude && !observation.private_geojson ) {
       geoprivacyIconClass = "icon-no-location";
       geoprivacyLabel = I18n.t( "location_unknown" );
+      if ( canInterpolate ) {
+        interpolateButton = (
+          <div>
+            <a
+              className="linky"
+              href={`/observations/${observation.id}/edit?interpolate_coordinates=true`}
+            >
+              { I18n.t( "guess_location_from_other_observations?" ) }
+            </a>
+          </div>
+        );
+      }
     }
     let placeGuess = I18n.t( "location_unknown" );
     if ( observation ) {
@@ -70,7 +83,8 @@ class Map extends React.Component {
           <div className="TaxonMap empty">
             <div className="no_location">
               <i className="fa fa-map-marker" />
-              { geoprivacyLabel }
+              <span>{ geoprivacyLabel }</span>
+              { interpolateButton }
             </div>
           </div>
           <div className="map_details">
@@ -168,9 +182,9 @@ class Map extends React.Component {
       const obscured = observation.obscured && !observation.private_geojson
         && (
           <span className="obscured">
-            { "(" }
+            (
             { I18n.t( "obscured" ) }
-            { ")" }
+            )
           </span>
         );
       const showLength = observation.obscured ? 22 : 32;
@@ -186,7 +200,8 @@ class Map extends React.Component {
             >
               { I18n.t( "show" ) }
             </button>
-          </div> );
+          </div>
+        );
       }
       placeGuessElement = (
         <div>
@@ -235,6 +250,7 @@ class Map extends React.Component {
 Map.propTypes = {
   observation: PropTypes.object,
   observationPlaces: PropTypes.array,
+  canInterpolate: PropTypes.bool,
   config: PropTypes.object,
   updateCurrentUser: PropTypes.func
 };

--- a/app/webpack/observations/show/containers/app_container.js
+++ b/app/webpack/observations/show/containers/app_container.js
@@ -7,8 +7,7 @@ import { setLicensingModalState } from "../ducks/licensing_modal";
 function mapStateToProps( state ) {
   return {
     observation: state.observation,
-    config: state.config,
-    controlledTerms: state.controlledTerms.terms
+    config: state.config
   };
 }
 

--- a/app/webpack/observations/show/containers/map_container.js
+++ b/app/webpack/observations/show/containers/map_container.js
@@ -2,10 +2,27 @@ import { connect } from "react-redux";
 import { updateCurrentUser } from "../../../shared/ducks/config";
 import Map from "../components/map";
 
+function coordinatesObscured( observation ) {
+  return observation.latitude || observation.obscured;
+}
+
 function mapStateToProps( state ) {
   return {
     observation: state.observation,
     observationPlaces: state.observationPlaces,
+    canInterpolate: (
+      state.config
+      && state.config.currentUser
+      && state.observation
+      && state.observation.user
+      && state.config.currentUser.id === state.observation.user.id
+      && state.observation.time_observed_at
+      && state.otherObservations
+      && state.otherObservations.earlierUserObservations
+      && state.otherObservations.laterUserObservations
+      && state.otherObservations.earlierUserObservations.filter( coordinatesObscured ).length > 0
+      && state.otherObservations.laterUserObservations.filter( coordinatesObscured ).length > 0
+    ),
     config: state.config
   };
 }

--- a/app/webpack/observations/show/containers/map_container.js
+++ b/app/webpack/observations/show/containers/map_container.js
@@ -13,6 +13,7 @@ function mapStateToProps( state ) {
     canInterpolate: (
       state.config
       && state.config.currentUser
+      && state.config.currentUser.roles.indexOf( "admin" ) >= 0
       && state.observation
       && state.observation.user
       && state.config.currentUser.id === state.observation.user.id

--- a/app/webpack/observations/show/containers/map_container.js
+++ b/app/webpack/observations/show/containers/map_container.js
@@ -18,10 +18,18 @@ function mapStateToProps( state ) {
       && state.config.currentUser.id === state.observation.user.id
       && state.observation.time_observed_at
       && state.otherObservations
-      && state.otherObservations.earlierUserObservations
-      && state.otherObservations.laterUserObservations
-      && state.otherObservations.earlierUserObservations.filter( coordinatesObscured ).length > 0
-      && state.otherObservations.laterUserObservations.filter( coordinatesObscured ).length > 0
+      && state.otherObservations.earlierUserObservationsByObserved
+      && state.otherObservations.laterUserObservationsByObserved
+      && state
+        .otherObservations
+        .earlierUserObservationsByObserved
+        .filter( coordinatesObscured )
+        .length > 0
+      && state
+        .otherObservations
+        .laterUserObservationsByObserved
+        .filter( coordinatesObscured )
+        .length > 0
     ),
     config: state.config
   };

--- a/app/webpack/observations/show/ducks/other_observations.js
+++ b/app/webpack/observations/show/ducks/other_observations.js
@@ -1,8 +1,11 @@
 import _ from "lodash";
 import inatjs from "inaturalistjs";
+import moment from "moment";
 
 const SET_EARLIER_USER_OBSERVATIONS = "obs-show/other_observations/SET_EARLIER_USER_OBSERVATIONS";
 const SET_LATER_USER_OBSERVATIONS = "obs-show/other_observations/SET_LATER_USER_OBSERVATIONS";
+const SET_EARLIER_USER_OBSERVATIONS_BY_OBSERVED = "obs-show/other_observations/SET_EARLIER_USER_OBSERVATIONS_BY_OBSERVED";
+const SET_LATER_USER_OBSERVATIONS_BY_OBSERVED = "obs-show/other_observations/SET_LATER_USER_OBSERVATIONS_BY_OBSERVED";
 const SET_NEARBY = "obs-show/other_observations/SET_NEARBY";
 const SET_MORE_FROM_CLADE = "obs-show/other_observations/SET_MORE_FROM_CLADE";
 
@@ -59,6 +62,14 @@ export default function reducer( state = OTHER_OBSERVATIONS_DEFAULT_STATE, actio
       return Object.assign( { }, state, {
         laterUserObservations: _.filter( action.observations, otherObsFilter )
       } );
+    case SET_EARLIER_USER_OBSERVATIONS_BY_OBSERVED:
+      return Object.assign( { }, state, {
+        earlierUserObservationsByObserved: action.observations
+      } );
+    case SET_LATER_USER_OBSERVATIONS_BY_OBSERVED:
+      return Object.assign( { }, state, {
+        laterUserObservationsByObserved: action.observations
+      } );
     case SET_NEARBY:
       return Object.assign( { }, state, {
         nearby: Object.assign( {}, action.data, {
@@ -87,6 +98,20 @@ export function setEarlierUserObservations( observations ) {
 export function setLaterUserObservations( observations ) {
   return {
     type: SET_LATER_USER_OBSERVATIONS,
+    observations
+  };
+}
+
+export function setEarlierUserObservationsByObserved( observations ) {
+  return {
+    type: SET_EARLIER_USER_OBSERVATIONS_BY_OBSERVED,
+    observations
+  };
+}
+
+export function setLaterUserObservationsByObserved( observations ) {
+  return {
+    type: SET_LATER_USER_OBSERVATIONS_BY_OBSERVED,
     observations
   };
 }
@@ -174,9 +199,9 @@ export function fetchMoreFromClade( ) {
 }
 
 export function fetchMoreFromThisUser( ) {
-  return ( dispatch, getState ) => {
+  return async ( dispatch, getState ) => {
     const s = getState( );
-    const { testingApiV2 } = s.config;
+    const { testingApiV2, currentUser } = s.config;
     const { observation } = s;
     if ( !observation || !observation.user ) { return null; }
     const baseParams = {
@@ -194,11 +219,47 @@ export function fetchMoreFromThisUser( ) {
     }
     const prevParams = Object.assign( {}, baseParams, { order: "desc", id_below: observation.id } );
     const nextParams = Object.assign( {}, baseParams, { order: "asc", id_above: observation.id } );
-    return inatjs.observations.search( prevParams ).then(
-      responseBefore => inatjs.observations.search( nextParams ).then( responseAfter => {
-        dispatch( setEarlierUserObservations( responseBefore.results ) );
-        dispatch( setLaterUserObservations( responseAfter.results ) );
-      } ).catch( ( ) => { } )
-    ).catch( ( ) => { } );
+    const responseBefore = await inatjs.observations.search( prevParams );
+    const responseAfter = await inatjs.observations.search( nextParams );
+    dispatch( setEarlierUserObservations( responseBefore.results ) );
+    dispatch( setLaterUserObservations( responseAfter.results ) );
+
+    // Fetch observations for missing location interpolation
+
+    // If we have a location we don't need to interpolate
+    if ( observation.latitude || observation.obscured ) return Promise.resolve();
+    // If the viewer isn't the observer we shouldn't interpolate
+    if ( !currentUser || currentUser.id !== observation.user.id ) return Promise.resolve();
+    const obsDateTime = moment( observation.time_observed_at || observation.observed_on );
+    // If we don't have a date/time we can't interpolate
+    if ( !obsDateTime ) return Promise.resolve();
+
+    const prevByObservedParams = Object.assign( {}, baseParams, {
+      order: "desc",
+      d1: moment( observation.time_observed_at || observation.observed_on ).subtract( 1, "days" ).format( ),
+      d2: obsDateTime.format(),
+      geo: true,
+      per_page: 1,
+      not_id: observation.id
+    } );
+    const responseObservedBefore = await inatjs.observations.search( prevByObservedParams );
+
+    const nextByObservedParams = Object.assign( {}, baseParams, {
+      order: "asc",
+      d1: obsDateTime.format(),
+      d2: moment( observation.time_observed_at || observation.observed_on ).add( 1, "days" ).format( ),
+      has_geo: true,
+      per_page: 1,
+      not_id: observation.id
+    } );
+    const responseObservedAfter = await inatjs.observations.search( nextByObservedParams );
+    if (
+      responseObservedBefore.results.length === 0
+      || responseObservedBefore.results.length === 0
+    ) {
+      return Promise.resolve();
+    }
+    dispatch( setEarlierUserObservationsByObserved( responseObservedBefore.results ) );
+    return dispatch( setLaterUserObservationsByObserved( responseObservedAfter.results ) );
   };
 }

--- a/app/webpack/observations/show/ducks/other_observations.js
+++ b/app/webpack/observations/show/ducks/other_observations.js
@@ -15,6 +15,8 @@ const OTHER_OBSERVATIONS_DEFAULT_STATE = {
 
 const OTHER_OBSERVATION_FIELDS = {
   id: true,
+  latitude: true,
+  obscured: true,
   photos: {
     id: true,
     uuid: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2265,6 +2265,9 @@ en:
   grid_tooltip: Show grid view
   group: Group
   grouping: Grouping
+  # Link that lets the user guess the location of an observation that does not
+  # have coordinates based on observations observed before and after
+  guess_location_from_other_observations?: Guess location from other observations?
   guides: Guides
   guide_compiled_by: Guide compiled by
   guide_deleted: Guide deleted
@@ -2529,7 +2532,6 @@ en:
   internal_taxon_rank: Internal taxon rank
   introduced: Introduced
   introduced_in_place: "Introduced in %{place}"
-  interpolate_coordinates: Interpolate Coordinates
   invitation: Invitation
   invite: invite
   invite_people: Invite people

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2529,6 +2529,7 @@ en:
   internal_taxon_rank: Internal taxon rank
   introduced: Introduced
   introduced_in_place: "Introduced in %{place}"
+  interpolate_coordinates: Interpolate Coordinates
   invitation: Invitation
   invite: invite
   invite_people: Invite people

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -756,6 +756,11 @@ describe "Observation Index" do
         filters: [ { range: { id: { gte: 99 } } } ])
     end
 
+    it "filters by not_id" do
+      expect(
+        Observation.params_to_elastic_query( { not_id: 123 } )
+      ).to include( inverse_filters: [{ term: { id: 123 } }] )
+    end
   end
 
   describe "prepare_batch_for_index" do

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -756,10 +756,22 @@ describe "Observation Index" do
         filters: [ { range: { id: { gte: 99 } } } ])
     end
 
-    it "filters by not_id" do
+    it "filters by single not_id integer" do
       expect(
         Observation.params_to_elastic_query( { not_id: 123 } )
-      ).to include( inverse_filters: [{ term: { id: 123 } }] )
+      ).to include( inverse_filters: [{ terms: { id: [123] } }] )
+    end
+
+    it "filters by single not_id array" do
+      expect(
+        Observation.params_to_elastic_query( { not_id: [123, 456] } )
+      ).to include( inverse_filters: [{ terms: { id: [123, 456] } }] )
+    end
+
+    it "filters by single not_id csv" do
+      expect(
+        Observation.params_to_elastic_query( { not_id: "123,456" } )
+      ).to include( inverse_filters: [{ terms: { id: [123, 456] } }] )
     end
   end
 

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -2133,25 +2133,29 @@ describe Observation, "interpolate_coordinates" do
   end
 
   it "should be time-weighted" do
-    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    _o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
     o2 = create :observation, user: user, observed_on_string: "2020-02-01 14:30"
-    o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
-    expect( o1.time_zone ).to eq "UTC"
-    expect( o2.time_zone ).to eq "UTC"
-    expect( o3.time_zone ).to eq "UTC"
+    _o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
     expect( o2.latitude ).to be_blank
     o2.interpolate_coordinates
     expect( o2.latitude ).to eq 0.75
   end
 
   it "should work for observations that already have coordinates" do
-    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    _o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
     o2 = create :observation, user: user, observed_on_string: "2020-02-01 14:00", latitude: 0.1, longitude: 0.1
-    o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
-    expect( o1.time_zone ).to eq "UTC"
-    expect( o2.time_zone ).to eq "UTC"
-    expect( o3.time_zone ).to eq "UTC"
+    _o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
     expect( o2.latitude ).not_to be_blank
+    o2.interpolate_coordinates
+    expect( o2.latitude ).to eq 0.5
+  end
+
+  it "should assume even weight if prev/next times are identical" do
+    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    o2 = create :observation, user: user, observed_on_string: "2020-02-01 13:00"
+    o3 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 1, longitude: 1
+    expect( o1.time_observed_at ).to eq o3.time_observed_at
+    expect( o2.latitude ).to be_blank
     o2.interpolate_coordinates
     expect( o2.latitude ).to eq 0.5
   end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -2131,6 +2131,30 @@ describe Observation, "interpolate_coordinates" do
     o2.interpolate_coordinates
     expect( o2.latitude ).to eq 0.5
   end
+
+  it "should be time-weighted" do
+    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    o2 = create :observation, user: user, observed_on_string: "2020-02-01 14:30"
+    o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
+    expect( o1.time_zone ).to eq "UTC"
+    expect( o2.time_zone ).to eq "UTC"
+    expect( o3.time_zone ).to eq "UTC"
+    expect( o2.latitude ).to be_blank
+    o2.interpolate_coordinates
+    expect( o2.latitude ).to eq 0.75
+  end
+
+  it "should work for observations that already have coordinates" do
+    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    o2 = create :observation, user: user, observed_on_string: "2020-02-01 14:00", latitude: 0.1, longitude: 0.1
+    o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
+    expect( o1.time_zone ).to eq "UTC"
+    expect( o2.time_zone ).to eq "UTC"
+    expect( o3.time_zone ).to eq "UTC"
+    expect( o2.latitude ).not_to be_blank
+    o2.interpolate_coordinates
+    expect( o2.latitude ).to eq 0.5
+  end
 end
 
 def setup_test_case_taxonomy

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -2101,6 +2101,38 @@ describe Observation, "sound_url" do
   end
 end
 
+describe Observation, "interpolate_coordinates" do
+  let( :user ) { create :user, time_zone: "UTC" }
+  it "should not work if a user only has 1 observation" do
+    o = create :observation, user: user, observed_on_string: "2020-02-01 14:00"
+    expect( o.latitude ).to be_blank
+    o.interpolate_coordinates
+    expect( o.latitude ).to be_blank
+  end
+
+  it "should not work if a user only has 2 observations" do
+    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    o2 = create :observation, user: user, observed_on_string: "2020-02-01 14:00"
+    expect( o1.time_zone ).to eq "UTC"
+    expect( o2.time_zone ).to eq "UTC"
+    expect( o2.latitude ).to be_blank
+    o2.interpolate_coordinates
+    expect( o2.latitude ).to be_blank
+  end
+
+  it "should interpolate 0.5,0.5 between 0,0 and 1,1" do
+    o1 = create :observation, user: user, observed_on_string: "2020-02-01 13:00", latitude: 0, longitude: 0
+    o2 = create :observation, user: user, observed_on_string: "2020-02-01 14:00"
+    o3 = create :observation, user: user, observed_on_string: "2020-02-01 15:00", latitude: 1, longitude: 1
+    expect( o1.time_zone ).to eq "UTC"
+    expect( o2.time_zone ).to eq "UTC"
+    expect( o3.time_zone ).to eq "UTC"
+    expect( o2.latitude ).to be_blank
+    o2.interpolate_coordinates
+    expect( o2.latitude ).to eq 0.5
+  end
+end
+
 def setup_test_case_taxonomy
   # Tree:
   #          sf


### PR DESCRIPTION
This adds a user-facing link to an existing tool on obs/edit that lets your interpolate the coordinates of your own observation based on observations you made before and after.

* Adds tests for `Observation#interpolate_coordinates`
* Makes `Observation#interpolate_coordinates` use elasticsearch instead of postgres
* Adds a link to `obs/edit?interpolate_coordinates=true` to the map on obs/show if the user is viewing their own obs AND the obs has no coordinates AND the user has observations with coordinates observed within a day in the future AND a day in the past (the last two require two additional API requests on obs/show)

Ideally I think the user should be shown which observations are being used for the interpolation and the locations of all three points on a map, but I didn't get that far in a day, and I think this is a small improvement on the status quo.