### PR TITLE
feat: add param to redirect URL after account deletion

### DIFF
--- a/app/views/users/delete.html.haml
+++ b/app/views/users/delete.html.haml
@@ -22,7 +22,7 @@
       %p=t "views.users.delete.still_want_to_delete_html", confirmation_code: confirmation_code
       = form_for current_user, method: :delete do |f|
         .form-group
-          = text_field_tag :confirmation, nil, placeholder: t( "views.users.delete.type_confirmation_code", confirmation_code: confirmation_code, default: "Type #{confirmation_code}" ), class: "form-control"
+          = text_field_tag :confirmation, nil, placeholder: t( "views.users.delete.type_confirmation_code", confirmation_code: confirmation_code, default: "Type #{confirmation_code}" ), class: "form-control", autocapitalize: "off"
           = hidden_field_tag :confirmation_code, confirmation_code
         = f.submit t(:delete_your_account), class: "btn btn-danger"
         = link_to t(:cancel), :back, class: "btn btn-default"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6080,6 +6080,9 @@ en:
   user_faved_this_observation: "%{user} faved this observation"
   user_flagged_as_a_non_spammer_html: "%{user} marked as a non-spammer"
   user_flagged_as_a_spammer_html: "%{user} flagged as a spammer"
+  user_has_been_removed_from_site: |
+    %{username} has been removed from %{site_name} (it may take up to an hour
+     to completely delete all associated content)
   user_has_opted_out_of_community_id: User has opted-out of Community Taxon
   user_hasnt_joined_any_projects: "%{user} hasn't joined any projects"
   user_helped_x_people_with_y_ids_html: "%{user} helped <strong>%{x} people</strong> with <strong>%{y} IDs</strong>"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10301,6 +10301,13 @@ CREATE INDEX index_users_on_place_id ON public.users USING btree (place_id);
 
 
 --
+-- Name: index_users_on_remember_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_remember_token ON public.users USING btree (remember_token);
+
+
+--
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10974,6 +10981,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240222032444'),
 ('20240326135332'),
 ('20240429211140'),
+('20240430163539'),
 ('20240530162451'),
 ('20240606154217'),
 ('20240618044707'),

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -69,6 +69,12 @@ describe UsersController, "delete" do
       count ).to eq 1
   end
 
+  it "redirects with the account_deleted=true parameter" do
+    sign_in user
+    delete :destroy, params: { id: user.id, confirmation: user.login, confirmation_code: user.login }
+    expect( response.redirect_url ).to match /account_deleted=true/
+  end
+
   it "should be possible for the user" do
     sign_in user
     without_delay { delete :destroy, params: { id: user.id, confirmation: user.login, confirmation_code: user.login } }


### PR DESCRIPTION
This allows mobile clients showing these pages in webviews to detect if deletion was successful.