### PR TITLE
Small refactor of CohortLifecycle

### DIFF
--- a/app/models/segmentation_statistic.rb
+++ b/app/models/segmentation_statistic.rb
@@ -21,12 +21,12 @@ class SegmentationStatistic < ApplicationRecord
 
   def self.generate_segmentation_data_for_interval( start_date, end_date, use_database: false )
     segmentation_data = {}
-    current_date = end_date
+    iteration_date = end_date
     num_days = ( end_date.to_date - start_date.to_date ).to_i
     num_days.times do
-      puts "Processing #{current_date}..."
-      users_from_kibana_data( current_date, segmentation_data )
-      current_date -= 1.day
+      puts "Processing #{iteration_date}..."
+      users_from_kibana_data( iteration_date, segmentation_data )
+      iteration_date -= 1.day
     end
     users_from_db( end_date, segmentation_data ) if use_database
     segmentation_data


### PR DESCRIPTION
Related to #4285

* Uses dates throughout the script instead of times
* Accepts date as a method parameter
  * As a result can be run on days other than today
  * This will help prevent issues around daylight savings. We can schedule the task for early in the day UTC to run on data from the previous day UTC, and the schedule can stay the say regardless of local DST