### PR TITLE
feat: add updater field in observation ofvs

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -177,6 +177,7 @@ class Observation < ApplicationRecord
         indexes :user_id, type: "integer"
         indexes :uuid, type: "keyword"
         indexes :value, type: "keyword"
+        indexes :updater_id, type: "integer"
         indexes :value_ci, type: "text", analyzer: "keyword_analyzer"
       end
       # TODO Remove out_of_range from the index

--- a/app/models/observation_field_value.rb
+++ b/app/models/observation_field_value.rb
@@ -315,6 +315,7 @@ class ObservationFieldValue < ApplicationRecord
       name_ci: observation_field.name,
       value: self.value,
       value_ci: self.value,
+      updater_id: updater_id,
       user_id: user_id
     }
     # make sure taxon_id is an integer

--- a/app/webpack/observations/show/components/observation_field_value.jsx
+++ b/app/webpack/observations/show/components/observation_field_value.jsx
@@ -134,22 +134,22 @@ class ObservationFieldValue extends React.Component {
         <div className="added-by">
           { ofv.user && (
           <div>
-          <div className="view">
-            { I18n.t( "label_colon", { label: I18n.t( "added_by" ) } ) }
-          </div>
-          <a href={`/people/${ofv.user.login}`}>
-            { ofv.user.login }
-          </a>
+            <div className="view">
+              { I18n.t( "label_colon", { label: I18n.t( "added_by" ) } ) }
+            </div>
+            <a href={`/people/${ofv.user.login}`}>
+              { ofv.user.login }
+            </a>
           </div>
           ) }
           { ofv.updater && (
           <div>
-          <div className="view">
-            { I18n.t( "label_colon", { label: I18n.t( "last_edited_by" ) } ) }
-          </div>
-          <a href={`/people/${ofv.updater.login}`}>
-            { ofv.updater.login }
-          </a>
+            <div className="view">
+              { I18n.t( "label_colon", { label: I18n.t( "last_edited_by" ) } ) }
+            </div>
+            <a href={`/people/${ofv.updater.login}`}>
+              { ofv.updater.login }
+            </a>
           </div>
           ) }
         </div>

--- a/app/webpack/observations/show/components/observation_field_value.jsx
+++ b/app/webpack/observations/show/components/observation_field_value.jsx
@@ -132,12 +132,26 @@ class ObservationFieldValue extends React.Component {
     if ( ofv.user ) {
       addedBy = (
         <div className="added-by">
+          { ofv.user && (
+          <div>
           <div className="view">
             { I18n.t( "label_colon", { label: I18n.t( "added_by" ) } ) }
           </div>
           <a href={`/people/${ofv.user.login}`}>
             { ofv.user.login }
           </a>
+          </div>
+          ) }
+          { ofv.updater && (
+          <div>
+          <div className="view">
+            { I18n.t( "label_colon", { label: I18n.t( "last_edited_by" ) } ) }
+          </div>
+          <a href={`/people/${ofv.updater.login}`}>
+            { ofv.updater.login }
+          </a>
+          </div>
+          ) }
         </div>
       );
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2666,6 +2666,7 @@ en:
   large: large
   last_active_with_date: "Last Active: %{date}"
   last_confirmed_observation: Last confirmed observation
+  # label for a field displaying the username of the last user who edited this observation field
   last_edited_by: Last edited by
   last_observation: Last observation
   last_observation_caps: LAST OBSERVATION

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2666,6 +2666,7 @@ en:
   large: large
   last_active_with_date: "Last Active: %{date}"
   last_confirmed_observation: Last confirmed observation
+  last_edited_by: Last edited by
   last_observation: Last observation
   last_observation_caps: LAST OBSERVATION
   last_seen: Last seen


### PR DESCRIPTION
fix: #4184

API PR: https://github.com/inaturalist/iNaturalistAPI/pull/480
First time with Ruby, Im sorry if I made some mistake.

This approach only works for new obfv updates. in ElasticSearch we are not persisting the updater, but it is where we are taking the rest of the data from. I couldn't find a best way to do this.
I expected to collect this data from postgres but we r using elastic for this. Why?
Thanks for the feedback :)