### PR TITLE
fix: :bug: rounding could lead to truncation of significant zeroes

### DIFF
--- a/app/webpack/observations/show/components/map_details.jsx
+++ b/app/webpack/observations/show/components/map_details.jsx
@@ -31,6 +31,14 @@ class MapDetails extends React.Component {
     } );
   }
 
+  static sliceFloat( num ) {
+    if ( !num ) { return ""; }
+    const str = num.toString( );
+    const arr = str.split( "." );
+    if ( arr.length === 1 ) { return str; }
+    return `${arr[0]}.${arr[1].slice( 0, 5 )}`;
+  }
+
   constructor( ) {
     super( );
     this.state = {
@@ -166,8 +174,8 @@ class MapDetails extends React.Component {
             { " " }
             <span id="latlng" className="value">
               { hasCoords ? ( [
-                _.round( observation.latitude, 5 ),
-                _.round( observation.longitude, 5 )
+                MapDetails.sliceFloat( observation.latitude ),
+                MapDetails.sliceFloat( observation.longitude )
               ].join( ", " ) ) : ""}
             </span>
             { clipboardButton }


### PR DESCRIPTION
Fixes: https://github.com/inaturalist/inaturalist/issues/4252

**Solution**: This pull request addresses the issue by truncating the float to 5 decimal places instead of rounding. Truncating in this context is preferable as it avoids the introduction of rounding errors and maintains a precision of approximately 1 meter, which is sufficient for most needs.

Alternative Solutions Considered:

- Using `toFixed(5)` would result in trailing zeroes in all cases, which is undesirable.
- Using `NumberFormat` with `minimumFractionDigits` would have similar issues to lodash rounding, potentially leading to precision problems with floats.

By truncating the float using string converstion, it is ensured a consistent and accurate representation of the coordinates without unnecessary trailing zeroes.

Cheers
Hannes

## Example: 41.3251611, -79.1282972167
![image](https://github.com/user-attachments/assets/ea7d8b52-7710-4a4c-befa-19df2aa2e221)
