### PR TITLE
fix: replace legacy life list titles (#3755)

### DIFF
--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -36,7 +36,7 @@ class CheckList < List
   end
   
   def owner_name
-    self.place.name
+    place&.name
   end
   
   # Is this the default check list of its place?

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -49,7 +49,11 @@ class List < ApplicationRecord
     return nil if new_record?
     CGI.escape("#{id}-#{title.gsub(/[\'\"]/, '').gsub(/\W/, '-')}")
   end
-  
+
+  def title
+    self[:title]&.sub(/^.+'s Life List/, I18n.t(:life_list, user: owner_name))
+  end
+
   #
   # Adds a taxon to this list and returns the listed_taxon (valid or not). 
   # Note that subclasses like CheckList may override this.

--- a/app/models/project_list.rb
+++ b/app/models/project_list.rb
@@ -8,7 +8,7 @@ class ProjectList < List
   end
   
   def owner_name
-    project.title
+    project&.title
   end
   
   def listed_taxa_editable_by?(user)

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -74,4 +74,17 @@ describe List do
     end
   end
 
+  describe "legacy life list title" do
+    let(:list) { List.make!(title: "old_user_login's Life List") }
+    let(:localized_title) { I18n.t(:life_list, user: list.owner_name) }
+    it "should display the current list owner name in a legacy life list title" do
+      expect(list.title).to eq localized_title
+      list.title = "old_user_login's Life List of Animalia"
+      expect(list.title).to eq "#{localized_title} of Animalia"
+    end
+    it "should display an unaltered list title if the list is NOT a legacy life list" do
+      list.title = "this is a list title"
+      expect(list.title).to eq "this is a list title"
+    end
+  end
 end


### PR DESCRIPTION
It looks to me like the most straightforward way to address this issue is to override the title attribute for lists, and substitute the :life_list translation with the current list owner for the legacy title.

Note that this will mean that anyone in a non-English locale will now see a localized version of the "xxx's Life List" text instead of the hard-coded English phrase. From looking at the [old life list code](https://github.com/inaturalist/inaturalist/blob/a77a4153b002d3d12d955299cd08597819fe9817/app/models/life_list.rb#L239-L243), I see that there was also a taxon-specific version of a life list, but I did not see an appropriate translation for this, so the substitution only replaces the "xxx's Life List" portion of the title.

Please let me know if a different approach is preferred here.