### PR TITLE
Fail POST /observations/:id/quality/:metric when attr missing

### DIFF
--- a/app/controllers/quality_metrics_controller.rb
+++ b/app/controllers/quality_metrics_controller.rb
@@ -79,7 +79,7 @@ class QualityMetricsController < ApplicationController
           flash[:error] = msg
           redirect_back_or_default( @observation )
         end
-        format.json { render json: { error: msg, object: qm } }
+        format.json { render status: :unprocessable_entity, json: { error: msg, object: qm } }
       end
     end
   end

--- a/spec/controllers/quality_metrics_controller_api_spec.rb
+++ b/spec/controllers/quality_metrics_controller_api_spec.rb
@@ -51,6 +51,13 @@ shared_examples_for "a QualityMetricsController" do
       expect( o.quality_metrics ).to be_blank
     end
 
+    it "should fail if the metric is about the date but the date does not exist" do
+      dateless = create( :observation, observed_on_string: "" )
+      expect( dateless.observed_on ).to be_blank
+      post :vote, as: :json, params: { id: dateless.id, metric: QualityMetric::DATE }
+      expect( response.status ).to eq 422
+    end
+
     describe "elastic index" do
       elastic_models( Observation )
 


### PR DESCRIPTION
E.g. voting that a date doesn't look right when an observation has no date. It was already failing to create the record, but the endpoint was returning a success response. This changes the API slightly but IMO this should be considered a bug fix.