### PR TITLE
fix: Edited taxobox for Wikipedia entries

### DIFF
--- a/app/views/taxa/_description.html.haml
+++ b/app/views/taxa/_description.html.haml
@@ -94,17 +94,22 @@
         box = <<-WIKI
           {{Automatic taxobox
           | taxon = #{@taxon.name}
-          #{"| rank = #{Taxon::WIKIPEDIA_RANKS[@taxon.rank]}" unless @taxon.rank.blank?}
-          #{"| parent = #{parent_title}" if parent_title}
           #{"| image = #{image}" if image}
+          #{"| image_caption = #{image}" if image}
+          | authority =
+          | type_species =
+          | type_species_authority =
           }}
         WIKI
         if @taxon.species? && @taxon.genus
           box = <<-WIKI
             {{Speciesbox
-            | parent = #{@taxon.genus.name}
             | taxon = #{@taxon.name}
             #{"| image = #{image}" if image}
+            #{"| image_caption = #{image}" if image}
+            | authority =
+            | type_species =
+            | type_species_authority =
             }}
           WIKI
         end

--- a/app/views/taxa/_description.html.haml
+++ b/app/views/taxa/_description.html.haml
@@ -108,8 +108,6 @@
             #{"| image = #{image}" if image}
             #{"| image_caption =" if image}
             | authority =
-            | type_species =
-            | type_species_authority =
             }}
           WIKI
         end

--- a/app/views/taxa/_description.html.haml
+++ b/app/views/taxa/_description.html.haml
@@ -95,7 +95,7 @@
           {{Automatic taxobox
           | taxon = #{@taxon.name}
           #{"| image = #{image}" if image}
-          #{"| image_caption = #{image}" if image}
+          #{"| image_caption =" if image}
           | authority =
           | type_species =
           | type_species_authority =
@@ -106,7 +106,7 @@
             {{Speciesbox
             | taxon = #{@taxon.name}
             #{"| image = #{image}" if image}
-            #{"| image_caption = #{image}" if image}
+            #{"| image_caption =" if image}
             | authority =
             | type_species =
             | type_species_authority =


### PR DESCRIPTION
I found an issue today where taxobox uses old available fields for the taxobox. This issue has been known for some time - see this discussion, https://forum.inaturalist.org/t/fix-taxobox-parameters-in-create-this-page-on-wikipedia-prompt/18395/12. I've tried to make minimal efforts to remove those fields and to add others. 