### PR TITLE
Allow admins to moderate media as private

### DIFF
--- a/app/assets/stylesheets/moderator_actions/hide_content.scss
+++ b/app/assets/stylesheets/moderator_actions/hide_content.scss
@@ -15,3 +15,6 @@ img.item-to-hide {
 span.content-hidden {
   cursor: pointer;
 }
+.bootstrap label {
+  font-weight: 600;
+}

--- a/app/assets/stylesheets/shared/modals.scss
+++ b/app/assets/stylesheets/shared/modals.scss
@@ -127,5 +127,8 @@ body > div > [role="dialog"] .modal-body {
       max-height: 300px;
       overflow: auto;
     }
+    input[name="private"] {
+      margin-right: 5px;
+    }
   }
 }

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -8,6 +8,7 @@ class PhotosController < ApplicationController
   before_action :authenticate_user!, except: [:show],
     unless: -> { authenticated_with_oauth? }
   before_action :return_here, only: [:show, :invite, :inviter, :fix]
+  before_action :curator_required, only: [:hide]
 
   prepend_around_action :enable_replica, only: [:show]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -971,12 +971,12 @@ class UsersController < ApplicationController
   def moderation
     before = params[:before] || Time.now
     if @user == current_user && !current_user.is_admin?
-      flash[:error] = t(:you_dont_have_permission_to_do_that)
+      flash[:error] = t( :you_dont_have_permission_to_do_that )
       return redirect_back_or_default person_by_login_path( @user.login )
     end
     max = 100
     @valid_years = ( 2008..Date.today.year ).to_a.reverse
-    @years = ( params[:years] || [] ).map(&:to_i) & @valid_years
+    @years = ( params[:years] || [] ).map( &:to_i ) & @valid_years
     @types = ( params[:types] || [] ) & %w(Flag ModeratorNote ModeratorAction)
     scopes = {}
     scopes["ModeratorNote"] = ModeratorNote.
@@ -988,13 +988,18 @@ class UsersController < ApplicationController
       where( flaggable_user_id: @user ).
       where( "flaggable_type != 'Taxon'" ).
       order( "id desc" )
+    scopes["ModeratorAction"] = ModeratorAction.
+      where( "created_at < ?", before ).
+      where( resource_user_id: @user ).
+      order( "id desc" )
     @records = []
-    scopes.each do |type, scope|
+    scopes.each do | type, scope |
       next unless @types.blank? || @types.include?( type )
+
       if @years.blank?
         scope = scope.limit( max )
       else
-        @years.each do |year|
+        @years.each do | year |
           d1 = "#{year}-01-01"
           d2 = "#{year}-12-31"
           scope = scope.where( "#{Object.const_get( type ).table_name}.created_at BETWEEN ? AND ?", d1, d2 )
@@ -1002,42 +1007,7 @@ class UsersController < ApplicationController
       end
       @records += scope.to_a
     end
-    if @types.blank? || @types.include?( "ModeratorAction" )
-      ma_scope = ModeratorAction.
-        where( "moderator_actions.created_at < ?", before ).
-        order( "moderator_actions.id desc" )
-      if @years.blank?
-        ma_scope = ma_scope.limit( max )
-      else
-        @years.each do | year |
-          ma_scope = ma_scope.where(
-            "moderator_actions.created_at BETWEEN ? AND ?",
-            "#{year}-01-01",
-            "#{year}-12-31"
-          )
-        end
-      end
-      @records += ma_scope.
-        where( resource_type: "Identification" ).
-        joins( "JOIN identifications i ON i.id = moderator_actions.resource_id" ).
-        where( "i.user_id = ?", @user ).to_a
-      @records += ma_scope.
-        where( resource_type: "Comment" ).
-        joins( "JOIN comments c ON c.id = moderator_actions.resource_id" ).
-        where( "c.user_id = ?", @user ).to_a
-      @records += ma_scope.
-        where( resource_type: "User" ).
-        where( "moderator_actions.resource_id = ?", @user ).to_a
-      @records += ma_scope.
-        where( resource_type: "Photo" ).
-        joins( "JOIN photos ON photos.id = moderator_actions.resource_id" ).
-        where( "photos.user_id = ?", @user ).to_a
-      @records += ma_scope.
-        where( resource_type: "Sound" ).
-        joins( "JOIN sounds ON sounds.id = moderator_actions.resource_id" ).
-        where( "sounds.user_id = ?", @user ).to_a
-    end
-    @records = @records.flatten.sort_by {| r | r.created_at }
+    @records = @records.flatten.sort_by( &:created_at )
     respond_to do | format |
       format.html do
         render layout: "bootstrap-container"

--- a/app/models/deleted_photo.rb
+++ b/app/models/deleted_photo.rb
@@ -1,18 +1,37 @@
+# frozen_string_literal: true
+
 class DeletedPhoto < ApplicationRecord
   belongs_to :user
   belongs_to :photo
-  scope :still_in_s3, ->{ where(removed_from_s3: false) }
+  scope :still_in_s3, -> { where( removed_from_s3: false ) }
 
-  def remove_from_s3( options = { } )
-    return if removed_from_s3?
+  def eligible_for_removal?
+    return false if removed_from_s3?
+
     if orphan?
-      return if created_at > 1.month.ago
+      return false if created_at > 1.month.ago
     else
-      return if created_at > 6.month.ago
+      latest_moderator_action = ModeratorAction.where(
+        resource_type: ["Photo", "LocalPhoto"],
+        resource_id: photo_id
+      ).order( id: :desc ).first
+      if latest_moderator_action&.action == ModeratorAction::HIDE &&
+          latest_moderator_action&.private?
+        return false if created_at > ModeratorAction::PRIVATE_MEDIA_RETENTION_TIME.ago
+      elsif created_at > 6.month.ago
+        return false
+      end
     end
-    # do not remove from S3 if the DeletedPhoto is still associated to a Photo 
+    # do not remove from S3 if the DeletedPhoto is still associated to a Photo
     # (for example after resurrect)
-    return if photo
+    return false if photo
+
+    true
+  end
+
+  def remove_from_s3( options = {} )
+    return unless eligible_for_removal?
+
     client = options[:s3_client] || LocalPhoto.new.s3_client
     static_bucket = LocalPhoto.s3_bucket( false )
 
@@ -22,35 +41,35 @@ class DeletedPhoto < ApplicationRecord
     # first check to see if the photo has files in the ODP bucket
     if LocalPhoto.odp_s3_bucket_enabled?
       odp_bucket = LocalPhoto.s3_bucket( true )
