### PR TITLE
fix: :bug: set correct link for identifier icon subtitle

### DIFF
--- a/app/webpack/observations/show/components/identifiers.jsx
+++ b/app/webpack/observations/show/components/identifiers.jsx
@@ -49,7 +49,7 @@ class Identifiers extends React.Component {
     } else {
       panelContents = identifiers.map( i => (
         <div className="identifier" key={`identifier-${i.user.id}`}>
-          <UserWithIcon user={i.user} subtitle={i.count} subtitleIconClass="icon-identification" />
+          <UserWithIcon user={i.user} subtitle={i.count} subtitleIconClass="icon-identification" subtitleLinkOverwrite={`/identifications?user_id=${i.user.login}&taxon_id=${taxon.id}`} />
         </div>
       ) );
     }

--- a/app/webpack/observations/show/components/user_with_icon.jsx
+++ b/app/webpack/observations/show/components/user_with_icon.jsx
@@ -54,6 +54,7 @@ UserWithIcon.propTypes = {
     PropTypes.string,
     PropTypes.number
   ] ),
+  subtitleLinkOverwrite: PropTypes.string,
   subtitleIconClass: PropTypes.string,
   hideSubtitle: PropTypes.bool,
   skipSubtitleLink: PropTypes.bool

--- a/app/webpack/observations/show/components/user_with_icon.jsx
+++ b/app/webpack/observations/show/components/user_with_icon.jsx
@@ -6,6 +6,7 @@ const UserWithIcon = ( {
   hideSubtitle,
   skipSubtitleLink,
   subtitle,
+  subtitleLinkOverwrite,
   subtitleIconClass,
   user
 } ) => {
@@ -25,9 +26,10 @@ const UserWithIcon = ( {
        }
     </>
   );
+  const subtitleLinkDefault = `/observations?user_id=${user.login}&place_id=any&verifiable=any`;
   const subtitleLink = skipSubtitleLink
     ? subtitleContent
-    : <a href={`/observations?user_id=${user.login}&place_id=any&verifiable=any`}>{ subtitleContent }</a>;
+    : <a href={subtitleLinkOverwrite || subtitleLinkDefault}>{ subtitleContent }</a>;
 
   return (
     <div className="UserWithIcon">


### PR DESCRIPTION
Closes #4216 

This update introduces a new optional parameter, `subtitleLinkOverwrite`, to the ` user_with_icon` React component. This parameter allows for overriding the default link behavior.

This parameter is used to update the link on the observation page for the top identifiers widget, specifically pointing it to, the identifications page eg. https://www.inaturalist.org/identifications?user_id=samfellows566&taxon_id=4345.

We could add a parameter for `for=others`, but I believe the count currently includes self-identifications as well.

Cheers
Hannes


