### PR TITLE
#3818 fix broken links containing at sign

### DIFF
--- a/app/webpack/shared/components/user_text.jsx
+++ b/app/webpack/shared/components/user_text.jsx
@@ -80,7 +80,7 @@ const CONFIG = {
 class UserText extends React.Component {
   // Imperfect solution until we can get an API endpoint to check for the existence of these users
   static hyperlinkMentions( text ) {
-    return text.replace( /(\B)@([A-z][\\\w\\\-_]*)/g, "$1<a href=\"/people/$2\">@$2</a>" );
+    return text.replace( /(\B)(?<!\/)@([A-z][\\\w\\\-_]*)/g, "$1<a href=\"/people/$2\">@$2</a>" );
   }
 
   constructor( ) {


### PR DESCRIPTION
fix #3818
It's not the best solution, but I think it's acceptable. I would first check in Elasticsearch how many descriptions contain the characters "/@" in cases where it's not part of a link. I can't think of a reason why someone would do that, but I would check just in case..

I would do it myself, but I don't have access to the database (or I don't know how to access it). I appreciate any tips on how to populate my local environment with real data.