### PR TITLE
refactor: split DQA help into smaller strings

### DIFF
--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -1030,6 +1030,7 @@ time {
   .popover-data-quality-link {
     color: $bootstrap-link-color;
     cursor: pointer;
+    margin-inline-start: 5px;
     i {
       padding: 0px 2px;
     }

--- a/app/webpack/observations/show/components/assessment.jsx
+++ b/app/webpack/observations/show/components/assessment.jsx
@@ -155,23 +155,11 @@ class Assessment extends React.Component {
                           __html: I18n.t( "views.observations.show.dqa_help_casual_voted_out_html" )
                         }}
                       />
-                      <li
-                        dangerouslySetInnerHTML={{
-                          __html: I18n.t( "views.observations.show.dqa_help_casual_opted_out_maverick_html" )
-                        }}
-                      />
+                      <li>{ I18n.t( "views.observations.show.dqa_help_casual_opted_out_maverick" ) }</li>
                     </ul>
-                    <p
-                      dangerouslySetInnerHTML={{
-                        __html: I18n.t( "views.observations.show.dqa_help_system_lead_html" )
-                      }}
-                    />
+                    <p>{ I18n.t( "views.observations.show.dqa_help_system_lead" ) }</p>
                     <ul>
-                      <li
-                        dangerouslySetInnerHTML={{
-                          __html: I18n.t( "views.observations.show.dqa_help_system_captive_vote_html" )
-                        }}
-                      />
+                      <li>{ I18n.t( "views.observations.show.dqa_help_system_captive_vote" ) }</li>
                     </ul>
                   </div>
                 </Popover>

--- a/app/webpack/observations/show/components/assessment.jsx
+++ b/app/webpack/observations/show/components/assessment.jsx
@@ -1,4 +1,5 @@
-
+// We use dangerouslySetInnerHTML a lot in this file
+/* eslint-disable react/no-danger */
 import React from "react";
 import PropTypes from "prop-types";
 import {
@@ -71,14 +72,108 @@ class Assessment extends React.Component {
                   <div className="header">
                     { I18n.t( "data_quality_assessment" ) }
                   </div>
-                  <div
-                    className="contents"
-                    dangerouslySetInnerHTML={{
-                      __html: I18n.t( "views.observations.show.quality_assessment_help4_html", {
-                        site_name: SITE.short_name
-                      } )
-                    }}
-                  />
+                  <div className="contents">
+                    <p
+                      dangerouslySetInnerHTML={{
+                        __html: I18n.t( "views.observations.show.dqa_help_needs_id_lead_html" )
+                      }}
+                    />
+                    <ul>
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_needs_id_has_a_date_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_needs_id_is_georeferenced_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_needs_id_has_photos_or_sounds_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_needs_id_is_not_of_human_html" )
+                        }}
+                      />
+                    </ul>
+                    <p
+                      dangerouslySetInnerHTML={{
+                        __html: I18n.t( "views.observations.show.dqa_help_research_grade_lead_html" )
+                      }}
+                    />
+                    <ul>
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_research_grade_community_species_html", {
+                            site_name: SITE.short_name
+                          } )
+                        }}
+                      />
+                    </ul>
+                    <p
+                      dangerouslySetInnerHTML={{
+                        __html: I18n.t( "views.observations.show.dqa_help_casual_lead_html" )
+                      }}
+                    />
+                    <ul>
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_day_year_not_accurate_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_location_not_accurate_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_not_wild_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_not_organism_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_not_recent_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_not_one_subject_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_voted_out_html" )
+                        }}
+                      />
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_casual_opted_out_maverick_html" )
+                        }}
+                      />
+                    </ul>
+                    <p
+                      dangerouslySetInnerHTML={{
+                        __html: I18n.t( "views.observations.show.dqa_help_system_lead_html" )
+                      }}
+                    />
+                    <ul>
+                      <li
+                        dangerouslySetInnerHTML={{
+                          __html: I18n.t( "views.observations.show.dqa_help_system_captive_vote_html" )
+                        }}
+                      />
+                    </ul>
+                  </div>
                 </Popover>
               )}
               className="cool"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7668,6 +7668,79 @@ en:
           shares licensed "Research Grade" observations with a number of data
           partners for use in science and conservation.
         disagreement_count_desc: "# of identified taxa that are not among a taxon's ancestors"
