### PR TITLE
[Bug Fix] New flag not created, old flag unresolved if flag reason matches user's previous flag for taxon

### DIFF
--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -149,15 +149,11 @@ class FlagsController < ApplicationController
     end
 
     @create_comment = false
-    if @flag = Flag.where( create_options.except( "initial_comment_body" ) ).where( resolved: true ).first
-      @flag.resolved = false
-    else
-      @flag = @object.flags.build(create_options)
-      @create_comment = create_options.key?( :initial_comment_body ) && create_options[:initial_comment_body].length > 0
-      if @create_comment
-        @comment_attributes = { parent: @flag, user: current_user, body: create_options[:initial_comment_body] }
-        @flag.comments.build( @comment_attributes )
-      end
+    @flag = @object.flags.build(create_options)
+    @create_comment = create_options.key?( :initial_comment_body ) && create_options[:initial_comment_body].length > 0
+    if @create_comment
+      @comment_attributes = { parent: @flag, user: current_user, body: create_options[:initial_comment_body] }
+      @flag.comments.build( @comment_attributes )
     end
     if @flag.flag == "other" && !params[:flag_explanation].blank?
       @flag.flag = params[:flag_explanation]


### PR DESCRIPTION
This PR fixes the issue #4153  
* The code explicitly looked for flags that matched the reason/user/taxon and unresolved the flag. This PR removes that code path. 
* This is my first PR in this repo, so let me know if I need to do anything else! 