### PR TITLE
fix: :bug: fix stale compare modal due to caching

### DIFF
--- a/app/webpack/observations/identify/ducks/suggestions.js
+++ b/app/webpack/observations/identify/ducks/suggestions.js
@@ -81,12 +81,13 @@ export default function reducer(
       const { observation } = action;
       const isFeaturedObs = observation.uuid === state.query.featured_observation_uuid
         || observation.id === state.query.featured_observation_id;
+      const isTaxonChange = observation.taxon && state.query.taxon_id !== observation.taxon.id;
       newState.query = {
         source: state.query.source,
         order_by: state.query.order_by
       };
-      // If observation currently in query (tab change in modal), preserve taxon and place filters
-      if ( observation && isFeaturedObs ) {
+      // If observation currently in query (tab change in modal), preserve taxon and place filters. Except if a taxon change is detected.
+      if ( observation && isFeaturedObs && !isTaxonChange ) {
         newState.query = Object.assign( newState.query, {
           taxon: state.query.taxon,
           taxon_id: state.query.taxon_id,
@@ -279,6 +280,8 @@ export function fetchSuggestions( query ) {
       // can't show misidentifications of nothing
       return null;
     }
+
+    console.log(newQuery)
     dispatch( updateQuery( newQuery ) );
     dispatch( startLoading( ) );
     const sanitizedQuery = sanitizeQuery( newQuery );


### PR DESCRIPTION
Closes https://github.com/inaturalist/inaturalist/issues/4146

This fixes the issue, where the compare observation modal failed to update the suggested taxon upon user interaction. The root cause was identified as unintended caching behavior, originally designed to preserve filter states in the identification modal.

Implemented a check to determine if the taxon object attribute has changed when a user clicks on a different compare button. This ensures that the compare observation modal updates the suggested taxon accordingly.

- Manual tests were conducted to verify that the compare observation modal now correctly updates the suggested taxon.
- Additional tests confirmed that the identification modal's caching and filter preservation functionalities remain unaffected by this change.