+        # Leads a list of requirements for an observation to be Needs ID
+        dqa_help_needs_id_lead_html: |
+          The data quality assessment is a summary of an observation's
+          accuracy. All observations start as <strong>"casual"</strong>
+          grade, and become <strong>"needs ID"</strong> when
+        # One of a list of requirements an observation must meet to be in the Needs ID category
+        dqa_help_needs_id_has_a_date_html: the observation <strong>has a date</strong>
+        # One of a list of requirements an observation must meet to be in the Needs ID category
+        dqa_help_needs_id_is_georeferenced_html: the observation <strong>is georeferenced</strong> (i.e. has lat/lon coordinates)
+        # One of a list of requirements an observation must meet to be in the Needs ID category
+        dqa_help_needs_id_has_photos_or_sounds_html: the observation <strong>has photos or sounds</strong>
+        # One of a list of requirements an observation must meet to be in the Needs ID category
+        dqa_help_needs_id_is_not_of_human_html: the observation <strong>isn't of a human</strong>
+        # Leads a list of requirements for an observation to be Research Grade
+        dqa_help_research_grade_lead_html: Observations become <strong>"research grade"</strong> when
+        # One of a list of requirements an observation must meet to be in the Research Grade category
+        dqa_help_research_grade_community_species_html: |
+          the %{site_name} <strong>community agrees on species-level ID or
+          lower</strong>, i.e. when more than 2/3 of identifiers agree on a
+          taxon (if the community has voted that the Community Taxon can no
+          longer be improved, this reverts to subfamily-level ID or lower)
+        # Leads a list of ways an observation to revert to Casual status
+        dqa_help_casual_lead_html: |
+          Observations will revert to <strong>"casual"</strong> if the above
+          conditions aren't met or the community agrees
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_day_year_not_accurate_html: |
+          the <strong>day and year do not look accurate</strong> (e.g. snow
+          appears in the photo but the date is during summer; do not take
+          time of day into account)
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_location_not_accurate_html: |
+          the <strong>location doesn't look accurate</strong> (e.g. monkeys in
+          the middle of the ocean, hippos in office buildings, etc.)
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_not_wild_html: |
+          the <strong>organism isn't wild/naturalized</strong> (e.g. captive
+          or cultivated by humans)
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_not_organism_html: |
+          the observation <strong>doesn't present evidence of an
+          organism</strong>, e.g. images of water features, rocks, landscapes
+          that don't include the organism, etc.
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_not_recent_html: |
+          the observation <strong>doesn't present recent (~100 years) evidence
+          of the organism</strong> (e.g. fossils, but tracks, scat, and dead
+          leaves are ok)
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_not_one_subject_html: |
+          the observation <strong>doesn't present evidence related to one
+          subject</strong> (e.g. it has four photos of unrelated organisms; a
+          photo showing habitat of the observation’s subject is OK)
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_voted_out_html: |
+          the observation no longer needs an ID <em>and</em> the community ID
+          is at family or above
+        # One of a list of reasons for an observation to revert to Casual
+        dqa_help_casual_opted_out_maverick_html: |
+          the observer has opted out of the community ID and the community ID
+          taxon is not an ancestor or descendant of the taxon associated with
+          the observer's ID
+        # Leads a list of ways that iNat itself can vote in the DQA
+        dqa_help_system_lead_html: |
+          And if that wasn't complicated enough, there are also situations
+          where the system gets a vote:
+        # One of a list of wasy iNat itself can vote in the DQA
+        dqa_help_system_captive_vote_html: |
+          The system will vote that the observation is not wild/naturalized if
+          there are at least 10 other observations of a genus or lower in the
+          smallest county-, state-, or country-equivalent place that contains
+          this observation and 80% or more of those observations have been
+          marked as not wild/naturalized.
         identification_count_desc: '# of identifications for an individual taxon'
         flagged_photos_desc_html: |
           Some of these photos have been flagged for inappropriate content or
@@ -7677,82 +7750,6 @@ en:
           power to see the hidden coordinates of this or any
           other observation in the project and implies that you
           agree to the project <a href="%{url}" target="_blank">terms</a>.
