### PR TITLE
fix: :bug: remove loading spinner if result is empty

### DIFF
--- a/app/assets/javascripts/ang/templates/observation_search/identifiers_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/identifiers_table.html.haml
@@ -16,7 +16,7 @@
           %user-icon{ u: "u" }
           %user-login{ u: "u" }
         %td {{ shared.numberWithCommas( u.resultCount ) }}
-  .spinner.ng-cloak{ "ng-show": "pagination.searching || identifiersPagination.searching" }
+  .spinner.ng-cloak{ "ng-show": "(pagination.searching || identifiersPagination.searching) && !noIdentifiers( )" }
     %span.fa.fa-spin.fa-refresh
   .noresults.text-muted.ng-cloak{ "ng-show": "noIdentifiers( )" }
     {{ shared.t( 'no_results_found' ) }}

--- a/app/assets/javascripts/ang/templates/observation_search/observers_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/observers_table.html.haml
@@ -21,7 +21,9 @@
           {{ shared.numberWithCommas( u.observationCount ) }}
         %td{ :class => "{{ observersSort == '-speciesCount' ? 'sorting' : '' }}" }
           {{ shared.numberWithCommas( u.speciesCount ) }}
-  .spinner.ng-cloak{ "ng-show": "pagination.searching || observersPagination.searching" }
+  .spinner.ng-cloak{ "ng-show": "(pagination.searching || observersPagination.searching) && !noObservers( )" }
     %span.fa.fa-spin.fa-refresh
+    {{ pagination.searching }}
+    {{ observersPagination.searching }}
   .noresults.text-muted.ng-cloak{ "ng-show": "noObservers( )" }
     {{ shared.t( 'no_results_found' ) }}

--- a/app/assets/javascripts/ang/templates/observation_search/observers_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/observers_table.html.haml
@@ -23,7 +23,5 @@
           {{ shared.numberWithCommas( u.speciesCount ) }}
   .spinner.ng-cloak{ "ng-show": "(pagination.searching || observersPagination.searching) && !noObservers( )" }
     %span.fa.fa-spin.fa-refresh
-    {{ pagination.searching }}
-    {{ observersPagination.searching }}
   .noresults.text-muted.ng-cloak{ "ng-show": "noObservers( )" }
     {{ shared.t( 'no_results_found' ) }}

--- a/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
@@ -16,7 +16,7 @@
               {{ t.photoLicenseShort( ) }}
         .caption
           %inat-taxon.title.split-taxon{ taxon: "t", url: "/taxa/{{ t.id }}" }
-  .spinner.ng-cloak{ "ng-show": "speciesPagination.searching" }
+  .spinner.ng-cloak{ "ng-show": "speciesPagination.searching && !noTaxa( )" }
     %span.fa.fa-spin.fa-refresh
   .noresults.text-muted.ng-cloak{ "ng-show": "noTaxa( )" }
     {{ shared.t( 'no_results_found' ) }}


### PR DESCRIPTION
Currently, when visiting an observation tab (e.g., view=species, view=observers, or view=identifiers), if the result set is empty, the loading spinner continues to display indefinitely. For example: https://www.inaturalist.org/observations?place_id=143465&subview=map&taxon_id=41644&view=observers.

This patch removes the loading spinner when the result set is empty, improving the user experience.

We can use the corresponding `noXXXX` function, which correctly returns false while the search is ongoing. Alternatively, we could use the `searchingStopped` function directly, but that would require some refactoring to make it compatible with the infinite scroll and loading icon behavior.

Cheers
Hannes
