### PR TITLE
Blocking removes users from each other's projects

### DIFF
--- a/app/models/project_user_invitation.rb
+++ b/app/models/project_user_invitation.rb
@@ -6,6 +6,8 @@ class ProjectUserInvitation < ApplicationRecord
   validates_presence_of :user_id, :invited_user_id, :project_id
   validates_uniqueness_of :invited_user_id, :scope => :project_id, :message => "has already been invited"
   validate :user_is_not_already_a_member
+  validate :user_has_not_blocked_owner
+  validate :owner_has_not_blocked_user
   after_create :email_user, :create_update_for_user
   after_destroy :destroy_updates
 
@@ -39,10 +41,26 @@ class ProjectUserInvitation < ApplicationRecord
   end
 
   def user_is_not_already_a_member
-    return true if project_id.blank?|| invited_user_id.blank?
+    return if project_id.blank? || invited_user_id.blank?
+
     if ProjectUser.where(:project_id => project_id, :user_id => invited_user_id).exists?
       errors.add(:invited_user_id, "is already a member of that project")
     end
-    true
+  end
+
+  def owner_has_not_blocked_user
+    return if project_id.blank? || invited_user_id.blank?
+
+    if UserBlock.where(user_id: project.user_id, blocked_user_id: invited_user_id).any?
+      errors.add(:invited_user_id, "is blocked by the owner of the project")
+    end
+  end
+
+  def user_has_not_blocked_owner
+    return if project_id.blank? || invited_user_id.blank?
+
+    if UserBlock.where(user_id: invited_user_id, blocked_user_id: project.user_id).any?
+      errors.add(:invited_user_id, "has blocked the owner of the project")
+    end
   end
 end

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -15,7 +15,7 @@ class UserBlock < ApplicationRecord
   validate :cant_block_staff
   validate :uniqueness_of_blocked_user, on: :create
 
-  after_create :destroy_friendships, :notify_staff_about_potential_problem_user
+  after_create :destroy_friendships, :notify_staff_about_potential_problem_user, :remove_from_projects
 
   def to_s
     "<UserBlock #{id} user_id: #{user_id}, blocked_user_id: #{blocked_user_id}>"
@@ -49,6 +49,12 @@ class UserBlock < ApplicationRecord
     true
   end
 
+  def remove_from_projects
+    [user, blocked_user].permutation.each do |(a, b)|
+      ProjectUser.joins(:project).where(user: a, project: {user: b}).destroy_all
+      ProjectUserInvitation.joins(:project).where(user: a, project: {user: b}).destroy_all
+    end
+  end
 
   def destroy_friendships
     Friendship.where( user_id: user_id, friend_id: blocked_user_id ).destroy_all

--- a/spec/models/project_user_invitation_spec.rb
+++ b/spec/models/project_user_invitation_spec.rb
@@ -29,6 +29,18 @@ describe ProjectUserInvitation do
       pui = ProjectUserInvitation.make(:project => pu.project, :invited_user => pu.user)
       expect( pui ).not_to be_valid
     end
+
+    it "should not be possible for someone who has blocked the project owner" do
+      project = Project.make!
+      user_block = UserBlock.make!(blocked_user: project.user)
+      expect( ProjectUserInvitation.new(project: project, user: user_block.user) ).not_to be_valid
+    end
+
+    it "should not be possible for someone the project owner has blocked" do
+      user_block = UserBlock.make!
+      project = Project.make!(project_type: 'umbrella', user: user_block.user)
+      expect( ProjectUserInvitation.new(project: project, user: user_block.blocked_user) ).not_to be_valid
+    end
   end
 
   describe ProjectUserInvitation, "deletion" do

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -30,6 +30,22 @@ describe ProjectUser, "creation" do
     expect(pu.user.subscriptions.where(:resource_type => "AssessmentSection", :resource_id => as)).to be_blank
   end
 
+  it "should be invalid of the user has blocked the project owner" do
+    user_block = UserBlock.make!
+    project = Project.make!(project_type: 'umbrella', user: user_block.user)
+    project_user = ProjectUser.new(project: project, user: user_block.blocked_user)
+    expect(project_user.save).to be_falsey
+    expect(project_user.errors.first.message).to include("has been blocked")
+  end
+
+  it "should be invalid of the project owner has blocked the user" do
+    user_block = UserBlock.make!
+    project = Project.make!(project_type: 'umbrella', user: user_block.blocked_user)
+    project_user = ProjectUser.new(project: project, user: user_block.user)
+    expect(project_user.save).to be_falsey
+    expect(project_user.errors.first.message).to include("has blocked the owner")
+  end
+
   it "should set curator_coordinate_access to observer by default" do
     expect( ProjectUser.make!.preferred_curator_coordinate_access ).to eq ProjectUser::CURATOR_COORDINATE_ACCESS_OBSERVER
   end

--- a/spec/models/user_block_spec.rb
+++ b/spec/models/user_block_spec.rb
@@ -54,6 +54,20 @@ describe UserBlock do
       UserBlock.create!( user: user, blocked_user: blocked_user )
       expect( blocked_user.followees ).not_to include user
     end
+
+    it "removes the blocked user from the user's projects" do
+      project = Project.make!( project_type: 'umbrella', user: user )
+      ProjectUser.make!( user: blocked_user, project: project )
+      UserBlock.create!( user: user, blocked_user: blocked_user )
+      expect( project.users ).not_to include( blocked_user )
+    end
+
+    it "removes the blocker from the blocked user's projects" do
+      project = Project.make!( project_type: 'umbrella', user: blocked_user )
+      ProjectUser.make!( user: user, project: project )
+      UserBlock.create!( user: user, blocked_user: blocked_user )
+      expect( project.users ).not_to include( user )
+    end
   end
   describe "prevents" do
     before do


### PR DESCRIPTION
Fixes https://github.com/inaturalist/inaturalist/issues/4108

Regardless of project type,
- When blocking a user:
  - remove blocker and blockee from one another's projects
  - delete any pending project invitations
- Prevent either user from adding the other to their project

This does not affect the requirements of any umbrella project.