### PR TITLE
TaxonPhotos indexing lifecycle change

### DIFF
--- a/app/es_indices/controlled_term_index.rb
+++ b/app/es_indices/controlled_term_index.rb
@@ -1,6 +1,7 @@
-class ControlledTerm < ApplicationRecord
+# frozen_string_literal: true
 
-  include ActsAsElasticModel
+class ControlledTerm < ApplicationRecord
+  acts_as_elastic_model
 
   scope :load_for_index, -> { includes({ values: [ :values, :labels, :controlled_term_taxa ] }, :labels, :controlled_term_taxa, :attrs) }
 

--- a/app/es_indices/identification_index.rb
+++ b/app/es_indices/identification_index.rb
@@ -1,6 +1,7 @@
-class Identification < ApplicationRecord
+# frozen_string_literal: true
 
-  include ActsAsElasticModel
+class Identification < ApplicationRecord
+  acts_as_elastic_model
 
   DEFAULT_ES_BATCH_SIZE = 500
 

--- a/app/es_indices/observation_field_index.rb
+++ b/app/es_indices/observation_field_index.rb
@@ -1,6 +1,7 @@
-class ObservationField < ApplicationRecord
+# frozen_string_literal: true
 
-  include ActsAsElasticModel
+class ObservationField < ApplicationRecord
+  acts_as_elastic_model
 
   settings index: { number_of_shards: 1, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Observation < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model
 
   DEFAULT_ES_BATCH_SIZE = 100
   DEFAULT_ES_BATCH_SLEEP = 2

--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -1,6 +1,7 @@
-class Place < ApplicationRecord
+# frozen_string_literal: true
 
-  include ActsAsElasticModel
+class Place < ApplicationRecord
+  acts_as_elastic_model
 
   DEFAULT_ES_BATCH_SIZE = 100
 

--- a/app/es_indices/project_index.rb
+++ b/app/es_indices/project_index.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Project < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model
 
   DEFAULT_ES_BATCH_SIZE = 500
 

--- a/app/es_indices/taxon_index.rb
+++ b/app/es_indices/taxon_index.rb
@@ -1,6 +1,7 @@
-class Taxon < ApplicationRecord
+# frozen_string_literal: true
 
-  include ActsAsElasticModel
+class Taxon < ApplicationRecord
+  acts_as_elastic_model
 
   DEFAULT_ES_BATCH_SIZE = 500
 

--- a/app/es_indices/taxon_photo_index.rb
+++ b/app/es_indices/taxon_photo_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TaxonPhoto < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model lifecycle_callbacks: [:destroy]
 
   DEFAULT_ES_BATCH_SIZE = 50
 

--- a/app/es_indices/update_action_index.rb
+++ b/app/es_indices/update_action_index.rb
@@ -1,6 +1,7 @@
-class UpdateAction < ApplicationRecord
+# frozen_string_literal: true
 
-  include ActsAsElasticModel
+class UpdateAction < ApplicationRecord
+  acts_as_elastic_model
 
   settings index: { number_of_shards: Rails.env.production? ? 6 : 4, analysis: ElasticModel::ANALYSIS } do
     mappings(dynamic: true) do

--- a/app/es_indices/user_index.rb
+++ b/app/es_indices/user_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model
 
   scope :load_for_index, -> { includes( :roles, :flags, :provider_authorizations ) }
 

--- a/app/models/controlled_term.rb
+++ b/app/models/controlled_term.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ControlledTerm < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include ActsAsUUIDable
   before_validation :set_uuid
   def set_uuid

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -1,6 +1,6 @@
 #encoding: utf-8
 class Identification < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model
   acts_as_spammable fields: [ :body ],
                     comment_type: "comment",
                     automated: false

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2,7 +2,7 @@
 
 class Observation < ApplicationRecord
 
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include ObservationSearch
   include ActsAsUUIDable
 

--- a/app/models/observation_field.rb
+++ b/app/models/observation_field.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ObservationField < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include ActsAsUUIDable
   before_validation :set_uuid
   def set_uuid

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -2,7 +2,7 @@
 
 class Place < ApplicationRecord
   acts_as_flaggable
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include ActsAsUUIDable
   before_validation :set_uuid
   def set_uuid

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ApplicationRecord
 
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include HasJournal
 
   belongs_to :user

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -25,7 +25,7 @@ class Taxon < ApplicationRecord
   # set this when you want methods to respond with user-specific content
   attr_accessor :current_user
 
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include ActsAsUUIDable
   before_validation :set_uuid
   def set_uuid

--- a/app/models/taxon_photo.rb
+++ b/app/models/taxon_photo.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TaxonPhoto < ApplicationRecord
-  include ActsAsElasticModel
+  acts_as_elastic_model lifecycle_callbacks: [:destroy]
 
   audited except: [:taxon_id], associated_with: :taxon
 

--- a/app/models/update_action.rb
+++ b/app/models/update_action.rb
@@ -1,6 +1,6 @@
 class UpdateAction < ApplicationRecord
 
-  include ActsAsElasticModel
+  acts_as_elastic_model
 
   belongs_to :resource, polymorphic: true
   belongs_to :notifier, polymorphic: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@
 
 class User < ApplicationRecord
   include ActsAsSpammable::User
-  include ActsAsElasticModel
+  acts_as_elastic_model
   include ActsAsUUIDable
   include HasJournal
 

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -9,4 +9,6 @@ else
 end
 Elasticsearch::Model.client = Elasticsearch::Client.new(es_config)
 # load our own Elasticsearch logic
-require 'elastic_model'
+require "elastic_model"
+
+ActiveRecord::Base.send( :include, ActsAsElasticModel )

--- a/db/migrate/20160809221731_remove_updates_index.rb
+++ b/db/migrate/20160809221731_remove_updates_index.rb
@@ -1,5 +1,5 @@
 class Update < ActiveRecord::Base
-  include ActsAsElasticModel
+  acts_as_elastic_model
 end
 
 class RemoveUpdatesIndex < ActiveRecord::Migration

--- a/lib/elastic_model.rb
+++ b/lib/elastic_model.rb
@@ -1,2 +1,6 @@
-Dir["#{File.dirname(__FILE__)}/elastic_model/elastic_model.rb",
-    "#{File.dirname(__FILE__)}/elastic_model/acts_as_elastic_model.rb"].each { |f| load(f) }
+# frozen_string_literal: true
+
+Dir[
+  "#{File.dirname( __FILE__ )}/elastic_model/elastic_model.rb",
+  "#{File.dirname( __FILE__ )}/elastic_model/acts_as_elastic_model.rb"
+].each {| f | load( f ) }

--- a/lib/elastic_model/acts_as_elastic_model.rb
+++ b/lib/elastic_model/acts_as_elastic_model.rb
@@ -1,349 +1,372 @@
+# frozen_string_literal: true
+
 module ActsAsElasticModel
+  def self.included( base )
+    base.extend ClassMethods
+  end
 
-  extend ActiveSupport::Concern
-  @@inserts = 0
+  module ClassMethods
+    def acts_as_elastic_model( options = {} )
+      options[:lifecycle_callbacks] ||= [:create, :update, :destroy]
+      @inserts = 0
+      include Elasticsearch::Model
 
-  included do
-    include Elasticsearch::Model
+      attr_accessor :skip_indexing
+      attr_accessor :wait_for_index_refresh
+      attr_accessor :es_source
 
-    attr_accessor :skip_indexing
-    attr_accessor :wait_for_index_refresh
-    attr_accessor :es_source
-
-    # load the index definition, if it exists
-    index_path = File.join(Rails.root, "app/es_indices/#{ name.underscore }_index.rb")
-    if File.exists?(index_path)
-      ActiveSupport::Dependencies.require_or_load(index_path)
-    end
-
-    # set the index name based on the environment, useful for specs
-    index_prefix = ENV.fetch("INAT_ES_INDEX_PREFIX") { (Rails.env.prod_dev? ? "production" : Rails.env) }
-    index_name [ index_prefix, model_name.collection ].join('_')
-
-    after_commit on: [:create, :update] do
-      unless respond_to?(:skip_indexing) && skip_indexing
-        elastic_index!
+      # load the index definition, if it exists
+      index_path = File.join( Rails.root, "app/es_indices/#{name.underscore}_index.rb" )
+      if File.exist?( index_path )
+        ActiveSupport::Dependencies.require_or_load( index_path )
       end
-    end
 
-    after_commit on: [:destroy] do
-      elastic_delete!
-    end
+      # set the index name based on the environment, useful for specs
+      index_prefix = ENV.fetch( "INAT_ES_INDEX_PREFIX" ) { ( Rails.env.prod_dev? ? "production" : Rails.env ) }
+      index_name [index_prefix, model_name.collection].join( "_" )
 
-    class << self
-      def elastic_search(options = {})
-        try_and_try_again( [
-          Elastic::Transport::Transport::Errors::ServiceUnavailable,
-          Elastic::Transport::Transport::Errors::TooManyRequests], sleep: 1, tries: 10 ) do
-          begin
-            __elasticsearch__.search(ElasticModel.search_hash(options))
-          rescue Elastic::Transport::Transport::Errors::BadRequest => e
-            Logstasher.write_exception(e)
-            Rails.logger.error "[Error] elastic_search failed: #{ e }"
-            Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
+      if options[:lifecycle_callbacks]&.include?( :create )
+        after_commit on: :create do
+          unless self&.skip_indexing
+            elastic_index!
+          end
+        end
+      end
+      if options[:lifecycle_callbacks]&.include?( :update )
+        after_commit on: :update do
+          unless self&.skip_indexing
+            elastic_index!
+          end
+        end
+      end
+      if options[:lifecycle_callbacks]&.include?( :destroy )
+        after_commit on: :destroy do
+          unless self&.skip_indexing
+            elastic_delete!
           end
         end
       end
 
-      def elastic_paginate(options={})
-        options = options.dup
-        options[:page] ||= 1
-        options[:per_page] ||= 20
-        options[:source] ||= options[:keep_es_source] ? "*" : [ "id" ]
-        result = elastic_search(options).
-          per_page(options[:per_page]).page(options[:page])
-        result_to_will_paginate_collection(result, options)
-      end
+      include ActsAsElasticModel::InstanceMethods
+      extend ActsAsElasticModel::SingletonMethods
+    end
+  end
 
-      def elastic_get( id, options = { } )
+  module SingletonMethods
+    def elastic_search(options = {})
+      try_and_try_again( [
+        Elastic::Transport::Transport::Errors::ServiceUnavailable,
+        Elastic::Transport::Transport::Errors::TooManyRequests], sleep: 1, tries: 10 ) do
         begin
-          __elasticsearch__.client.get( index: index_name, id: id )
-        rescue Elastic::Transport::Transport::Errors::NotFound => a
-          nil
+          __elasticsearch__.search(ElasticModel.search_hash(options))
+        rescue Elastic::Transport::Transport::Errors::BadRequest => e
+          Logstasher.write_exception(e)
+          Rails.logger.error "[Error] elastic_search failed: #{ e }"
+          Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
         end
       end
+    end
 
-      def elastic_mget( ids, options = {} )
-        return [] if ids.empty?
+    def elastic_paginate(options={})
+      options = options.dup
+      options[:page] ||= 1
+      options[:per_page] ||= 20
+      options[:source] ||= options[:keep_es_source] ? "*" : [ "id" ]
+      result = elastic_search(options).
+        per_page(options[:per_page]).page(options[:page])
+      result_to_will_paginate_collection(result, options)
+    end
 
-        __elasticsearch__.client.mget(
-          index: index_name,
-          body: {
-            docs: ids.map do | id |
-              { _id: id }
-            end
-          },
-          _source: options[:source]
-        )["docs"].map {| d | d["_source"] }.compact
+    def elastic_get( id, options = { } )
+      begin
+        __elasticsearch__.client.get( index: index_name, id: id )
+      rescue Elastic::Transport::Transport::Errors::NotFound => a
+        nil
       end
+    end
 
-      # standard way to bulk index instances. Called without options it will
-      # page through all instances 1000 at a time (default for find_in_batches)
-      # You can also send options, including scope:
-      #   Place.elastic_index!(batch_size: 20)
-      #   Place.elastic_index!(scope: Place.where(id: [1,2,3,...]), batch_size: 20)
-      def elastic_index!(options = { })
-        options[:batch_size] ||=
-          defined?(self::DEFAULT_ES_BATCH_SIZE) ? self::DEFAULT_ES_BATCH_SIZE : 1000
-        options[:sleep] ||=
-          defined?(self::DEFAULT_ES_BATCH_SLEEP) ? self::DEFAULT_ES_BATCH_SLEEP : 1
-        debug = options.delete(:debug)
-        filter_scope = options.delete(:scope)
-        run_at = options.delete(:run_at)
-        # this method will accept an existing scope
-        scope = (filter_scope && filter_scope.is_a?(ActiveRecord::Relation)) ?
-          filter_scope : self.all
-        # it also accepts an array of IDs to filter by
-        if filter_ids = options.delete(:ids)
-          filter_ids = filter_ids.compact.uniq
-          batch_sleep = options.delete(:sleep)
-          if filter_ids.length > options[:batch_size]
-            # call again for each batch, then return
-            filter_ids.each_slice(options[:batch_size]) do |slice|
-              elastic_index!(options.merge(ids: slice, run_at: run_at))
-              if batch_sleep.is_a?( Numeric ) && !options[:delay]
-                # sleep after index an ID batch, since during indexing
-                # we only sleep when indexing multiple batches, and here
-                # we explicitly requested a single batch to be indexed
-                sleep batch_sleep
-              end
+    def elastic_mget( ids, options = {} )
+      return [] if ids.empty?
+
+      __elasticsearch__.client.mget(
+        index: index_name,
+        body: {
+          docs: ids.map do | id |
+            { _id: id }
+          end
+        },
+        _source: options[:source]
+      )["docs"].map {| d | d["_source"] }.compact
+    end
+
+    # standard way to bulk index instances. Called without options it will
+    # page through all instances 1000 at a time (default for find_in_batches)
+    # You can also send options, including scope:
+    #   Place.elastic_index!(batch_size: 20)
+    #   Place.elastic_index!(scope: Place.where(id: [1,2,3,...]), batch_size: 20)
+    def elastic_index!(options = { })
+      options[:batch_size] ||=
+        defined?(self::DEFAULT_ES_BATCH_SIZE) ? self::DEFAULT_ES_BATCH_SIZE : 1000
+      options[:sleep] ||=
+        defined?(self::DEFAULT_ES_BATCH_SLEEP) ? self::DEFAULT_ES_BATCH_SLEEP : 1
+      debug = options.delete(:debug)
+      filter_scope = options.delete(:scope)
+      run_at = options.delete(:run_at)
+      # this method will accept an existing scope
+      scope = (filter_scope && filter_scope.is_a?(ActiveRecord::Relation)) ?
+        filter_scope : self.all
+      # it also accepts an array of IDs to filter by
+      if filter_ids = options.delete(:ids)
+        filter_ids = filter_ids.compact.uniq
+        batch_sleep = options.delete(:sleep)
+        if filter_ids.length > options[:batch_size]
+          # call again for each batch, then return
+          filter_ids.each_slice(options[:batch_size]) do |slice|
+            elastic_index!(options.merge(ids: slice, run_at: run_at))
+            if batch_sleep.is_a?( Numeric ) && !options[:delay]
+              # sleep after index an ID batch, since during indexing
+              # we only sleep when indexing multiple batches, and here
+              # we explicitly requested a single batch to be indexed
+              sleep batch_sleep
             end
-            return
           end
-          scope = scope.where(id: filter_ids)
+          return
         end
-        if indexed_before = options.delete(:indexed_before)
-          if column_names.include?( "last_indexed_at" )
-            scope = scope.where("last_indexed_at IS NULL OR last_indexed_at < ?", indexed_before)
-          end
+        scope = scope.where(id: filter_ids)
+      end
+      if indexed_before = options.delete(:indexed_before)
+        if column_names.include?( "last_indexed_at" )
+          scope = scope.where("last_indexed_at IS NULL OR last_indexed_at < ?", indexed_before)
         end
-        # indexing can be delayed
-        if options.delete(:delay)
-          # make sure to fetch the results of the scope and store
-          # the resulting IDs instead of scopes for DelayedJobs.
-          # For example, delayed calls this like are very efficient:
-          #   Observation.elastic_index!(scope: User.find(1).observations, delay: true)
-          result_ids = scope.order(:id).pluck(:id)
-          return unless result_ids.any?
-          id_hash = Digest::MD5.hexdigest( result_ids.join( "," ) )
-          queue = if result_ids.size > 50
-            "throttled"
-          end
-          return self.delay(
-            unique_hash: { "#{self.name}::delayed_index": id_hash },
-            queue: queue,
-            run_at: run_at
-          ).elastic_index!( options.except( :batch_size ).merge(
-            ids: result_ids,
-            indexed_before: 5.minutes.from_now.strftime("%FT%T")
-          ) )
+      end
+      # indexing can be delayed
+      if options.delete(:delay)
+        # make sure to fetch the results of the scope and store
+        # the resulting IDs instead of scopes for DelayedJobs.
+        # For example, delayed calls this like are very efficient:
+        #   Observation.elastic_index!(scope: User.find(1).observations, delay: true)
+        result_ids = scope.order(:id).pluck(:id)
+        return unless result_ids.any?
+        id_hash = Digest::MD5.hexdigest( result_ids.join( "," ) )
+        queue = if result_ids.size > 50
+          "throttled"
         end
-        # now we can preload all associations needed for efficient indexing
+        return self.delay(
+          unique_hash: { "#{self.name}::delayed_index": id_hash },
+          queue: queue,
+          run_at: run_at
+        ).elastic_index!( options.except( :batch_size ).merge(
+          ids: result_ids,
+          indexed_before: 5.minutes.from_now.strftime("%FT%T")
+        ) )
+      end
+      # now we can preload all associations needed for efficient indexing
+      if self.respond_to?(:load_for_index)
+        scope = scope.load_for_index
+      end
+      wait_for_index_refresh = options.delete(:wait_for_index_refresh)
+      batch_sleep = options.delete(:sleep)
+      batches_indexed = 0
+      scope.find_in_batches(**options) do |batch|
+        if batch_sleep && batches_indexed > 0
+          # sleep only if more than one batch is being indexed
+          sleep batch_sleep.to_i
+        end
+        if debug && batch && batch.length > 0
+          Rails.logger.info "[INFO #{Time.now}] Starting to index #{self.name} :: #{batch[0].id}"
+        end
+        bulk_index(batch, wait_for_index_refresh: wait_for_index_refresh)
+        batches_indexed += 1
+      end
+      __elasticsearch__.refresh_index! if Rails.env.test?
+    end
+
+    def elastic_sync(start_id, end_id, options)
+      return if !start_id || !end_id || start_id >= end_id
+      options[:batch_size] ||=
+        defined?(self::DEFAULT_ES_BATCH_SIZE) ? self::DEFAULT_ES_BATCH_SIZE : 1000
+      batch_start_id = start_id
+      while batch_start_id <= end_id
+        Rails.logger.debug "[DEBUG] Processing from #{ batch_start_id }"
+        batch_end_id = batch_start_id + options[:batch_size]
+        if batch_end_id > end_id + 1
+          batch_end_id = end_id + 1
+        end
+        scope = self.where("id >= ? AND id < ?", batch_start_id, batch_end_id)
         if self.respond_to?(:load_for_index)
           scope = scope.load_for_index
         end
-        wait_for_index_refresh = options.delete(:wait_for_index_refresh)
-        batch_sleep = options.delete(:sleep)
-        batches_indexed = 0
-        scope.find_in_batches(**options) do |batch|
-          if batch_sleep && batches_indexed > 0
-            # sleep only if more than one batch is being indexed
-            sleep batch_sleep.to_i
-          end
-          if debug && batch && batch.length > 0
-            Rails.logger.info "[INFO #{Time.now}] Starting to index #{self.name} :: #{batch[0].id}"
-          end
-          bulk_index(batch, wait_for_index_refresh: wait_for_index_refresh)
-          batches_indexed += 1
+        batch = scope.to_a
+        prepare_for_index(batch)
+        results = elastic_search(
+          sort: { id: :asc },
+          size: options[:batch_size],
+          filters: [
+            { range: { id: { gte: batch_start_id } } },
+            { range: { id: { lt: batch_end_id } } }
+          ],
+          source: ["id"]
+        ).group_by{ |r| r.id.to_i }
+        bulk_index(batch, skip_prepare_batch: true)
+        ids_only_in_es = results.keys - batch.map(&:id)
+        unless ids_only_in_es.empty?
+          Rails.logger.debug "[DEBUG] Deleting vestigial docs in ES: #{ ids_only_in_es }"
+          elastic_delete_by_ids!( [ids_only_in_es] )
         end
-        __elasticsearch__.refresh_index! if Rails.env.test?
+        batch_start_id = batch_end_id
       end
+    end
 
-      def elastic_sync(start_id, end_id, options)
-        return if !start_id || !end_id || start_id >= end_id
-        options[:batch_size] ||=
-          defined?(self::DEFAULT_ES_BATCH_SIZE) ? self::DEFAULT_ES_BATCH_SIZE : 1000
-        batch_start_id = start_id
-        while batch_start_id <= end_id
-          Rails.logger.debug "[DEBUG] Processing from #{ batch_start_id }"
-          batch_end_id = batch_start_id + options[:batch_size]
-          if batch_end_id > end_id + 1
-            batch_end_id = end_id + 1
-          end
-          scope = self.where("id >= ? AND id < ?", batch_start_id, batch_end_id)
-          if self.respond_to?(:load_for_index)
-            scope = scope.load_for_index
-          end
-          batch = scope.to_a
-          prepare_for_index(batch)
-          results = elastic_search(
-            sort: { id: :asc },
-            size: options[:batch_size],
-            filters: [
-              { range: { id: { gte: batch_start_id } } },
-              { range: { id: { lt: batch_end_id } } }
-            ],
-            source: ["id"]
-          ).group_by{ |r| r.id.to_i }
-          bulk_index(batch, skip_prepare_batch: true)
-          ids_only_in_es = results.keys - batch.map(&:id)
-          unless ids_only_in_es.empty?
-            Rails.logger.debug "[DEBUG] Deleting vestigial docs in ES: #{ ids_only_in_es }"
-            elastic_delete_by_ids!( [ids_only_in_es] )
-          end
-          batch_start_id = batch_end_id
+    def elastic_prune(start_id, end_id, options)
+      return if !start_id || !end_id || start_id >= end_id
+      options[:batch_size] ||=
+        defined?(self::DEFAULT_ES_BATCH_SIZE) ? self::DEFAULT_ES_BATCH_SIZE : 1000
+      batch_start_id = start_id
+      while batch_start_id <= end_id
+        Rails.logger.debug "[DEBUG] Processing from #{ batch_start_id }"
+        batch_end_id = batch_start_id + options[:batch_size]
+        if batch_end_id > end_id + 1
+          batch_end_id = end_id + 1
         end
+        scope = self.where("id >= ? AND id < ?", batch_start_id, batch_end_id)
+        batch_ids = scope.pluck(:id)
+        ids_only_in_es = elastic_search(
+          sort: { id: :asc },
+          size: options[:batch_size],
+          filters: [
+            { range: { id: { gte: batch_start_id } } },
+            { range: { id: { lt: batch_end_id } } },
+            { bool: {
+              must_not: {
+                terms: { id: batch_ids }
+              }
+            } }
+          ],
+          source: ["id"]
+        ).map(&:id)
+        unless ids_only_in_es.empty?
+          Rails.logger.debug "[DEBUG] Deleting vestigial docs in ES: #{ ids_only_in_es }"
+          elastic_delete_by_ids!( [ids_only_in_es] )
+        end
+        batch_start_id = batch_end_id
       end
+    end
 
-      def elastic_prune(start_id, end_id, options)
-        return if !start_id || !end_id || start_id >= end_id
-        options[:batch_size] ||=
-          defined?(self::DEFAULT_ES_BATCH_SIZE) ? self::DEFAULT_ES_BATCH_SIZE : 1000
-        batch_start_id = start_id
-        while batch_start_id <= end_id
-          Rails.logger.debug "[DEBUG] Processing from #{ batch_start_id }"
-          batch_end_id = batch_start_id + options[:batch_size]
-          if batch_end_id > end_id + 1
-            batch_end_id = end_id + 1
+    def result_to_will_paginate_collection(result, options={})
+      try_and_try_again( PG::ConnectionBad, sleep: 20 ) do
+        begin
+          records = options[:keep_es_source] ?
+            result.records.map_with_hit do |record, hit|
+              record.es_source = hit._source
+              record
+            end : result.records.to_a
+          elastic_ids = result.results.results.map{ |r| r.id.to_i }
+          elastic_ids_to_delete = elastic_ids - records.map(&:id)
+          elastic_delete_by_ids!( elastic_ids_to_delete )
+          WillPaginate::Collection.create(result.current_page, result.per_page,
+            result.total_entries - elastic_ids_to_delete.count) do |pager|
+            pager.replace(records)
           end
-          scope = self.where("id >= ? AND id < ?", batch_start_id, batch_end_id)
-          batch_ids = scope.pluck(:id)
-          ids_only_in_es = elastic_search(
-            sort: { id: :asc },
-            size: options[:batch_size],
-            filters: [
-              { range: { id: { gte: batch_start_id } } },
-              { range: { id: { lt: batch_end_id } } },
-              { bool: {
-                must_not: {
-                  terms: { id: batch_ids }
-                }
-              } }
-            ],
-            source: ["id"]
-          ).map(&:id)
-          unless ids_only_in_es.empty?
-            Rails.logger.debug "[DEBUG] Deleting vestigial docs in ES: #{ ids_only_in_es }"
-            elastic_delete_by_ids!( [ids_only_in_es] )
-          end
-          batch_start_id = batch_end_id
-        end
-      end
-
-      def result_to_will_paginate_collection(result, options={})
-        try_and_try_again( PG::ConnectionBad, sleep: 20 ) do
-          begin
-            records = options[:keep_es_source] ?
-              result.records.map_with_hit do |record, hit|
-                record.es_source = hit._source
-                record
-              end : result.records.to_a
-            elastic_ids = result.results.results.map{ |r| r.id.to_i }
-            elastic_ids_to_delete = elastic_ids - records.map(&:id)
-            elastic_delete_by_ids!( elastic_ids_to_delete )
-            WillPaginate::Collection.create(result.current_page, result.per_page,
-              result.total_entries - elastic_ids_to_delete.count) do |pager|
-              pager.replace(records)
-            end
-          rescue Elastic::Transport::Transport::Errors::BadRequest => e
-            Logstasher.write_exception(e)
-            Rails.logger.error "[Error] Elasticsearch query failed: #{ e }"
-            Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
-            WillPaginate::Collection.new(1, 30, 0)
-          end
-        end
-      end
-
-      def refresh_es_index
-        __elasticsearch__.refresh_index! unless Rails.env.test?
-      end
-
-      def preload_for_elastic_index( instances )
-        return if instances.blank?
-        klass = instances.first.class
-        if klass.respond_to?(:load_for_index)
-          klass.preload_associations( instances,
-            klass.load_for_index.values[:includes] )
-        end
-      end
-
-      def elastic_delete_by_ids!( ids, options = { } )
-        return if ids.blank?
-        bulk_delete( ids, options )
-        __elasticsearch__.refresh_index! if Rails.env.test?
-      end
-
-      private
-
-      # standard wrapper for bulk indexing with Elasticsearch::Model
-      def bulk_index( batch, options = {} )
-        batch_to_index = if respond_to?( :prune_batch_for_index )
-          prune_batch_for_index( batch )
-        else
-          batch
-        end
-        return if batch_to_index.empty?
-
-        try_and_try_again(
-          [
-            Elastic::Transport::Transport::Errors::ServiceUnavailable,
-            Elastic::Transport::Transport::Errors::TooManyRequests
-          ], sleep: 1, tries: 10
-        ) do
-          begin
-            __elasticsearch__.client.bulk( {
-              index: __elasticsearch__.index_name,
-              body: prepare_for_index( batch_to_index, options ),
-              refresh: options[:wait_for_index_refresh] ? "wait_for" : false
-            } )
-            if batch_to_index.first.respond_to?( :last_indexed_at )
-              ActiveRecord::Base.connection.without_sticking do
-                where( id: batch_to_index ).update_all( last_indexed_at: Time.now )
-              end
-            end
-            GC.start
-          rescue Elastic::Transport::Transport::Errors::BadRequest => e
-            Logstasher.write_exception( e )
-            Rails.logger.error "[Error] elastic_index! failed: #{e}"
-            Rails.logger.error "Backtrace:\n#{e.backtrace[0..30].join( "\n" )}\n..."
-          end
-        end
-      end
-
-      # map each instance into its indexable form with `as_indexed_json`
-      def prepare_for_index(batch, options = { })
-        # some models need some extra preparation for faster indexing.
-        # I tried to just define a custom `prepare_for_index` in
-        # Taxon, but this one from this module took precedence
-        if self.respond_to?(:prepare_batch_for_index) && !options[:skip_prepare_batch]
-          prepare_batch_for_index(batch)
-        end
-        batch.map do |obj|
-          { index: { _id: obj.id, data: obj.as_indexed_json } }
-        end
-      end
-
-      def bulk_delete( ids, options = { } )
-        try_and_try_again( [
-          Elastic::Transport::Transport::Errors::ServiceUnavailable,
-          Elastic::Transport::Transport::Errors::TooManyRequests], sleep: 1, tries: 10 ) do
-          begin
-            __elasticsearch__.client.bulk({
-              index: __elasticsearch__.index_name,
-              body: ids.map do |id|
-                { delete: { _id: id } }
-              end,
-              refresh: options[:wait_for_index_refresh] ? "wait_for" : false
-            })
-          rescue Elastic::Transport::Transport::Errors::BadRequest => e
-            Logstasher.write_exception(e)
-            Rails.logger.error "[Error] elastic_delete! failed: #{ e }"
-            Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
-          end
+        rescue Elastic::Transport::Transport::Errors::BadRequest => e
+          Logstasher.write_exception(e)
+          Rails.logger.error "[Error] Elasticsearch query failed: #{ e }"
+          Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
+          WillPaginate::Collection.new(1, 30, 0)
         end
       end
     end
 
+    def refresh_es_index
+      __elasticsearch__.refresh_index! unless Rails.env.test?
+    end
+
+    def preload_for_elastic_index( instances )
+      return if instances.blank?
+      klass = instances.first.class
+      if klass.respond_to?(:load_for_index)
+        klass.preload_associations( instances,
+          klass.load_for_index.values[:includes] )
+      end
+    end
+
+    def elastic_delete_by_ids!( ids, options = { } )
+      return if ids.blank?
+      bulk_delete( ids, options )
+      __elasticsearch__.refresh_index! if Rails.env.test?
+    end
+
+    private
+
+    # standard wrapper for bulk indexing with Elasticsearch::Model
+    def bulk_index( batch, options = {} )
+      batch_to_index = if respond_to?( :prune_batch_for_index )
+        prune_batch_for_index( batch )
+      else
+        batch
+      end
+      return if batch_to_index.empty?
+
+      try_and_try_again(
+        [
+          Elastic::Transport::Transport::Errors::ServiceUnavailable,
+          Elastic::Transport::Transport::Errors::TooManyRequests
+        ], sleep: 1, tries: 10
+      ) do
+        begin
+          __elasticsearch__.client.bulk( {
+            index: __elasticsearch__.index_name,
+            body: prepare_for_index( batch_to_index, options ),
+            refresh: options[:wait_for_index_refresh] ? "wait_for" : false
+          } )
+          if batch_to_index.first.respond_to?( :last_indexed_at )
+            ActiveRecord::Base.connection.without_sticking do
+              where( id: batch_to_index ).update_all( last_indexed_at: Time.now )
+            end
+          end
+          GC.start
+        rescue Elastic::Transport::Transport::Errors::BadRequest => e
+          Logstasher.write_exception( e )
+          Rails.logger.error "[Error] elastic_index! failed: #{e}"
+          Rails.logger.error "Backtrace:\n#{e.backtrace[0..30].join( "\n" )}\n..."
+        end
+      end
+    end
+
+    # map each instance into its indexable form with `as_indexed_json`
+    def prepare_for_index(batch, options = { })
+      # some models need some extra preparation for faster indexing.
+      # I tried to just define a custom `prepare_for_index` in
+      # Taxon, but this one from this module took precedence
+      if self.respond_to?(:prepare_batch_for_index) && !options[:skip_prepare_batch]
+        prepare_batch_for_index(batch)
+      end
+      batch.map do |obj|
+        { index: { _id: obj.id, data: obj.as_indexed_json } }
+      end
+    end
+
+    def bulk_delete( ids, options = { } )
+      try_and_try_again( [
+        Elastic::Transport::Transport::Errors::ServiceUnavailable,
+        Elastic::Transport::Transport::Errors::TooManyRequests], sleep: 1, tries: 10 ) do
+        begin
+          __elasticsearch__.client.bulk({
+            index: __elasticsearch__.index_name,
+            body: ids.map do |id|
+              { delete: { _id: id } }
+            end,
+            refresh: options[:wait_for_index_refresh] ? "wait_for" : false
+          })
+        rescue Elastic::Transport::Transport::Errors::BadRequest => e
+          Logstasher.write_exception(e)
+          Rails.logger.error "[Error] elastic_delete! failed: #{ e }"
+          Rails.logger.error "Backtrace:\n#{ e.backtrace[0..30].join("\n") }\n..."
+        end
+      end
+    end
+  end
+
+  module InstanceMethods
     def elastic_index!
       if self.class.respond_to?( :prune_batch_for_index ) && self.class.prune_batch_for_index( [self] ).empty?
         return
@@ -364,10 +387,11 @@ module ActsAsElasticModel
             update_column(:last_indexed_at, Time.now)
           end
 
-          @@inserts += 1
+          inserts = self.class.instance_variable_get( "@inserts" ) + 1
+          self.class.instance_variable_set( "@inserts", inserts )
           # garbage collect after a small batch of individual instance indexing
           # don't do this for every elastic_index! as GC is somewhat expensive
-          GC.start if @@inserts % 10 == 0
+          GC.start if ( inserts % 100 ).zero?
         rescue Elastic::Transport::Transport::Errors::BadRequest => e
           Logstasher.write_exception(e)
           Rails.logger.error "[Error] elastic_index! failed: #{ e }"
@@ -405,6 +429,5 @@ module ActsAsElasticModel
           self.class.load_for_index.values[:includes])
       end
     end
