### PR TITLE
Add taxon inclusion / exclusion to Explore

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -198,6 +198,7 @@ var SearchController = function (
     page: 1,
     spam: false
   };
+  $scope.withoutTaxa = [];
   $scope.earthRadiusInKm = 6371;
   $scope.dragIconOffset = 20;
   $scope.dragRectDeltaXInPx = null;
@@ -472,6 +473,13 @@ var SearchController = function (
       // this will remove the autocomplete image since there's no taxon
       $scope.updateTaxonAutocomplete( );
       $scope.taxonInitialized = true;
+    }
+    if ( $scope.params.without_taxon_id ) {
+      TaxaFactory.show( $scope.params.without_taxon_id, iNaturalist.localeParams( ) )
+        .then( function ( response ) {
+          var taxa = TaxaFactory.responseToInstances( response );
+          $scope.withoutTaxa = taxa;
+        } );
     }
   };
   $scope.initializePlaceParams = function ( ) {
@@ -1172,10 +1180,18 @@ var SearchController = function (
       $scope.updateTaxonAutocomplete( );
       $scope.searchAndUpdateStats( );
     } else {
-      $scope.params.without_taxon_id = $scope.params.without_taxon_id
-        ? [$scope.params.without_taxon_id, taxon.id].join( "," )
-        : taxon.id;
+      $scope.witoutTaxa = $scope.witoutTaxa || [];
+      var existing = $scope.witoutTaxa.find( wt => wt.id === taxon.id );
+      if ( !existing ) {
+        $scope.withoutTaxa.push( taxon );
+      }
+      $scope.params.without_taxon_id = $scope.withoutTaxa.map( function ( wt ) { return wt.id; } ).join( "," );
     }
+  }
+
+  $scope.removeWithoutTaxon = function ( taxon ) {
+    $scope.withoutTaxa = $scope.withoutTaxa.filter( wt => wt.id !== taxon.id );
+    $scope.params.without_taxon_id = $scope.withoutTaxa.map( function ( wt ) { return wt.id; } ).join( "," );
   }
 
   $scope.filterByBounds = function ( ) {
@@ -2295,3 +2311,11 @@ var MapController = function (
     $scope.fullscreen = !$scope.fullscreen;
   };
 };