-      s3_objects = client.list_objects( bucket: odp_bucket, prefix: "photos/#{ photo_id }/" )
+      s3_objects = client.list_objects( bucket: odp_bucket, prefix: "photos/#{photo_id}/" )
       images = s3_objects.contents
       found_in_odp_bucket = true unless images.blank?
     end
 
     # if there are no ODP files, check the static bucket
     if images.blank?
-      s3_objects = client.list_objects( bucket: static_bucket, prefix: "photos/#{ photo_id }/" )
+      s3_objects = client.list_objects( bucket: static_bucket, prefix: "photos/#{photo_id}/" )
       images = s3_objects.contents
     end
 
     # there were files in either bucket
-    if s3_objects && s3_objects.data && s3_objects.data.is_a?( Aws::S3::Types::ListObjectsOutput )
-      if images.any?
-        if found_in_odp_bucket
-          # the photo has files in the OBP bucket, so delete them
-          odp_bucket = LocalPhoto.s3_bucket( true )
-          puts "deleting photo #{photo_id} [#{images.size} files] from S3 ODP"
-          client.delete_objects( bucket: odp_bucket, delete: { objects: images.map{|s| { key: s.key } } } )
-        end
-        # the photo has files in either bucket, so attempt a delete from the static bucket
-        puts "deleting photo #{photo_id} [#{images.size} files] from S3"
-        client.delete_objects( bucket: static_bucket, delete: { objects: images.map{|s| { key: s.key } } } )
-        update( removed_from_s3: true )
-      else
-        # the file list is for some reason empty
-        update( removed_from_s3: true )
-        puts "#{photo_id} has no photos in S3"
+    return unless s3_objects&.data.is_a?( Aws::S3::Types::ListObjectsOutput )
+
+    if images.any?
+      if found_in_odp_bucket
+        # the photo has files in the OBP bucket, so delete them
+        odp_bucket = LocalPhoto.s3_bucket( true )
+        puts "deleting photo #{photo_id} [#{images.size} files] from S3 ODP"
+        client.delete_objects( bucket: odp_bucket, delete: { objects: images.map {| s | { key: s.key } } } )
       end
+      # the photo has files in either bucket, so attempt a delete from the static bucket
+      puts "deleting photo #{photo_id} [#{images.size} files] from S3"
+      client.delete_objects( bucket: static_bucket, delete: { objects: images.map {| s | { key: s.key } } } )
+      update( removed_from_s3: true )
+    else
+      # the file list is for some reason empty
+      update( removed_from_s3: true )
+      puts "#{photo_id} has no photos in S3"
     end
   end
 
@@ -60,9 +79,8 @@ class DeletedPhoto < ApplicationRecord
       where( "id >= ?", min_id ).
       where( "id < ?", max_id ).
       includes( :photo ).
-      find_each( batch_size: 1000 ) do |dp|
+      find_each( batch_size: 1000 ) do | dp |
       dp.remove_from_s3( s3_client: client )
     end
   end
-
 end

--- a/app/models/deleted_sound.rb
+++ b/app/models/deleted_sound.rb
@@ -1,5 +1,31 @@
+# frozen_string_literal: true
+
 class DeletedSound < ApplicationRecord
   belongs_to :user
   belongs_to :sound
-  scope :still_in_s3, ->{ where(removed_from_s3: false) }
+  scope :still_in_s3, -> { where( removed_from_s3: false ) }
+
+  def eligible_for_removal?
+    return false if removed_from_s3?
+
+    if orphan?
+      return false if created_at > 1.month.ago
+    else
+      latest_moderator_action = ModeratorAction.where(
+        resource_type: ["Sound", "LocalSound"],
+        resource_id: sound_id
+      ).order( id: :desc ).first
+      if latest_moderator_action&.action == ModeratorAction::HIDE &&
+          latest_moderator_action&.private?
+        return false if created_at > ModeratorAction::PRIVATE_MEDIA_RETENTION_TIME.ago
+      elsif created_at > 6.month.ago
+        return false
+      end
+    end
+    # do not remove from S3 if the DeletedSound is still associated to a Sound
+    # (for example after resurrect)
+    return false if sound
+
+    true
+  end
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -12,7 +12,10 @@ class Photo < ApplicationRecord
   has_many :observations, :through => :observation_photos
   has_many :taxa, :through => :taxon_photos
 
-  has_moderator_actions %w(hide unhide)
+  has_moderator_actions [
+    ModeratorAction::HIDE,
+    ModeratorAction::UNHIDE
+  ]
 
   attr_accessor :api_response, :orphan,
     :remote_original_url,

--- a/app/models/sound.rb
+++ b/app/models/sound.rb
@@ -5,7 +5,10 @@ class Sound < ApplicationRecord
   has_many :observation_sounds, :dependent => :destroy
   has_many :observations, :through => :observation_sounds
 
-  has_moderator_actions %w(hide unhide)
+  has_moderator_actions [
+    ModeratorAction::HIDE,
+    ModeratorAction::UNHIDE
+  ]
 
   serialize :native_response
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,6 +211,8 @@ class User < ApplicationRecord
   has_one :user_parent, dependent: :destroy, inverse_of: :user
   has_many :parentages, class_name: "UserParent", foreign_key: "parent_user_id", inverse_of: :parent_user
   has_many :moderator_actions, inverse_of: :user
+  has_many :moderator_actions_as_resource_user, inverse_of: :resource_user,
+    class_name: "ModeratorAction", foreign_key: "resource_user_id"
   has_many :moderator_notes, inverse_of: :user
   has_many :moderator_notes_as_subject, class_name: "ModeratorNote",
     foreign_key: "subject_user_id", inverse_of: :subject_user,

--- a/app/views/moderator_actions/hide_content.html.haml
+++ b/app/views/moderator_actions/hide_content.html.haml
@@ -40,15 +40,19 @@
         minlength: ModeratorAction::MINIMUM_REASON_LENGTH,
         maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH,
         placeholder: placeholder_text
+    - if is_admin? && ["Photo", "Sound"].include?( @item.class.base_class.name ) && !@item.hidden?
+      %label
+        = f.check_box :private
+        = t( :make_private )
     = f.hidden_field :action, value: @item.hidden? ? ModeratorAction::UNHIDE : ModeratorAction::HIDE
     = f.hidden_field :user_id, value: current_user.id
     = f.hidden_field :resource_id, value: @item.id
     = f.hidden_field :resource_type, value: @item.class.base_class.name
     - if @item.hidden?
-      .text.text-muted
+      .text.upstacked.text-muted
         = t( :unhide_desc )
     - else