-
   end
 end

--- a/spec/lib/elastic_model/indices/taxon_photo_index_spec.rb
+++ b/spec/lib/elastic_model/indices/taxon_photo_index_spec.rb
@@ -28,6 +28,7 @@ describe "TaxonPhoto Index" do
     tp = TaxonPhoto.make!( id: taxon_photo_id )
     tp.elastic_index!
     tp.elastic_index!
+    tp.elastic_index!
   end
 
   it "as_indexed_json does need to regenerate embedding if the photo has been updated" do
@@ -37,7 +38,9 @@ describe "TaxonPhoto Index" do
     tp = TaxonPhoto.make!( id: taxon_photo_id )
     tp.elastic_index!
     tp.elastic_index!
+    tp.elastic_index!
     tp.photo.touch
+    tp.elastic_index!
     tp.elastic_index!
     tp.elastic_index!
   end
@@ -49,7 +52,9 @@ describe "TaxonPhoto Index" do
     tp = TaxonPhoto.make!( id: taxon_photo_id )
     tp.elastic_index!
     tp.elastic_index!
+    tp.elastic_index!
     tp.photo = Photo.make!
+    tp.elastic_index!
     tp.elastic_index!
     tp.elastic_index!
   end
@@ -61,7 +66,9 @@ describe "TaxonPhoto Index" do
     tp = TaxonPhoto.make!( id: taxon_photo_id )
     tp.elastic_index!
     tp.elastic_index!
+    tp.elastic_index!
     tp.taxon.update( parent: Taxon.make! )
+    tp.elastic_index!
     tp.elastic_index!
     tp.elastic_index!
   end


### PR DESCRIPTION
* Change ActsAsElasticModel from concern to be included via method, and allow that method to accept parameters
* ActsAsElasticModel lifecycles are configurable via `lifecycle_callbacks` parameter
* TaxonPhotos are not indexed by default on create or update (they will be indexed in bulk on a schedule instead of real-time on model lifecycles)