+document.addEventListener( 'click', function( e ) {
+  var details = [...document.querySelectorAll( 'details.explore-details-popover' )];
+  details.forEach( f => {
+    if ( !f.contains( e.target ) ) {
+      f.removeAttribute( "open" );
+    }
+  } );
+} );

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1181,7 +1181,7 @@ var SearchController = function (
       $scope.searchAndUpdateStats( );
     } else {
       $scope.witoutTaxa = $scope.witoutTaxa || [];
-      var existing = $scope.witoutTaxa.find( wt => wt.id === taxon.id );
+      var existing = $scope.witoutTaxa.find( function( wt ) { return wt.id === taxon.id; } );
       if ( !existing ) {
         $scope.withoutTaxa.push( taxon );
       }
@@ -1190,7 +1190,7 @@ var SearchController = function (
   }
 
   $scope.removeWithoutTaxon = function ( taxon ) {
-    $scope.withoutTaxa = $scope.withoutTaxa.filter( wt => wt.id !== taxon.id );
+    $scope.withoutTaxa = $scope.withoutTaxa.filter( function( wt ) { return wt.id !== taxon.id; } );
     $scope.params.without_taxon_id = $scope.withoutTaxa.map( function ( wt ) { return wt.id; } ).join( "," );
   }
 
@@ -2313,7 +2313,7 @@ var MapController = function (
 };
 document.addEventListener( 'click', function( e ) {
   var details = [...document.querySelectorAll( 'details.explore-details-popover' )];
-  details.forEach( f => {
+  details.forEach( function( f ) {
     if ( !f.contains( e.target ) ) {
       f.removeAttribute( "open" );
     }

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -2312,8 +2312,7 @@ var MapController = function (
   };
 };
 document.addEventListener( 'click', function( e ) {
-  var details = [...document.querySelectorAll( 'details.explore-details-popover' )];
-  details.forEach( function( f ) {
+  document.querySelectorAll( 'details.explore-details-popover' ).forEach( function( f ) {
     if ( !f.contains( e.target ) ) {
       f.removeAttribute( "open" );
     }

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1158,6 +1158,26 @@ var SearchController = function (
     $scope.drawing.manager.setMap( $rootScope.map );
   };
 
+  $scope.addTaxon = function( taxon ) {
+    $scope.selectedTaxon = new iNatModels.Taxon( taxon );
+    $scope.params.taxon_id = taxon.id;
+    $scope.updateTaxonAutocomplete( );
+    $scope.searchAndUpdateStats( );
+  }
+
+  $scope.subtractTaxon = function( taxon ) {
+    if ( $scope.params.taxon_id === taxon.id ) {
+      $scope.selectedTaxon = null;
+      $scope.params.taxon_id = null;
+      $scope.updateTaxonAutocomplete( );
+      $scope.searchAndUpdateStats( );
+    } else {
+      $scope.params.without_taxon_id = $scope.params.without_taxon_id
+        ? [$scope.params.without_taxon_id, taxon.id].join( "," )
+        : taxon.id;
+    }
+  }
+
   $scope.filterByBounds = function ( ) {
     $scope.params.lat = null;
     $scope.params.lng = null;

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -622,8 +622,10 @@ var SearchController = function (
         params: stateParams,
         selectedPlace: JSON.stringify( $scope.selectedPlace ),
         selectedTaxon: JSON.stringify( $scope.selectedTaxon ),
+        withoutTaxa: JSON.stringify( $scope.withoutTaxa ),
         mapBounds: $scope.mapBounds
       };
+
       currentSearch = urlParams;
     }
 
@@ -1579,6 +1581,9 @@ var SearchController = function (
       if ( state.selectedTaxon ) {
         state.selectedTaxon = new iNatModels.Taxon( JSON.parse( state.selectedTaxon ) );
       }
+      if ( state.withoutTaxa ) {
+        state.withoutTaxa = JSON.parse( state.withoutTaxa ).map( wt => new iNatModels.Taxon( wt ) );
+      }
       if ( state.selectedPlace ) {
         state.selectedPlace = new iNatModels.Place( JSON.parse( state.selectedPlace ) );
       }
@@ -1603,6 +1608,11 @@ var SearchController = function (
         // useful for selecting a taxon from the observations grid view
         $scope.params.taxon_id = state.params.taxon_id;
         $scope.initializeTaxonParams( );
+      }
+      if ( state.withoutTaxa !== $scope.withoutTaxa ) {
+        $scope.withoutTaxa = state.withoutTaxa;
+      } else if ( state.params && state.params.without_taxon_id !== $scope.params.without_taxon_id ) {
+        $scope.params.without_taxon_id = state.params.without_taxon_id;
       }
       var previousProcessedParams = ObservationsFactory.processParamsForAPI(
         previousParams,

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1582,7 +1582,8 @@ var SearchController = function (
         state.selectedTaxon = new iNatModels.Taxon( JSON.parse( state.selectedTaxon ) );
       }
       if ( state.withoutTaxa ) {
-        state.withoutTaxa = JSON.parse( state.withoutTaxa ).map( wt => new iNatModels.Taxon( wt ) );
+        state.withoutTaxa = JSON.parse( state.withoutTaxa )
+          .map( function( wt ) { return new iNatModels.Taxon( wt ) } );
       }
       if ( state.selectedPlace ) {
         state.selectedPlace = new iNatModels.Place( JSON.parse( state.selectedPlace ) );

--- a/app/assets/javascripts/ang/factories/observations.js.erb
+++ b/app/assets/javascripts/ang/factories/observations.js.erb
@@ -133,7 +133,7 @@ iNatAPI.factory( "ObservationsFactory", [
         } );
         // ...and then consolidate their responses
         return Promise.all( promises ).then( function ( promiseResults ) {
-          const taxa = _.flatten( promiseResults );
+          var taxa = _.flatten( promiseResults );
           var newResults = speciesCountsResponse.data.results.map( function( res ) {
             res.taxon = taxa.find( function( taxon ) { return taxon.id === res.taxon.id; } );
             return res;

--- a/app/assets/javascripts/ang/factories/observations.js.erb
+++ b/app/assets/javascripts/ang/factories/observations.js.erb
@@ -114,10 +114,34 @@ iNatAPI.factory( "ObservationsFactory", [
       return shared.basicGet( url, _.extend( { }, params, { fields: V2_OBSERVATION_FIELDS } ) );
     };
     var speciesCounts = function ( params ) {
+      // First we need to get the actual counts response
       var url = "/observations/species_counts";
       return shared.basicGet( url, _.extend( { }, params, {
-        fields: { taxon: V2_TAXON_FIELDS }
-      } ) );
+        fields: { taxon: { id: true } }
+      } ) ).then( function( speciesCountsResponse ) {
+        // Then we want to load taxa including ancestors, which are only
+        // available from the details endpoint. That endpoint only accepts 30
+        // IDs at a time, so we need to make multiple requests...
+        var taxonIds = speciesCountsResponse.data.results.map( function( res ) { return res.taxon.id; } );
+        var promises = _.chunk( taxonIds, 30 ).map( function ( taxonIdsChunk ) {
+          return shared.basicGet(
+            "/taxa/" + taxonIdsChunk.join( "," ),
+            { per_page: 30, fields: V2_TAXON_FIELDS }
+          ).then( function( taxaResponse ) {
+            return taxaResponse.data.results;
+          } );
+        } );
+        // ...and then consolidate their responses
+        return Promise.all( promises ).then( function ( promiseResults ) {
+          const taxa = _.flatten( promiseResults );
+          var newResults = speciesCountsResponse.data.results.map( function( res ) {
+            res.taxon = taxa.find( function( taxon ) { return taxon.id === res.taxon.id; } );
+            return res;
+          } )
+          speciesCountsResponse.data.results = newResults;
+          return speciesCountsResponse;
+        } );
+      } );
     };
     var identifiers = function ( params ) {
       var url = "/observations/identifiers";

--- a/app/assets/javascripts/ang/factories/observations.js.erb
+++ b/app/assets/javascripts/ang/factories/observations.js.erb
@@ -58,6 +58,9 @@ iNatAPI.constant( "V2_TAXON_FIELDS", {
     iconic_taxon_name: true,
     is_active: true,
     preferred_common_name: true,
+    preferred_common_names: {
+      name: true
+    },
     rank: true,
     rank_level: true
   },
@@ -114,34 +117,13 @@ iNatAPI.factory( "ObservationsFactory", [
       return shared.basicGet( url, _.extend( { }, params, { fields: V2_OBSERVATION_FIELDS } ) );
     };
     var speciesCounts = function ( params ) {
-      // First we need to get the actual counts response
       var url = "/observations/species_counts";
       return shared.basicGet( url, _.extend( { }, params, {
-        fields: { taxon: { id: true } }
-      } ) ).then( function( speciesCountsResponse ) {
-        // Then we want to load taxa including ancestors, which are only
-        // available from the details endpoint. That endpoint only accepts 30
-        // IDs at a time, so we need to make multiple requests...
-        var taxonIds = speciesCountsResponse.data.results.map( function( res ) { return res.taxon.id; } );
-        var promises = _.chunk( taxonIds, 30 ).map( function ( taxonIdsChunk ) {
-          return shared.basicGet(
-            "/taxa/" + taxonIdsChunk.join( "," ),
-            { per_page: 30, fields: V2_TAXON_FIELDS }
-          ).then( function( taxaResponse ) {
-            return taxaResponse.data.results;
-          } );
-        } );
-        // ...and then consolidate their responses
-        return Promise.all( promises ).then( function ( promiseResults ) {
-          var taxa = _.flatten( promiseResults );
-          var newResults = speciesCountsResponse.data.results.map( function( res ) {
-            res.taxon = taxa.find( function( taxon ) { return taxon.id === res.taxon.id; } );
-            return res;
-          } )
-          speciesCountsResponse.data.results = newResults;
-          return speciesCountsResponse;
-        } );
-      } );
+        include_ancestors: true,
+        fields: {
+          taxon: V2_TAXON_FIELDS
+        }
+      } ) );
     };
     var identifiers = function ( params ) {
       var url = "/observations/identifiers";

--- a/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
@@ -8,6 +8,21 @@
           {{ t.conservation_status.status }}
         %div{ "ng-show" => "t.establishmentMeansCode( ) && !t.conservationStatus( )", :class => "corner establishment-means {{ t.establishmentMeansCode( ) }}", title: "{{ shared.taxonMeansTitle( t ) }}" }
           {{ t.establishmentMeansCode( ) }}
+        %div{ class: "corner context-menu" }
+          %details.btn.btn-nostyle
+            %summary
+              %i.fa.fa-sliders
+            %div.menu
+              %ul
+                %li
+                  Add / Subtract Ancestor Taxa
+                  %ul
+                    %li{ "ng-repeat": "a in t.ancestors" }
+                      %button.btn.btn-primary.btn-xs{ "ng-click": "addTaxon(a)", "ng-disabled": "{{ a.id === params.taxon_id }}" }
+                        %i.fa.fa-plus
+                      %button.btn.btn-default.btn-xs{ "ng-click": "subtractTaxon(a)", "ng-disabled": "{{ a.id !== params.taxon_id && selectedTaxon.ancestor_ids.indexOf( a.id ) >= 0 }}" }
+                        %i.fa.fa-minus
+                      {{ a.name }}
         .photometa
           %a{ "ng-href": "{{ extendBrowserLocation({ taxon_id: t.id, view: null, page: null }) }}", target: "_self"  }
             {{ shared.t( 'x_observations', { count: (t.resultCount == 1 ? t.resultCount : shared.numberWithCommas( t.resultCount ) ) } ) }}

--- a/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
@@ -9,20 +9,20 @@
         %div{ "ng-show" => "t.establishmentMeansCode( ) && !t.conservationStatus( )", :class => "corner establishment-means {{ t.establishmentMeansCode( ) }}", title: "{{ shared.taxonMeansTitle( t ) }}" }
           {{ t.establishmentMeansCode( ) }}
         %div{ class: "corner context-menu" }
-          %details.btn.btn-nostyle
+          %details.btn.btn-nostyle.explore-details-popover
             %summary
               %i.fa.fa-sliders
-            %div.menu
+            .menu
               %ul
                 %li
                   Add / Subtract Ancestor Taxa
                   %ul
-                    %li{ "ng-repeat": "a in t.ancestors" }
+                    %li.ancestor{ "ng-repeat": "a in t.ancestors" }
                       %button.btn.btn-primary.btn-xs{ "ng-click": "addTaxon(a)", "ng-disabled": "{{ a.id === params.taxon_id }}" }
                         %i.fa.fa-plus
                       %button.btn.btn-default.btn-xs{ "ng-click": "subtractTaxon(a)", "ng-disabled": "{{ a.id !== params.taxon_id && selectedTaxon.ancestor_ids.indexOf( a.id ) >= 0 }}" }
                         %i.fa.fa-minus
-                      {{ a.name }}
+                      %inat-taxon.title.split-taxon{ taxon: "a", url: "/taxa/{{ a.id }}" }
         .photometa
           %a{ "ng-href": "{{ extendBrowserLocation({ taxon_id: t.id, view: null, page: null }) }}", target: "_self"  }
             {{ shared.t( 'x_observations', { count: (t.resultCount == 1 ? t.resultCount : shared.numberWithCommas( t.resultCount ) ) } ) }}

--- a/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
@@ -15,13 +15,13 @@
             .menu
               %ul
                 %li
-                  Add / Subtract Ancestor Taxa
+                  {{ shared.t( 'include_slash_exclude_ancestor_taxa' ) }}
                   %ul
                     %li.ancestor{ "ng-repeat": "a in t.ancestors" }
-                      %button.btn.btn-primary.btn-xs{ "ng-click": "addTaxon(a)", "ng-disabled": "{{ a.id === params.taxon_id }}" }
-                        %i.fa.fa-plus
-                      %button.btn.btn-default.btn-xs{ "ng-click": "subtractTaxon(a)", "ng-disabled": "{{ a.id !== params.taxon_id && selectedTaxon.ancestor_ids.indexOf( a.id ) >= 0 }}" }
-                        %i.fa.fa-minus
+                      %button.btn.btn-primary.btn-xs{ "ng-click": "addTaxon(a)", "ng-disabled": "{{ a.id === params.taxon_id }}", "aria-label": "{{ shared.t( 'include__taxon' ) }}", title: "{{ shared.t( 'include__taxon' ) }}" }
+                        %i.fa.fa-plus{ "aria-hidden": true }
+                      %button.btn.btn-default.btn-xs{ "ng-click": "subtractTaxon(a)", "ng-disabled": "{{ a.id !== params.taxon_id && selectedTaxon.ancestor_ids.indexOf( a.id ) >= 0 }}", "aria-label": "{{ shared.t( 'exclude__taxon' ) }}", title: "{{ shared.t( 'exclude__taxon' ) }}" }
+                        %i.fa.fa-minus{ "aria-hidden": true }
                       %inat-taxon.title.split-taxon{ taxon: "a", url: "/taxa/{{ a.id }}" }
         .photometa
           %a{ "ng-href": "{{ extendBrowserLocation({ taxon_id: t.id, view: null, page: null }) }}", target: "_self"  }

--- a/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/taxa_grid.html.haml
@@ -8,7 +8,7 @@
           {{ t.conservation_status.status }}
         %div{ "ng-show" => "t.establishmentMeansCode( ) && !t.conservationStatus( )", :class => "corner establishment-means {{ t.establishmentMeansCode( ) }}", title: "{{ shared.taxonMeansTitle( t ) }}" }
           {{ t.establishmentMeansCode( ) }}
-        %div{ class: "corner context-menu" }
+        %div{ class: "corner context-menu", "ng-show": "currentUser && (currentUser.roles || []).indexOf('admin') >= 0" }
           %details.btn.btn-nostyle.explore-details-popover
             %summary
               %i.fa.fa-sliders

--- a/app/assets/stylesheets/observations/search.scss
+++ b/app/assets/stylesheets/observations/search.scss
@@ -1117,6 +1117,47 @@ $photo-count-line-width: 1px;
   background-color:#D12F19;
 }
 
+#taxa-grid {
+  .corner {
+    // We want z-index so the details appears over subsequent elements, but
+    // only when it's open
+    &.context-menu:has(details[open]) {
+      z-index: 1;
+    }
+    &.context-menu {
+      left: 0;
+      right: auto;
+      background-color: transparent;
+      details:hover {
+        summary {
+          color: white;
+        }
+      }
+      summary {
+        list-style: none;
+        width: 25px;
+        height: 25px;
+        text-shadow: 0 1px 5px rgba(0, 0, 0, .25);;
+      }
+      .menu {
+        box-shadow: 0 1px 10px rgba(0, 0, 0, .25);
+        background-color: white;
+        border: 0 transparent;
+        color: black;
+        text-align: start;
+        padding: 5px;
+        ul {
+          list-style: none;
+          padding-inline-start: 0px;
+          li {
+            padding: 3px;
+          }
+        }
+      }
+    }
+  }
+}
+
 #taxa-grid .photometa {
   position: absolute;
   top: 182px;

--- a/app/assets/stylesheets/observations/search.scss
+++ b/app/assets/stylesheets/observations/search.scss
@@ -1189,12 +1189,28 @@ $photo-count-line-width: 1px;
         list-style: none;
         width: 25px;
         height: 25px;
-        text-shadow: 0 1px 5px rgba(0, 0, 0, .25);;
+        text-shadow: 0 1px 5px rgba(0, 0, 0, .25);
+
+        &::-webkit-details-marker {
+          display: none;
+        }
       }
       .ancestor {
         display: flex;
         gap: 5px;
         align-items: center;
+      }
+    }
+  }
+}
+@-moz-document url-prefix() {
+  #taxa-grid {
+    .corner {
+      .ancestor {
+        i.fa {
+          position: relative;
+          top: 1px;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/observations/search.scss
+++ b/app/assets/stylesheets/observations/search.scss
@@ -389,6 +389,29 @@ inat-taxon.split-taxon .icon {display: none;}
 #filter-container,
 #filters .primary-filters {
   margin-top: 20px;
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  margin-inline-end: 5px;
+
+  > button {
+    margin: 0;
+    color: #fff;
+    background: $btn-orange;
+  }
+
+  .without-taxa {
+    z-index: 2;
+    position: relative;
+    li {
+      display: flex;
+      align-items: center;
+      button {
+        position: relative;
+        top: 1px;
+      }
+    }
+  }
 }
 #filters .form-control {
   display: inline-block;
@@ -842,10 +865,6 @@ inat-taxon.split-taxon .icon {display: none;}
 #subview-controls .btn-default, .btn.places {
   padding: 6px 12px 6px;
 }
-#view-controls.open .btn-default.places {
-  color: #fff;
-  background: $btn-orange;
-}
 #place-name-input {margin-inline-start: 0;}
 #place-name-input button {
   background-color: $btn-orange;
@@ -1117,6 +1136,39 @@ $photo-count-line-width: 1px;
   background-color:#D12F19;
 }
 
+.explore-details-popover {
+  position: relative;
+  &:hover {
+    cursor: pointer;
+  }
+  .btn-xs {
+    position: relative;
+    top: -1px;
+  }
+  .menu {
+    position: absolute;
+    box-shadow: 0 1px 10px rgba(0, 0, 0, .25);
+    background-color: white;
+    border: 0 transparent;
+    color: black;
+    text-align: start;
+    padding: 5px;
+    ul {
+      list-style: none;
+      padding-inline-start: 0px;
+      margin-bottom: 0;
+      li {
+        padding: 3px;
+
+        .split-taxon .display-name,
+        .split-taxon .secondary-name {
+          display: inline;
+        }
+      }
+    }
+  }
+}
+
 #taxa-grid {
   .corner {
     // We want z-index so the details appears over subsequent elements, but
@@ -1139,20 +1191,10 @@ $photo-count-line-width: 1px;
         height: 25px;
         text-shadow: 0 1px 5px rgba(0, 0, 0, .25);;
       }
-      .menu {
-        box-shadow: 0 1px 10px rgba(0, 0, 0, .25);
-        background-color: white;
-        border: 0 transparent;
-        color: black;
-        text-align: start;
-        padding: 5px;
-        ul {
-          list-style: none;
-          padding-inline-start: 0px;
-          li {
-            padding: 3px;
-          }
-        }
+      .ancestor {
+        display: flex;
+        gap: 5px;
+        align-items: center;
       }
     }
   }

--- a/app/views/observations/index.html.haml
+++ b/app/views/observations/index.html.haml
@@ -23,7 +23,7 @@
   %meta{ name: "twitter:card", content: "summary" }
 #main-container{ "ng-app": "ObservationSearch", "ng-controller": "SearchController" }
   .container.container-fixed
-    .row.form
+    .row
       .col-xs-12
         #filters.clear
           %h1= t :observations
@@ -38,13 +38,24 @@
                   {{ numFiltersSet }}
             .dropdown-menu.dropdown-menu-right{"ng-include": "'ang/templates/observation_search/filter_menu.html'", onload: "onFiltersLoad( )"}
           .form-inline.pull-right.primary-filters
-            %input.form-control{ placeholder: t( "ranks.species" ), name: "taxon_name", value: params[:taxon_name] }
+            %div
+              %input.form-control{ placeholder: t( "ranks.species" ), name: "taxon_name", value: params[:taxon_name] }
+              .without-taxa.ng-cloak{ "ng-if": "withoutTaxa && withoutTaxa.length > 0" }
+                %details.explore-details-popover
+                  %summary
+                    Without {{ withoutTaxa ? withoutTaxa.length : 0 }} taxa
+                  .menu
+                    %ul
+                      %li{ "ng-repeat": "t in withoutTaxa" }
+                        %inat-taxon.title.split-taxon{ taxon: "t", url: "/taxa/{{ t.id }}" }
+                        %button.btn.btn-nostyle{ "ng-click": "removeWithoutTaxon( t )" }
+                          %i.glyphicon.glyphicon-remove-circle
             %span#place-name-input
               :ruby
                 # Note that if you give this a name like place_name, Chrome will apply its address autocomplete and potentiall obscure results.
                 # https://github.com/inaturalist/inaturalist/issues/2198
               %input#place_name.form-control{ name: "primary_q2", placeholder: t(:location), type: "text", "ng-model": "placeSearch" }
-              %button.btn.btn-default{ type: "button", "ng-click": "focusOnSearchedPlace( )" }= t(:go)
+            %button.btn.btn-default{ type: "button", "ng-click": "focusOnSearchedPlace( )" }= t(:go)
   #stats-container
     .container.container-fixed
       .row

--- a/app/views/observations/index.html.haml
+++ b/app/views/observations/index.html.haml
@@ -43,13 +43,13 @@
               .without-taxa.ng-cloak{ "ng-if": "withoutTaxa && withoutTaxa.length > 0" }
                 %details.explore-details-popover
                   %summary
-                    Without {{ withoutTaxa ? withoutTaxa.length : 0 }} taxa
+                    {{ shared.t( 'excluding_x_taxa', { count: withoutTaxa ? withoutTaxa.length : 0 } ) }}
                   .menu
                     %ul
                       %li{ "ng-repeat": "t in withoutTaxa" }
                         %inat-taxon.title.split-taxon{ taxon: "t", url: "/taxa/{{ t.id }}" }
-                        %button.btn.btn-nostyle{ "ng-click": "removeWithoutTaxon( t )" }
-                          %i.glyphicon.glyphicon-remove-circle
+                        %button.btn.btn-nostyle{ "ng-click": "removeWithoutTaxon( t )", "aria-label": "{{ shared.t( 'remove' ) }}", title: "{{ shared.t( 'remove' ) }}" }
+                          %i.glyphicon.glyphicon-remove-circle{ "aria-hidden": true }
             %span#place-name-input
               :ruby
                 # Note that if you give this a name like place_name, Chrome will apply its address autocomplete and potentiall obscure results.

--- a/app/webpack/projects/show/ducks/project.jsx
+++ b/app/webpack/projects/show/ducks/project.jsx
@@ -123,7 +123,6 @@ export function fetchMembers( ) {
       id: project.id,
       per_page: 100,
       order_by: "login",
-      skip_counts: true,
       fields: { user: USER_FIELDS }
     };
     if ( config.currentUser ) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2059,10 +2059,20 @@ en:
   # Taxonomic rank, e.g. "genus," "subfamily", "kingdom", etc.
   exact_rank: Exact Rank
   except: except
+  # Label for a button that filters an observation search so it does not
+  # include observations of a specific taxon
+  exclude__taxon: Exclude
   exclude_places: Exclude Places
   exclude_projects: Exclude Projects
   exclude_taxa: Exclude Taxa
   exclude_users: Exclude Users
+  # Shows how many taxa have been excluded from an observation search
+  excluding_x_taxa:
+    zero: Excluding %{count} taxa
+    one: Excluding %{count} taxon
+    few: Excluding %{count} taxa
+    many: Excluding %{count} taxa
+    other: Excluding %{count} taxa
   exclusion_filters: Exclusion Filters
   existing_flags: Existing Flags
   exit_full_screen: "Exit Full Screen"
@@ -2553,8 +2563,16 @@ en:
   inaturalist_network_affiliation: iNaturalist Network Affiliation
   # Label for messages you've received
   inbox: Inbox
+  # Label for a button that filters an observation search so it only includes
+  # observations of a specific taxon
+  include__taxon: Include
   include_places: Include Places
   include_projects: Include Projects
+  # Title for an array of options that allows the user to include or exclude
+  # the taxa that contain another taxon from an observation search, e.g. if
+  # the search results include Homo sapiens, the user could choose to refine
+  # the search to only Mammalia, or exclude all observations of Mammalia
+  include_slash_exclude_ancestor_taxa: Include / Exclude Ancestor Taxa
   include_suggestions_not_seen_nearby: Include suggestions not seen nearby
   include_suggestions_not_expected_nearby: Include suggestions not expected nearby
   include_taxa: Include Taxa


### PR DESCRIPTION
* Add buttons to taxon search results in Explore to refine the search by an ancestor of that taxon or exclude an ancestor of that taxon (staff-only for now)
* Show the currently selected values for `without_taxon_id` below the taxon autocomplete in the Explore header