### PR TITLE
#4288 not showing followButton with not logged users

### DIFF
--- a/app/webpack/observations/show/components/app.jsx
+++ b/app/webpack/observations/show/components/app.jsx
@@ -249,7 +249,7 @@ const App = ( {
                   </SplitButton>
                 </Col>
               )
-              : ( <FollowButtonContainer /> ) }
+                : config && config.currentUser && ( <FollowButtonContainer /> ) }
           </Row>
           <Row>
             <Col xs={12}>


### PR DESCRIPTION
#4288 
I think it’s better to simply not display the button rather than disabling it. Currently, it also shows errors in the console if you click on it.
![image](https://github.com/user-attachments/assets/b443595e-94b0-4c87-a0fc-5e4ca59df24c)

This is my first time contributing to an open source project; any feedback is welcome :)