### PR TITLE
feat: :wheelchair: disable gallery animation to reduce motion sickness

### DIFF
--- a/app/webpack/observations/identify/components/observation_modal.jsx
+++ b/app/webpack/observations/identify/components/observation_modal.jsx
@@ -265,6 +265,7 @@ class ObservationModal extends React.Component {
           <ZoomableImageGallery
             key={`map-for-${observation.id}`}
             items={images}
+            slideDuration={0}
             slideIndex={imagesCurrentIndex}
             showThumbnails={images && images.length > 1}
             lazyLoad={false}

--- a/app/webpack/observations/identify/components/suggestions.jsx
+++ b/app/webpack/observations/identify/components/suggestions.jsx
@@ -149,6 +149,7 @@ class Suggestions extends React.Component {
           disableArrowKeys
           showFullscreenButton={false}
           showPlayButton={false}
+          slideDuration={0}
           slideIndex={detailPhotoIndex}
           currentIndex={detailPhotoIndex}
           renderItem={item => (


### PR DESCRIPTION
Closes https://github.com/inaturalist/inaturalist/issues/4152

This pull request disables the transition effect in the identify modal gallery (and suggestions gallery), making the behavior consistent with the PhotoGallery in the Observation View. This change addresses user feedback requesting the removal of the slide animation when switching between photos.

The transition effect removal can be observed in the provided video.
Note: The suggestion tab functionality cannot be tested locally due to lack of access to the vision API.

[disabled-transitions.webm](https://github.com/inaturalist/inaturalist/assets/16878981/7bc06330-9dbc-42d6-80c7-c745b39ebb20)


Additional note: The same modal is used for compare taxa.