### PR TITLE
fix: :bug: change order of icons and count

### DIFF
--- a/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
@@ -15,14 +15,14 @@
             %span{:class => "quality_grade {{ o.quality_grade }}"}
               {{ o.qualityGrade( ) }}
             %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}"}
-              %i.icon-identification
               {{ o.identifications_count }}
+              %i.icon-identification
             %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
-              %i.icon-chatbubble
               {{ o.comments_count }}
+              %i.icon-chatbubble
             %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
-              %i.fa.fa-star
               {{ o.faves_count }}
+              %i.fa.fa-star
             %span.pull-right{"am-time-ago" => "(!o.obscured || o.private_geojson ) && ( o.time_observed_at || o.observed_on )", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('observed_on') + ' ' + (o.time_observed_at || o.observed_on ) }}", "ng-hide": "o.obscured && !o.private_geojson"}
             %span.pull-right{"ng-show": "o.obscured && !o.private_geojson"}
               %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "true", short: "true", "ng-show": "o.obscured && !o.private_geojson" }

--- a/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml
@@ -28,14 +28,14 @@
             %span{:class => "quality_grade {{ o.quality_grade }}"}
               {{ o.qualityGrade( ) }}
             %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}" }
-              %i.icon-identification
               {{ o.identifications_count }}
+              %i.icon-identification
             %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
-              %i.icon-chatbubble
               {{ o.comments_count }}
+              %i.icon-chatbubble
             %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
-              %i.fa.fa-star
               {{ o.faves_count }}
+              %i.fa.fa-star
         %td.user
           %a.user.userimage{ href: "/people/{{ o.user.login }}", "ng-style": "shared.backgroundIf( o.user.icon_url )", title: "{{ o.user.login }}", target: "_self" }
             %i.icon-person{"ng-hide" => "o.user.icon_url"}


### PR DESCRIPTION
Closes #4165 

In the current Observation Grid view, long research quality names (such as translations) cause the count and age to overlap or get pushed together, affecting readability.

I updated the order of elements: The count now always appears before the icon to improve layout consistency and better differentiation between age and counts. Applied the same adjustment to the Table view for visual consistency across different views.

Alternative Consideration:
An alternative solution could involve enforcing a maximum length for research quality names to prevent layout issues.

## Example of new grid view, with extra long text for research grade

![image](https://github.com/user-attachments/assets/5d09e24c-536c-4367-b033-3de18bfe9c95)

## Example of new table view, with extra long text for research grade

![image](https://github.com/user-attachments/assets/d38263b6-2451-48b3-baa1-1345ffb94a61)



