### PR TITLE
fix: index wikipedia_url even if description is for en-US

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -98,7 +98,7 @@ class Taxon < ApplicationRecord
   has_and_belongs_to_many :colors, -> { distinct }
   has_many :taxon_descriptions, dependent: :destroy
   has_one :en_wikipedia_description,
-    -> { where( "locale='en' AND provider='Wikipedia'" ) },
+    -> { where( locale: %w(en en-US en-GB), provider: "Wikipedia" ) },
     class_name: "TaxonDescription"
   has_many :controlled_term_taxa, inverse_of: :taxon, dependent: :destroy
   # deprecated, remove when we're sure transition to taxon frameworks is complete

--- a/app/models/taxon_description.rb
+++ b/app/models/taxon_description.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TaxonDescription < ApplicationRecord
-  # locale can potential have a region, since the different localized
-  # wikipedias do support regional "variants"
+  # locale can potentially have a region, since the different localized
+  # wikipedias support regional "variants"
   belongs_to :taxon
 end

--- a/app/models/taxon_description.rb
+++ b/app/models/taxon_description.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
 class TaxonDescription < ApplicationRecord
+  # locale can potential have a region, since the different localized
+  # wikipedias do support regional "variants"
   belongs_to :taxon
 end


### PR DESCRIPTION
Some taxa were not getting indexed with a `wikipedia_url` b/c they did not have a `TaxonDescription` for the `en` locale, but they did have one for the `en-US` locale, e.g. https://www.inaturalist.org/taxa/231783-Strangalia-acuminata