### PR TITLE
Taxon changes do not update hidden identifications

### DIFF
--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -260,9 +260,11 @@ class TaxonChange < ApplicationRecord
               batch_users_to_notify << record.user.id
               notified_user_ids << record.user.id
             end
-            if automatable? && ( !record_has_user || record.user.prefers_automatic_taxonomic_changes? )
-              auto_updatable_records << record
-            end
+            next unless automatable? &&
+              ( !record_has_user || record.user.prefers_automatic_taxonomic_changes? ) &&
+              !( record.is_a?( Identification ) && record.hidden? )
+
+            auto_updatable_records << record
           end
           if options[:debug]
             Rails.logger.info(

--- a/spec/models/taxon_swap_spec.rb
+++ b/spec/models/taxon_swap_spec.rb
@@ -508,6 +508,19 @@ describe TaxonSwap, "commit_records" do
     expect(o.taxon).not_to eq(@output_taxon)
   end
 
+  it "should not update hidden identifications" do
+    o = Observation.make!( taxon: @input_taxon )
+    ModeratorAction.make!( resource: o.identifications.last, action: "hide" )
+    expect( o.identifications.last.taxon ).to eq( @input_taxon )
+    expect( o.identifications.count ).to eq 1
+    expect( o.identifications.last.hidden? ).to be true
+    @swap.commit_records
+    o.reload
+    expect( o.identifications.last.taxon ).to eq( @input_taxon )
+    expect( o.identifications.count ).to eq 1
+    expect( o.identifications.last.hidden? ).to be true
+  end
+
   it "should not generate more than one update per user" do
     u = User.make!(:prefers_automatic_taxonomic_changes => false)
     expect(u.prefers_automatic_taxonomic_changes?).not_to be true


### PR DESCRIPTION
Taxon changes skip hidden identifications to prevent them from being re-added as unhidden with updated taxon #4276