### PR TITLE
#4288 not showing followButton with not logged users

### DIFF
--- a/app/webpack/observations/show/components/app.jsx
+++ b/app/webpack/observations/show/components/app.jsx
@@ -249,7 +249,7 @@ const App = ( {
                   </SplitButton>
                 </Col>
               )
-              : ( <FollowButtonContainer /> ) }
+                : config && config.currentUser && ( <FollowButtonContainer /> ) }
           </Row>
           <Row>
             <Col xs={12}>


### PR DESCRIPTION
I think it’s better to simply not display the button rather than disabling it. Currently, it also shows errors in the console if you click on it.