-      .text.text-muted
+      .text.upstacked.text-muted
         %p= t( :hide_desc )
         %p= t( :hide_desc_staff_can_unhide )
     = f.submit t( @item.hidden? ? :unhide_content : :hide_content ), class: "default button submit-flag-button"

--- a/app/views/users/moderation.html.haml
+++ b/app/views/users/moderation.html.haml
@@ -76,7 +76,12 @@
               = link_to t(:edit), edit_moderator_note_path( record ), class: "btn btn-sm btn-default"
               = link_to t(:delete), moderator_note_path( record ), method: :delete, data: { confirm: t(:are_you_sure?) }, class: "btn btn-sm btn-danger"
           - elsif record.is_a?( ModeratorAction )
-            = link_to t(:view), record.resource, class: "btn btn-sm btn-link"
+            - if record.resource
+              = link_to t(:view), record.resource, class: "btn btn-sm btn-link"
+            - elsif record.resource_parent
+              = link_to t(:view), record.resource_parent, class: "btn btn-sm btn-link"
+            - else
+              = t :removed
           - else
             = link_to t(:view), record, class: "btn btn-sm btn-link"
 

--- a/app/webpack/observations/identify/containers/moderator_action_modal_container.js
+++ b/app/webpack/observations/identify/containers/moderator_action_modal_container.js
@@ -15,8 +15,8 @@ function mapStateToProps( state ) {
 
 function mapDispatchToProps( dispatch ) {
   return {
-    submit: ( item, action, reason ) => {
-      dispatch( submitModeratorAction( item, action, reason ) )
+    submit: ( item, action, reason, makePrivate = false ) => {
+      dispatch( submitModeratorAction( item, action, reason, makePrivate ) )
         .then( ( ) => dispatch( fetchCurrentObservation( ) ) );
       dispatch( hideModeratorActionForm( ) );
     },

--- a/app/webpack/observations/show/components/activity_item_menu.jsx
+++ b/app/webpack/observations/show/components/activity_item_menu.jsx
@@ -37,7 +37,7 @@ const ActivityItemMenu = ( {
   const viewerIsAdmin = loggedInUser && loggedInUser.roles
     && loggedInUser.roles.indexOf( "admin" ) >= 0;
   const latestModeratorAction = _.first(
-    _.orderBy( item.moderator_actions || [], ["created_at", "desc"] )
+    _.orderBy( item.moderator_actions || [], "created_at", "desc" )
   );
   const currentUserIsHidingCurator = latestModeratorAction
     && latestModeratorAction.action === "hide"

--- a/app/webpack/observations/show/components/photo_browser.jsx
+++ b/app/webpack/observations/show/components/photo_browser.jsx
@@ -157,7 +157,7 @@ class PhotoBrowser extends React.Component {
         square = null;
       }
       const latestPhotoModeratorAction = _.first(
-        _.orderBy( photo.moderator_actions || [], ["created_at", "desc"] )
+        _.orderBy( photo.moderator_actions || [], "created_at", "desc" )
       );
       const currentUserIsPhotoHidingCurator = latestPhotoModeratorAction
         && latestPhotoModeratorAction.action === "hide"
@@ -179,6 +179,7 @@ class PhotoBrowser extends React.Component {
                   radioOptions: ["spam", "copyright infringement", "inappropriate"]
                 } )}
                 title={I18n.t( "flag_as_inappropriate" )}
+                label={I18n.t( "flag_as_inappropriate" )}
               >
                 <i className="fa fa-flag" />
               </button>
@@ -206,8 +207,30 @@ class PhotoBrowser extends React.Component {
                   title={photo.hidden
                     ? I18n.t( "unhide_content" )
                     : I18n.t( "hide_content" )}
+                  label={photo.hidden
+                    ? I18n.t( "unhide_content" )
+                    : I18n.t( "hide_content" )}
                 >
                   <i className={`fa ${photo.hidden ? "fa-eye" : "fa-eye-slash"}`} />
+                </button>
+                )
+              }
+              {
+                // admins see the option to hide content that is already
+                // hidden in case they need to mark it as private
+                ( !this.viewerIsObserver
+                  && viewerIsAdmin
+                  && photo.hidden
+                  && !latestPhotoModeratorAction?.private
+                ) && (
+                <button
+                  type="button"
+                  className="btn btn-nostyle"
+                  onClick={( ) => hideContent( photo )}
+                  title={I18n.t( "hide_content" )}
+                  label={I18n.t( "hide_content" )}
+                >
+                  <i className="fa fa-lock" />
                 </button>
                 )
               }
@@ -274,7 +297,7 @@ class PhotoBrowser extends React.Component {
       sound = new sound.constructor( { ...sound, user: observation.user } );
 
       const latestSoundModeratorAction = _.first(
-        _.orderBy( sound.moderator_actions || [], ["created_at", "desc"] )
+        _.orderBy( sound.moderator_actions || [], "created_at", "desc" )
       );
       const currentUserIsSoundHidingCurator = latestSoundModeratorAction
         && latestSoundModeratorAction.action === "hide"
@@ -376,6 +399,7 @@ class PhotoBrowser extends React.Component {
                     radioOptions: ["spam", "copyright infringement", "inappropriate"]
                   } )}
                   title={I18n.t( "flag_this_sound" )}
+                  label={I18n.t( "flag_this_sound" )}
                 >
                   <i className="fa fa-flag" />
                 </button>
@@ -403,8 +427,31 @@ class PhotoBrowser extends React.Component {
                     title={sound.hidden
                       ? I18n.t( "unhide_content" )
                       : I18n.t( "hide_content" )}
+                    label={sound.hidden
+                      ? I18n.t( "unhide_content" )
+                      : I18n.t( "hide_content" )}
                   >
                     <i className={`fa ${sound.hidden ? "fa-eye" : "fa-eye-slash"}`} />
+                  </button>
+                )
+                }
+                {
+                  // admins see the option to hide content that is already
+                  // hidden in case they need to mark it as private
+                  ( !this.viewerIsObserver
+                    && viewerIsAdmin
+                    && sound.hidden
+                    && !latestSoundModeratorAction?.private
+                  ) && (
+                  // eslint-disable-next-line jsx-a11y/control-has-associated-label
+                  <button
+                    type="button"
+                    className="btn btn-nostyle"
+                    onClick={( ) => hideContent( sound )}
+                    title={I18n.t( "hide_content" )}
+                    label={I18n.t( "hide_content" )}
+                  >
+                    <i className="fa fa-lock" />
                   </button>
                   )
                 }

--- a/app/webpack/observations/show/containers/moderator_action_modal_container.js
+++ b/app/webpack/observations/show/containers/moderator_action_modal_container.js
@@ -16,9 +16,9 @@ function mapStateToProps( state ) {
 
 function mapDispatchToProps( dispatch ) {
   return {
-    submit: ( item, action, reason ) => {
+    submit: ( item, action, reason, makePrivate = false ) => {
       dispatch( setItemAPIStatus( item, "processing" ) );
-      dispatch( submitModeratorAction( item, action, reason ) )
+      dispatch( submitModeratorAction( item, action, reason, makePrivate ) )
         .then( ( ) => dispatch( afterAPICall( ) ) )
         .catch( e => dispatch( afterAPICall( { error: e } ) ) );
       dispatch( hideModeratorActionForm( ) );

--- a/app/webpack/shared/components/moderator_action_modal.jsx
+++ b/app/webpack/shared/components/moderator_action_modal.jsx
@@ -22,6 +22,7 @@ const ModeratorActionModal = ( {
   if ( !item ) {
     return null;
   }
+  const viewerIsAdmin = config.currentUser?.roles?.indexOf( "admin" ) >= 0;
   let verb = I18n.t( "hide_content" );
   let placeholder = I18n.t( "please_explain_why_you_want_to_hide_this" );
   if ( action === "unhide" ) {
@@ -96,6 +97,17 @@ const ModeratorActionModal = ( {
   } else {
     throw new Error( "Can't moderate content of an unknown type" );
   }
+  let privateToggle;
+  if ( action === "hide" && viewerIsAdmin && (
+    item instanceof Photo || item instanceof Sound
+  ) ) {
+    privateToggle = (
+      <label>
+        <input type="checkbox" name="private" />
+        { I18n.t( "make_private" ) }
+      </label>
+    );
+  }
   return (
     <Modal
       show={visible}
@@ -107,7 +119,8 @@ const ModeratorActionModal = ( {
           e.preventDefault( );
           const formData = new FormData( e.target );
           const reason = formData.get( "reason" );
-          submit( item, action, reason );
+          const makePrivate = formData.get( "private" );
+          submit( item, action, reason, makePrivate );
           return false;
         }}
       >
@@ -118,7 +131,10 @@ const ModeratorActionModal = ( {
         </Modal.Header>
         <Modal.Body>
           {contentPreview}
-          <textarea name="reason" className="form-control" placeholder={placeholder} required />
+          <div className="form-group">
+            <textarea name="reason" className="form-control" placeholder={placeholder} required />
+          </div>
+          {privateToggle}
           <input type="hidden" name="action" value={action || ""} />
           <div className="text upstacked text-muted">
             <p>{ action === "unhide" ? I18n.t( "unhide_desc" ) : I18n.t( "hide_desc" ) }</p>

--- a/app/webpack/shared/ducks/moderator_actions.js
+++ b/app/webpack/shared/ducks/moderator_actions.js
@@ -32,7 +32,7 @@ const showModeratorActionForm = ( item, action ) => (
   }
 );
 
-const submitModeratorAction = ( item, action, reason ) => (
+const submitModeratorAction = ( item, action, reason, makePrivate = false ) => (
   function ( ) {
     const data = new FormData( );
     data.append( "authenticity_token", $( "meta[name=csrf-token]" ).attr( "content" ) );
@@ -51,6 +51,9 @@ const submitModeratorAction = ( item, action, reason ) => (
     data.append( "moderator_action[resource_id]", item.id );
     data.append( "moderator_action[reason]", reason );
     data.append( "moderator_action[action]", action );
+    if ( makePrivate ) {
+      data.append( "moderator_action[private]", "true" );
+    }
     return fetch( "/moderator_actions.json", {
       method: "POST",
       body: data

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3017,6 +3017,9 @@ en:
   make_a_taxon_swap_instead?: Make a TaxonSwap instead?
   make_curator: Make curator
   make_manager: Make manager
+  # Label for checkbox used to allow admin users to mark content as private when hiding. Private
+  # content is hidden from normal users, but also from curators, allowing only admins to view it
+  make_private: Make private
   make_sure_the_default_photo_looks_good: Make sure the default photo looks good in large size.
   make_this_your_default_license: "Make this your default %{type} license"
   make_this_the_primary_listing: "Make this the primary listing"
@@ -9942,8 +9945,19 @@ en:
             action:
               not_supported_for_this_kind_of_content: is not supported for this kind of content
             base:
+              # Error saying that the private attribute of a ModeratorAction can only be applied
+              # if the moderated resource is also marked as hidden
+              only_hidden_content_can_be_private:
+                Only hidden content can be private
+              # Error saying that only curator and admin users are allowed to create
+              # a ModeratorAction with action Hide
+              only_staff_and_curators_can_hide:
+                Only staff and curators can hide content
               only_staff_and_hiding_curators_can_unhide:
                 Only staff and curators who hide content can unhide it
+              # Error saying that only admin users (staff) can set resources as private
+              only_staff_can_make_private:
+                Only staff can set content as private
               staff_cannot_be_suspended: Staff cannot be suspended
             user_id:
               must_be_a_curator: must be a curator

--- a/db/migrate/20250124155306_add_private_to_moderator_actions.rb
+++ b/db/migrate/20250124155306_add_private_to_moderator_actions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrivateToModeratorActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :moderator_actions, :private, :boolean, default: false
+  end
+end

--- a/db/migrate/20250127200519_add_columns_to_moderator_actions.rb
+++ b/db/migrate/20250127200519_add_columns_to_moderator_actions.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class AddColumnsToModeratorActions < ActiveRecord::Migration[6.1]
+  def up
+    add_column :moderator_actions, :resource_user_id, :integer
+    add_column :moderator_actions, :resource_parent_id, :integer
+    add_column :moderator_actions, :resource_parent_type, :string
+    add_column :moderator_actions, :resource_content, :text
+
+    ModeratorAction.includes( :resource ).find_in_batches( batch_size: 500 ) do | batch |
+      ModeratorAction.transaction do
+        batch.each do | moderator_action |
+          next unless moderator_action.resource
+
+          updates = {}
+          if ( user = Flag.instance_user( moderator_action.resource ) )
+            updates[:resource_user_id] = user.id
+          end
+          if ( resource_content = Flag.instance_content( moderator_action.resource ) )
+            updates[:resource_content] = resource_content
+          end
+          if ( resource_parent = Flag.instance_parent( moderator_action.resource ) )
+            updates[:resource_parent_type] = resource_parent&.class&.polymorphic_name
+            updates[:resource_parent_id] = resource_parent&.id
+          end
+          next if updates.blank?
+
+          # use update_columns to make sure these columns are retroactively
+          # populated even if the records are no longer valid, e.g. if the
+          # moderating user has since been deleted
+          moderator_action.update_columns( updates )
+        end
+      end
+    end
+  end
+
+  def down
+    remove_column :moderator_actions, :resource_user_id
+    remove_column :moderator_actions, :resource_parent_id
+    remove_column :moderator_actions, :resource_parent_type
+    remove_column :moderator_actions, :resource_content
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2578,7 +2578,8 @@ CREATE TABLE public.moderator_actions (
     action character varying,
     reason character varying,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    private boolean DEFAULT false
 );
 
 
@@ -11392,6 +11393,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240923134658'),
 ('20241127180606'),
 ('20241202092831'),
-('20241218164832');
+('20241218164832'),
+('20250124155306');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2579,7 +2579,11 @@ CREATE TABLE public.moderator_actions (
     reason character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    private boolean DEFAULT false
+    private boolean DEFAULT false,
+    resource_user_id integer,
+    resource_parent_id integer,
+    resource_parent_type character varying,
+    resource_content text
 );
 
 
@@ -11394,6 +11398,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241127180606'),
 ('20241202092831'),
 ('20241218164832'),
-('20250124155306');
+('20250124155306'),
+('20250127200519');
 
 

--- a/lib/acts_as_flaggable/flag.rb
+++ b/lib/acts_as_flaggable/flag.rb
@@ -154,6 +154,49 @@ class Flag < ApplicationRecord
     flaggable_str.constantize.find( flaggable_id )
   end
 
+  def self.instance_parent( instance )
+    return unless instance
+
+    instance_type = instance.class.polymorphic_name
+    case instance_type
+    when "Comment", "Post" then instance.parent
+    when "Identification" then instance.observation
+    when "Photo"
+      if instance.observations.exists?
+        instance.observations.first
+      elsif instance.taxa.exists?
+        instance.taxa.first
+      elsif instance.guide_photos.exists?
+        instance.guide_photos.first.guide_taxon
+      end
+    when "Sound"
+      if instance.observations.exists?
+        instance.observations.first
+      end
+    end
+  end
+
+  def self.instance_user( instance )
+    return unless instance
+
+    instance_type = instance.class.polymorphic_name
+    case instance_type
+    when "User" then instance
+    when "Message" then instance.from_user
+    else
+      k, reflection = instance.class.reflections.detect do | r |
+        r[1].class_name == "User" && r[1].macro == :belongs_to
+      end
+      if reflection
+        instance.send( k )
+      end
+    end
+  end
+
+  def self.instance_content( instance )
+    instance.try_methods( :body, :description )
+  end
+
   def flagged_object
     return unless ( klass = Object.const_get( flaggable_type ) )
 
@@ -171,51 +214,25 @@ class Flag < ApplicationRecord
     true
   end
 
-  def get_flaggable_user
-    case flaggable_type
-    when "User" then flaggable
-    when "Message" then flaggable.from_user
-    else
-      k, reflection = flaggable.class.reflections.detect do | r |
-        r[1].class_name == "User" && r[1].macro == :belongs_to
-      end
-      if reflection
-        flaggable.send( k )
-      end
-    end
-  end
-
   def set_flaggable_user_id
-    return true unless flaggable
+    return unless flaggable
 
-    if ( u = get_flaggable_user )
-      self.flaggable_user_id = u.id
-    end
-    true
+    user = Flag.instance_user( flaggable )
+    return if user.blank?
+
+    self.flaggable_user_id = user.id
   end
 
   def set_flaggable_content
-    return true unless flaggable
+    return unless flaggable
 
-    self.flaggable_content = flaggable.try_methods( :body, :description )
-    true
+    self.flaggable_content = Flag.instance_content( flaggable )
   end
 
   def set_flaggable_parent
-    return true unless flaggable
+    return unless flaggable
 
-    self.flaggable_parent = case flaggable_type
-    when "Comment", "Post" then flaggable.parent
-    when "Identification" then flaggable.observation
-    when "Photo"
-      if flaggable.observations.exists?
-        flaggable.observations.first
-      elsif flaggable.taxa.exists?
-        flaggable.taxa.first
-      elsif flaggable.guide_photos.exists?
-        flaggable.guide_photos.first.guide_taxon
-      end
-    end
+    self.flaggable_parent = Flag.instance_parent( flaggable )
   end
 
   def viewable_by?( user )

--- a/lib/tasks/inaturalist.rake
+++ b/lib/tasks/inaturalist.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :inaturalist do
   desc "Copy example config files."
   task :setup do
@@ -79,15 +81,15 @@ namespace :inaturalist do
   end
 
   desc "Delete expired S3 photos"
-  task :delete_expired_photos => :environment do
+  task delete_expired_photos: :environment do
     client = LocalPhoto.new.s3_client
     fails = 0
     DeletedPhoto.still_in_s3.
-      joins("LEFT JOIN photos ON (deleted_photos.photo_id = photos.id)").
-      where("photos.id IS NULL").
-      where("(orphan=false AND deleted_photos.created_at <= ?)
+      joins( "LEFT JOIN photos ON (deleted_photos.photo_id = photos.id)" ).
+      where( "photos.id IS NULL" ).
+      where( "(orphan=false AND deleted_photos.created_at <= ?)
         OR (orphan=true AND deleted_photos.created_at <= ?)",
-        6.months.ago, 1.month.ago).includes( :photo ).find_each do |dp|
+        6.months.ago, 1.month.ago ).includes( :photo ).find_each do | dp |
       begin
         dp.remove_from_s3( s3_client: client )
       rescue
@@ -96,7 +98,7 @@ namespace :inaturalist do
       end
     end
     # Delete user profile pics for users that were deleted over a month ago
-    DeletedUser.where( "created_at < ?", 1.month.ago ).each do |du|
+    DeletedUser.where( "created_at < ?", 1.month.ago ).each do | du |
       begin
         User.remove_icon_from_s3( du.user_id )
       rescue
@@ -107,14 +109,15 @@ namespace :inaturalist do
   end
 
   desc "Delete expired local photos"
-  task :delete_expired_local_photos => :environment do
+  task delete_expired_local_photos: :environment do
     return unless Rails.env.development?
+
     deleted = []
-    DeletedPhoto.find_each do |dp|
+    DeletedPhoto.find_each do | dp |
       path = File.join( Rails.root, "public", "attachments", "local_photos", "files", dp.photo_id.to_s )
-      if File.exists?( path )
+      if File.exist?( path )
         deleted_paths = FileUtils.rm_rf( path )
-        if deleted_paths.size > 0
+        if deleted_paths.positive?
           deleted << dp.photo_id
         end
       end
@@ -123,8 +126,8 @@ namespace :inaturalist do
   end
 
   desc "Delete expired S3 sounds"
-  task :delete_expired_sounds => :environment do
-    S3_CONFIG = YAML.load_file(File.join(Rails.root, "config", "s3.yml"))
+  task delete_expired_sounds: :environment do
+    S3_CONFIG = YAML.load_file( File.join( Rails.root, "config", "s3.yml" ) )
     client = ::Aws::S3::Client.new(
       access_key_id: S3_CONFIG["access_key_id"],
       secret_access_key: S3_CONFIG["secret_access_key"],
@@ -133,17 +136,19 @@ namespace :inaturalist do
 
     fails = 0
     DeletedSound.still_in_s3.
-      joins("LEFT JOIN sounds ON (deleted_sounds.sound_id = sounds.id)").
-      where("sounds.id IS NULL").
-      where("(orphan=false AND deleted_sounds.created_at <= ?)
+      joins( "LEFT JOIN sounds ON (deleted_sounds.sound_id = sounds.id)" ).
+      where( "sounds.id IS NULL" ).
+      where( "(orphan=false AND deleted_sounds.created_at <= ?)
         OR (orphan=true AND deleted_sounds.created_at <= ?)",
-        6.months.ago, 1.month.ago).select(:id, :sound_id).find_each do |s|
-      sounds = client.list_objects( bucket: CONFIG.s3_bucket, prefix: "sounds/#{ s.sound_id }." ).contents
+        6.months.ago, 1.month.ago ).select( :id, :sound_id ).find_each do | s |
+      next unless s.eligible_for_removal?
+
+      sounds = client.list_objects( bucket: CONFIG.s3_bucket, prefix: "sounds/#{s.sound_id}." ).contents
       if sounds.any?
         pp sounds
         begin
-          client.delete_objects( bucket: CONFIG.s3_bucket, delete: { objects: sounds.map{|s| { key: s.key } } } )
-          s.update(removed_from_s3: true)
+          client.delete_objects( bucket: CONFIG.s3_bucket, delete: { objects: sounds.map {| s | { key: s.key } } } )
+          s.update( removed_from_s3: true )
         rescue
           fails += 1
           break if fails >= 5
@@ -153,23 +158,23 @@ namespace :inaturalist do
   end
 
   desc "Delete orphaned photos"
-  task :delete_orphaned_photos => :environment do
-    first_id = Photo.minimum(:id)
-    last_id = Photo.maximum(:id) - 10000
+  task delete_orphaned_photos: :environment do
+    first_id = Photo.minimum( :id )
+    last_id = Photo.maximum( :id ) - 10_000
     index = first_id
-    batch_size = 10000
+    batch_size = 10_000
     # using `where id BETWEEN` instead of .find_each or similar, which use
     # LIMIT and create fewer, but longer-running queries
     orphans_count = 0
     last_orphan_id = 0
     while index <= last_id
-      photos = Photo.joins("left join observation_photos op on (photos.id=op.photo_id)").
-        joins("left join taxon_photos tp on (photos.id=tp.photo_id)").
-        joins("left join guide_photos gp on (photos.id=gp.photo_id)").
-        where("op.id IS NULL and tp.id IS NULL and gp.id IS NULL").
-        where("photos.id BETWEEN ? AND ?", index, index + batch_size).
-        where("photos.created_at <= ?", 1.week.ago)
-      photos.each do |p|
+      photos = Photo.joins( "left join observation_photos op on (photos.id=op.photo_id)" ).
+        joins( "left join taxon_photos tp on (photos.id=tp.photo_id)" ).
+        joins( "left join guide_photos gp on (photos.id=gp.photo_id)" ).
+        where( "op.id IS NULL and tp.id IS NULL and gp.id IS NULL" ).
+        where( "photos.id BETWEEN ? AND ?", index, index + batch_size ).
+        where( "photos.created_at <= ?", 1.week.ago )
+      photos.each do | p |
         # set the orphan attribute on Photo, which will set the same on DeletedPhoto
         begin
           p.orphan = true
@@ -186,21 +191,21 @@ namespace :inaturalist do
   end
 
   desc "Delete orphaned sounds"
-  task :delete_orphaned_sounds => :environment do
-    first_id = Sound.minimum(:id)
-    last_id = Sound.maximum(:id) - 10000
-    index = 0
-    batch_size = 10000
+  task delete_orphaned_sounds: :environment do
+    first_id = Sound.minimum( :id )
+    last_id = Sound.maximum( :id ) - 10_000
+    index = first_id
+    batch_size = 10_000
     orphans_count = 0
     last_orphan_id = 0
     # using `where id BETWEEN` instead of .find_each or similar, which use
     # LIMIT and create fewer, but longer-running queries
     while index <= last_id
-      sounds = Sound.joins("left join observation_sounds os on (sounds.id=os.sound_id)").
-        where("os.id IS NULL").
-        where("sounds.id BETWEEN ? AND ?", index, index + batch_size).
-        where("sounds.created_at <= ?", 1.week.ago)
-      sounds.each do |s|
+      sounds = Sound.joins( "left join observation_sounds os on (sounds.id=os.sound_id)" ).
+        where( "os.id IS NULL" ).
+        where( "sounds.id BETWEEN ? AND ?", index, index + batch_size ).
+        where( "sounds.created_at <= ?", 1.week.ago )
+      sounds.each do | s |
         # set the orphan attribute on sound, which will set the same on Deletedsound
         s.orphan = true
         s.destroy
@@ -211,7 +216,6 @@ namespace :inaturalist do
       puts "#{index} :: total #{orphans_count} :: last #{last_orphan_id}"
     end
   end
-
 
   desc "Delete orphaned and expired photos"
   task :delete_orphaned_and_expired_photos, [:log_task_name] => :environment do | _, args |

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -101,6 +101,14 @@ DataPartner.blueprint do
   url { "https://#{Faker::Internet.domain_name}" }
 end
 
+DeletedPhoto.blueprint do
+  user { User.make! }
+end
+
+DeletedSound.blueprint do
+  user { User.make! }
+end
+
 ExplodedAtlasPlace.blueprint do
   atlas { Atlas.make! }
   place { make_place_with_geom }

--- a/spec/controllers/moderator_actions_controller_spec.rb
+++ b/spec/controllers/moderator_actions_controller_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ModeratorActionsController do
+  let( :generic_reason ) { Faker::Lorem.sentence }
+
+  describe "create" do
+    it "creates moderator actions" do
+      user = make_admin
+      sign_in user
+      photo = Photo.make!
+      post :create, format: :json, params: { moderator_action: {
+        resource_type: "Photo",
+        resource_id: photo.id,
+        reason: generic_reason,
+        action: ModeratorAction::HIDE,
+        private: true
+      } }
+      expect( response ).to be_successful
+      json = JSON.parse( response.body )
+      expect( json["resource_type"] ).to eq "Photo"
+      expect( json["resource_id"] ).to eq photo.id
+      expect( json["reason"] ).to eq generic_reason
+      expect( json["action"] ).to eq ModeratorAction::HIDE
+      expect( json["private"] ).to eq true
+      expect( json["user_id"] ).to eq user.id
+    end
+  end
+
+  describe "resource_url" do
+    let( :admin ) { make_admin }
+    let( :photo ) { LocalPhoto.make! }
+    let( :presigned_url ) { "https://#{Faker::Internet.domain_name}/image.png" }
+    let( :moderator_action ) do
+      ModeratorAction.make!(
+        resource: photo,
+        action: ModeratorAction::HIDE,
+        reason: generic_reason
+      )
+    end
+    before do
+      allow_any_instance_of( LocalPhoto ).to receive( :presigned_url ).and_return( presigned_url )
+    end
+
+    it "allows admins to generate URLs for hidden media" do
+      sign_in admin
+      get :resource_url, format: :json, params: { id: moderator_action.id }
+      expect( response ).to be_successful
+      json = JSON.parse( response.body )
+      expect( json["resource_url"] ).to eq presigned_url
+    end
+
+    it "allows curators to generate URLs for hidden media" do
+      sign_in make_curator
+      get :resource_url, format: :json, params: { id: moderator_action.id }
+      expect( response ).to be_successful
+      json = JSON.parse( response.body )
+      expect( json["resource_url"] ).to eq presigned_url
+    end
+
+    it "does not allow regular users to generate URLs for hidden media" do
+      sign_in User.make!
+      get :resource_url, format: :json, params: { id: moderator_action.id }
+      expect( response ).not_to be_successful
+      json = JSON.parse( response.body )
+      expect( json["error"] ).to eq I18n.t( :only_curators_can_access_that_page )
+    end
+
+    describe "private media" do
+      let( :moderator_action ) do
+        ModeratorAction.make!(
+          resource: photo,
+          action: ModeratorAction::HIDE,
+          reason: generic_reason,
+          private: true,
+          user: admin
+        )
+      end
+
+      it "allows admins to generate URLs for private media" do
+        sign_in make_admin
+        get :resource_url, format: :json, params: { id: moderator_action.id }
+        expect( response ).to be_successful
+        json = JSON.parse( response.body )
+        expect( json["resource_url"] ).to eq presigned_url
+      end
+
+      it "does not allow curators to generate URLs for private media" do
+        sign_in make_curator
+        get :resource_url, format: :json, params: { id: moderator_action.id }
+        expect( response ).not_to be_successful
+        json = JSON.parse( response.body )
+        expect( json["error"] ).to eq I18n.t( :only_administrators_may_access_that_page )
+      end
+
+      it "does not allow regular users to generate URLs for private media" do
+        sign_in User.make!
+        get :resource_url, format: :json, params: { id: moderator_action.id }
+        expect( response ).not_to be_successful
+        json = JSON.parse( response.body )
+        expect( json["error"] ).to eq I18n.t( :only_administrators_may_access_that_page )
+      end
+    end
+  end
+end

--- a/spec/controllers/photos_controller_api_spec.rb
+++ b/spec/controllers/photos_controller_api_spec.rb
@@ -94,6 +94,27 @@ shared_examples_for "a PhotosController" do
       expect( json["errors"]["uuid"] ).to eq ["has already been taken"]
     end
   end
+
+  describe "hide" do
+    let( :photo ) { LocalPhoto.make! }
+    it "regular users cannot access the hide endpoint" do
+      sign_in User.make!
+      get :hide, params: { id: photo.id }
+      expect( response ).not_to be_successful
+    end
+
+    it "curators can access the hide endpoint" do
+      sign_in make_curator
+      get :hide, params: { id: photo.id }
+      expect( response ).to be_successful
+    end
+
+    it "admins can access the hide endpoint" do
+      sign_in make_admin
+      get :hide, params: { id: photo.id }
+      expect( response ).to be_successful
+    end
+  end
 end
 
 describe PhotosController, "oauth authentication" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -370,7 +370,12 @@ describe UsersController, "moderation" do
     it "should work with a flag and ModeratorAction" do
       comment = create :comment, user: subject_user
       flag = create :flag, flaggable: comment
-      moderator_action = create :moderator_action, resource: comment, action: ModeratorAction::HIDE
+      moderator_action = create(
+        :moderator_action,
+        resource: comment,
+        action: ModeratorAction::HIDE,
+        user: make_curator
+      )
       get :moderation, params: { id: subject_user.login }
       expect( response.response_code ).to eq 200
       expect( assigns( :records ) ).to include flag

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -387,5 +387,23 @@ describe UsersController, "moderation" do
       expect( response.response_code ).to eq 200
       expect( assigns( :records ) ).to include moderator_note
     end
+    it "displays ModeratorActions even if the moderated resource has since been deleted" do
+      observation = Observation.make!
+      identification = Identification.make!( observation: observation, user: observation.user )
+      action = ModeratorAction.create(
+        resource: identification,
+        action: ModeratorAction::HIDE,
+        user: make_admin,
+        reason: Faker::Lorem.sentence
+      )
+      identification.destroy
+      get :moderation, params: { id: observation.user_id }
+      expect( response.response_code ).to eq 200
+      expect( assigns( :records ) ).to include action
+      expect( assigns( :records ).first.resource ).to be_nil
+      expect( response.body ).to have_tag(
+        "td", text: /Moderator Action.*Identification.*Removed/m
+      )
+    end
   end
 end

--- a/spec/models/deleted_sound_spec.rb
+++ b/spec/models/deleted_sound_spec.rb
@@ -2,96 +2,96 @@
 
 require "spec_helper"
 
-describe DeletedPhoto do
+describe DeletedSound do
   it { is_expected.to belong_to :user }
-  it { is_expected.to belong_to :photo }
+  it { is_expected.to belong_to :sound }
 
   describe "eligible_for_removal?" do
-    it "returns false if the photo is already removed" do
+    it "returns false if the sound is already removed" do
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: 1.year.ago
         ).eligible_for_removal?
       ).to be true
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: 1.year.ago,
           removed_from_s3: true
         ).eligible_for_removal?
       ).to be false
     end
 
-    it "returns false if the photo is orphaned but deleted more recently than 1 month" do
+    it "returns false if the sound is orphaned but deleted more recently than 1 month" do
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: ( 1.month - 1.day ).ago,
           orphan: true
         ).eligible_for_removal?
       ).to be false
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: ( 1.month + 1.day ).ago,
           orphan: true
         ).eligible_for_removal?
       ).to be true
     end
 
-    it "returns false if the photo is not orphaned but deleted more recently than 6 months" do
+    it "returns false if the sound is not orphaned but deleted more recently than 6 months" do
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: ( 6.months - 1.day ).ago,
           orphan: false
         ).eligible_for_removal?
       ).to be false
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: ( 6.months + 1.day ).ago,
           orphan: false
         ).eligible_for_removal?
       ).to be true
     end
 
-    it "returns false if the photo is set to private but deleted more recently than 2 months" do
-      photo = LocalPhoto.make!
+    it "returns false if the sound is set to private but deleted more recently than 2 months" do
+      sound = LocalSound.make!
       ModeratorAction.create(
         action: ModeratorAction::HIDE,
-        resource: photo,
+        resource: sound,
         user: make_admin,
         reason: Faker::Lorem.sentence,
         private: true
       )
-      photo.destroy
+      sound.destroy
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: ( 2.months - 1.day ).ago,
           orphan: false,
-          photo_id: photo.id
+          sound_id: sound.id
         ).eligible_for_removal?
       ).to be false
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: ( 2.months + 1.day ).ago,
           orphan: false,
-          photo_id: photo.id
+          sound_id: sound.id
         ).eligible_for_removal?
       ).to be true
     end
 
     it "returns false if the resource still exists" do
-      photo = LocalPhoto.make!
+      sound = LocalSound.make!
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: 1.year.ago,
-          photo_id: photo.id,
+          sound_id: sound.id,
           removed_from_s3: false
         ).eligible_for_removal?
       ).to be false
 
-      photo.destroy
+      sound.destroy
       expect(
-        DeletedPhoto.make!(
+        DeletedSound.make!(
           created_at: 1.year.ago,
-          photo_id: photo,
+          sound_id: sound,
           removed_from_s3: false
         ).eligible_for_removal?
       ).to be true

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -246,6 +246,205 @@ describe ModeratorAction do
         expect( u ).not_to be_suspended
       end
     end
+
+    describe "set_resource_user_id" do
+      it "is set properly for Comments" do
+        comment = Comment.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: comment,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_user ).to eq comment.user
+      end
+
+      it "is set properly for Identifications" do
+        identification = Identification.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: identification,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_user ).to eq identification.user
+      end
+
+      it "is set properly for Photos" do
+        photo = LocalPhoto.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: photo,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_user ).to eq photo.user
+      end
+
+      it "is set properly for Sounds" do
+        sound = LocalSound.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: sound,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_user ).to eq sound.user
+      end
+
+      it "is set properly for Users" do
+        user = User.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::SUSPEND,
+          resource: user,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_user ).to eq user
+      end
+    end
+
+    describe "set_resource_content" do
+      it "is set properly for Comments" do
+        comment = Comment.make!( body: Faker::Lorem.paragraph )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: comment,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_content ).to eq comment.body
+      end
+
+      it "is set properly for Identifications" do
+        identification = Identification.make!( body: Faker::Lorem.paragraph )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: identification,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_content ).to eq identification.body
+      end
+
+      it "is set properly for Photos" do
+        photo = LocalPhoto.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: photo,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_content ).to be_nil
+      end
+
+      it "is set properly for Sounds" do
+        sound = LocalSound.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: sound,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_content ).to be_nil
+      end
+
+      it "is set properly for Users" do
+        user = User.make!( description: Faker::Lorem.paragraph )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::SUSPEND,
+          resource: user,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_content ).to eq user.description
+      end
+    end
+
+    describe "set_resource_parent" do
+      it "is set properly for Comments" do
+        observation = Observation.make!
+        comment = Comment.make!( parent: observation )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: comment,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to eq comment.parent
+      end
+
+      it "is set properly for Identifications" do
+        observation = Observation.make!
+        identification = Identification.make!( observation: observation )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: identification,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to eq identification.observation
+      end
+
+      it "is set properly for observation Photos" do
+        observation = Observation.make!
+        photo = LocalPhoto.make!( user: observation.user )
+        observation_photo = ObservationPhoto.make!( observation: observation, photo: photo )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: observation_photo.photo,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to eq observation_photo.observation
+      end
+
+      it "is set properly for taxon Photos" do
+        taxon_photo = TaxonPhoto.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: taxon_photo.photo,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to eq taxon_photo.taxon
+      end
+
+      it "is set properly for guide Photos" do
+        guide_photo = GuidePhoto.make!
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: guide_photo.photo,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to eq guide_photo.guide_taxon
+      end
+
+      it "is set properly for observation Sounds" do
+        observation = Observation.make!
+        sound = LocalSound.make!( user: observation.user )
+        observation_sound = ObservationSound.make!( observation: observation, sound: sound )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::HIDE,
+          resource: observation_sound.sound,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to eq observation_sound.observation
+      end
+
+      it "is set properly for Users" do
+        user = User.make!( description: Faker::Lorem.paragraph )
+        action = ModeratorAction.make!(
+          action: ModeratorAction::SUSPEND,
+          resource: user,
+          user: admin,
+          reason: generic_reason
+        )
+        expect( action.resource_parent ).to be_nil
+      end
+    end
   end
 
   describe "persistence" do


### PR DESCRIPTION
- Allows admins to create ModeratorActions that make content "private"
- Private content cannot be unhidden by anyone other than other admins
- Curators cannot generate temporary presigned URLs for private content
- Once deleted, files associated with private content will removed from S3 within a maximum of 2 months (though all resources directly deleted by users will have their files removed in 30 days, and private resources are no exception)
- Also includes features requested in https://github.com/inaturalist/inaturalist/issues/4357
  - ModeratorActions record some metadata about the resources they are targeting, matching similar functionality in Flags. These data are preserved if the original resources are later deleted. This allows record keeping to persist if users delete content, or the users themselves are deleted
 