### PR TITLE
Remove 0 padding from day as this causes a CS1 error on en wiki.

### DIFF
--- a/app/views/taxa/_description.html.haml
+++ b/app/views/taxa/_description.html.haml
@@ -56,7 +56,7 @@
         else
           @taxon.name
         end
-        ref = "<ref name=\"inaturalist-#{@taxon.name}\">{{cite web |title=#{render( "taxa/taxon.txt.erb", taxon: @taxon )} |url=#{taxon_url(@taxon)} |website=#{@site.name} |access-date=#{Date.today.strftime('%d %B %Y')} |language=#{I18n.locale}}}</ref>"
+        ref = "<ref name=\"inaturalist-#{@taxon.name}\">{{cite web |title=#{render( "taxa/taxon.txt.erb", taxon: @taxon )} |url=#{taxon_url(@taxon)} |website=#{@site.name} |access-date=#{Date.today.strftime('%-d %B %Y')} |language=#{I18n.locale}}}</ref>"
         ref_link = "<ref name=\"inaturalist-#{@taxon.name}\" />"
         structure = <<-WIKI
           #{I18n.t(:taxon_is_a_rank,


### PR DESCRIPTION
References currently created this way causes errors in citation templates on en wiki because the template does not accept days with leading zeros (see zero-padding: https://en.wikipedia.org/wiki/Help:CS1_errors#bad_date )

%-d inserts the day with no leading 0 instead. 