-        quality_assessment_help4_html: |
-          <p>
-            The data quality assessment is a summary of an observation's accuracy. All
-            observations start as <strong>"casual"</strong> grade, and become
-            <strong>"needs ID"</strong> when
-          </p>
-
-          <ul>
-            <li>the observation <strong>has a date</strong></li>
-            <li>the observation <strong>is georeferenced</strong> (i.e. has lat/lon coordinates)</li>
-            <li>the observation <strong>has photos or sounds</strong></li>
-            <li>the observation <strong>isn't of a human</strong></li>
-          </ul>
-          <p>
-            Observations become <strong>"research grade"</strong> when
-          </p>
-          <ul>
-            <li>
-              the %{site_name} <strong>community agrees on species-level ID or
-              lower</strong>, i.e. when more than 2/3 of identifiers agree on a
-              taxon (if the community has voted that the Community Taxon can no
-              longer be improved, this reverts to subfamily-level ID or lower)
-            </li>
-          </ul>
-          <p>
-            Observations will revert to <strong>"casual"</strong> if the above conditions aren't met or the community agrees
-          </p>
-          <ul>
-            <li>
-              the <strong>day and year do not look accurate</strong> (e.g. snow appears in the
-              photo but the date is during summer. Do not take time of day into account)
-            </li>
-            <li>
-              the <strong>location doesn't look
-              accurate</strong> (e.g. monkeys in the middle of the ocean,
-              hippos in office buildings, etc.)
-            </li>
-            <li>
-              the <strong>organism isn't wild/naturalized</strong> (e.g. captive or cultivated by humans)
-            </li>
-            <li>
-              the observation <strong>doesn't present evidence of an
-              organism</strong>, e.g. images of water features,
-              rocks, landscapes that don't include the organism, etc.
-            </li>
-            <li>
-              the observation <strong>doesn't present recent (~100 years) evidence of
-              the organism</strong> (e.g. fossils, but tracks, scat, and dead leaves
-              are ok)
-            </li>
-            <li>
-              the observation <strong>doesn't present evidence related to one subject</strong>
-               (e.g. it has four photos of unrelated organisms. A photo showing habitat of the
-               observation’s subject is OK.)
-            </li>
-            <li>
-              the observation no longer needs an ID <em>and</em> the community ID is at family or above
-            </li>
-            <li>
-              the observer has opted out of the community ID and the community
-              ID taxon is not an ancestor or descendant of the taxon associated
-              with the observer's ID
-            </li>
-          </ul>
-          <p>
-            And if that wasn't complicated enough, there are also situations where the system gets a vote:
-          </p>
-          <ul>
-            <li>
-              The system will vote that the observation is not wild/naturalized
-              if there are at least 10 other observations of a genus or lower in
-              the smallest county-, state-, or country-equivalent place that
-              contains this observation and 80% or more of those observations
-              have been marked as not wild/naturalized.
-            </li>
-          </ul>
         score_desc: "score = cumulative count / (cumulative count + disagreement count + ancestor disagreements)"
         observation_flagged_notice_html: |
           This observation has been flagged as spam and is no longer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7726,16 +7726,16 @@ en:
           the observation no longer needs an ID <em>and</em> the community ID
           is at family or above
         # One of a list of reasons for an observation to revert to Casual
-        dqa_help_casual_opted_out_maverick_html: |
+        dqa_help_casual_opted_out_maverick: |
           the observer has opted out of the community ID and the community ID
           taxon is not an ancestor or descendant of the taxon associated with
           the observer's ID
         # Leads a list of ways that iNat itself can vote in the DQA
-        dqa_help_system_lead_html: |
+        dqa_help_system_lead: |
           And if that wasn't complicated enough, there are also situations
           where the system gets a vote:
         # One of a list of wasy iNat itself can vote in the DQA
-        dqa_help_system_captive_vote_html: |
+        dqa_help_system_captive_vote: |
           The system will vote that the observation is not wild/naturalized if
           there are at least 10 other observations of a genus or lower in the
           smallest county-, state-, or country-equivalent place that contains


### PR DESCRIPTION
Previously we've kept this string large to proviede the maximum amount of context for translators, and changed the key every time we updated the text, requiring them to retranslate everything on the assumption that Crowdin's Translation Memory feature will show the previous translation. We've recently learned there is an unknown limit on the size of string TM will work for, which changes the context/change resilience tradeoff in favor of smaller strings.