### PR TITLE
Potential improvement for explore-taxon-addition-subtraction

### DIFF
--- a/app/assets/javascripts/ang/factories/observations.js.erb
+++ b/app/assets/javascripts/ang/factories/observations.js.erb
@@ -58,6 +58,9 @@ iNatAPI.constant( "V2_TAXON_FIELDS", {
     iconic_taxon_name: true,
     is_active: true,
     preferred_common_name: true,
+    preferred_common_names: {
+      name: true
+    },
     rank: true,
     rank_level: true
   },
@@ -114,34 +117,13 @@ iNatAPI.factory( "ObservationsFactory", [
       return shared.basicGet( url, _.extend( { }, params, { fields: V2_OBSERVATION_FIELDS } ) );
     };
     var speciesCounts = function ( params ) {
-      // First we need to get the actual counts response
       var url = "/observations/species_counts";
       return shared.basicGet( url, _.extend( { }, params, {
-        fields: { taxon: { id: true } }
-      } ) ).then( function( speciesCountsResponse ) {
-        // Then we want to load taxa including ancestors, which are only
-        // available from the details endpoint. That endpoint only accepts 30
-        // IDs at a time, so we need to make multiple requests...
-        var taxonIds = speciesCountsResponse.data.results.map( function( res ) { return res.taxon.id; } );
-        var promises = _.chunk( taxonIds, 30 ).map( function ( taxonIdsChunk ) {
-          return shared.basicGet(
-            "/taxa/" + taxonIdsChunk.join( "," ),
-            { per_page: 30, fields: V2_TAXON_FIELDS }
-          ).then( function( taxaResponse ) {
-            return taxaResponse.data.results;
-          } );
-        } );
-        // ...and then consolidate their responses
-        return Promise.all( promises ).then( function ( promiseResults ) {
-          var taxa = _.flatten( promiseResults );
-          var newResults = speciesCountsResponse.data.results.map( function( res ) {
-            res.taxon = taxa.find( function( taxon ) { return taxon.id === res.taxon.id; } );
-            return res;
-          } )
-          speciesCountsResponse.data.results = newResults;
-          return speciesCountsResponse;
-        } );
-      } );
+        include_ancestors: true,
+        fields: {
+          taxon: V2_TAXON_FIELDS
+        }
+      } ) );
     };
     var identifiers = function ( params ) {
       var url = "/observations/identifiers";

--- a/app/webpack/projects/show/ducks/project.jsx
+++ b/app/webpack/projects/show/ducks/project.jsx
@@ -123,7 +123,6 @@ export function fetchMembers( ) {
       id: project.id,
       per_page: 100,
       order_by: "login",
-      skip_counts: true,
       fields: { user: USER_FIELDS }
     };
     if ( config.currentUser ) {


### PR DESCRIPTION
- add to the species_counts API call the [new parameter](https://github.com/inaturalist/iNaturalistAPI/commit/96126150e08c146d4b9f55a1bad0ecefe4ce119c) `include_ancestors` to prevent the need for subsequent taxon details API calls to fetch taxon ancestors
- ensure that if the user is testing API v2, taxon ancestors include the attribute `preferred_common_names` in order to display multiple common names