### PR TITLE
fix: :bug: remove preferred_place_id from leader widget

### DIFF
--- a/app/webpack/taxa/show/containers/top_identifier_container.js
+++ b/app/webpack/taxa/show/containers/top_identifier_container.js
@@ -19,6 +19,7 @@ function mapStateToProps( state ) {
   }
   const urlParams = defaultObservationParams( state );
   urlParams.view = "identifiers";
+  delete urlParams.preferred_place_id;
   return Object.assign( props, {
     name: leader.user.login,
     imageUrl: leader.user.icon_url,

--- a/app/webpack/taxa/show/containers/top_identifier_container.js
+++ b/app/webpack/taxa/show/containers/top_identifier_container.js
@@ -19,7 +19,7 @@ function mapStateToProps( state ) {
   }
   const urlParams = defaultObservationParams( state );
   urlParams.view = "identifiers";
-  delete urlParams.preferred_place_id;
+  urlParams.place_id = urlParams.place_id || "any";
   return Object.assign( props, {
     name: leader.user.login,
     imageUrl: leader.user.icon_url,

--- a/app/webpack/taxa/show/containers/top_observer_container.js
+++ b/app/webpack/taxa/show/containers/top_observer_container.js
@@ -19,6 +19,7 @@ function mapStateToProps( state ) {
   }
   const urlParams = defaultObservationParams( state );
   urlParams.view = "observers";
+  delete urlParams.preferred_place_id;
   return Object.assign( props, {
     name: leader.user.login,
     noContent: false,

--- a/app/webpack/taxa/show/containers/top_observer_container.js
+++ b/app/webpack/taxa/show/containers/top_observer_container.js
@@ -19,7 +19,7 @@ function mapStateToProps( state ) {
   }
   const urlParams = defaultObservationParams( state );
   urlParams.view = "observers";
-  delete urlParams.preferred_place_id;
+  urlParams.place_id = urlParams.place_id || "any";
   return Object.assign( props, {
     name: leader.user.login,
     noContent: false,


### PR DESCRIPTION
If a user's state includes a `preferred_place_id`, it is currently appended to the top identifier and observer links on the taxa page. While this behavior could be relevant in some contexts, it may not always make sense, as the counts are global and not restricted to a specific place.

This pull request removes the `preferred_place_id` from the object when generating these links, ensuring the links remain global as intended.

## Example of the current link generated on the widget:

![image](https://github.com/user-attachments/assets/2c0f72c4-8381-4b28-93fc-126a8693be06)

Cheers
Hannes