### PR TITLE
Update old "Darwin Core Archives" link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7491,7 +7491,7 @@ en:
                 rel="nofollow noreferrer noopener"
                 href="http://www.inaturalist.org/observations/gbif-observations-dwca.zip">DarwinCore
                 Archive (DwC-A) for GBIF</a>: this is the <a
-                href="https://github.com/gbif/ipt/wiki/DwCAHowToGuide#what-is-darwin-core-archive-dwc-a">DwC-A</a>
+                href="https://ipt.gbif.org/manual/en/ipt/latest/dwca-guide">DwC-A</a>
                 file we generate for GBIF to ingest, so it should not contain
                 anything that isn't in GBIF, but if you want the whole archive,
                 you can download it. It is a very large zip file containing


### PR DESCRIPTION
The old link now redirects to this link