### PR TITLE
fix: resend messages by unsuspended user

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 class MessagesController < ApplicationController
   before_action :doorkeeper_authorize!,
-    only: [ :index, :create, :show, :destroy, :count ],
-    if: lambda { authenticate_with_oauth? }
-  before_action :authenticate_user!, unless: lambda { authenticated_with_oauth? }
-  before_action :load_message, :only => [:show, :destroy]
-  before_action :require_owner, :only => [:show, :destroy]
-  before_action :load_box, :only => [:show, :new, :index]
+    only: [:index, :create, :show, :destroy, :count],
+    if: -> { authenticate_with_oauth? }
+  before_action :authenticate_user!, unless: -> { authenticated_with_oauth? }
+  before_action :load_message, only: [:show, :destroy]
+  before_action :require_owner, only: [:show, :destroy]
+  before_action :load_box, only: [:show, :new, :index]
   check_spam only: [:create, :update], instance: :message
 
   requires_privilege :speech, only: [:new]
@@ -36,7 +38,7 @@ class MessagesController < ApplicationController
     if params[:threads].yesish?
       unless params[:q].blank?
         error_message = "Search will not work when grouping by thread"
-        respond_to do |format|
+        respond_to do | format |
           format.html do
             flash[:error] = error_message
             redirect_back_or_default messages_path
@@ -47,7 +49,9 @@ class MessagesController < ApplicationController
         end
         return
       end
-      threads_scope = @messages.select( "max(id) AS latest_id, thread_id, COUNT(id) AS thread_messages_count" ).group( "thread_id" )
+      threads_scope = @messages.
+        select( "max(id) AS latest_id, thread_id, COUNT(id) AS thread_messages_count" ).
+        group( "thread_id" )
       @messages = Message.
         select( "messages.*, threads.thread_messages_count" ).
         from( "(#{threads_scope.to_sql}) AS threads" ).
@@ -56,25 +60,31 @@ class MessagesController < ApplicationController
     unless params[:q].blank?
       @q = params[:q].to_s[0..100]
       @messages = @messages.joins( "JOIN users ON users.id = from_user_id" ).
-        where( "subject ILIKE ? OR body ILIKE ? OR users.name ILIKE ? OR users.login = ?", "%#{@q}%", "%#{@q}%", "%#{@q}%", @q )
+        where(
+          "subject ILIKE ? OR body ILIKE ? OR users.name ILIKE ? OR users.login = ?",
+          "%#{@q}%",
+          "%#{@q}%",
+          "%#{@q}%",
+          @q
+        )
     end
     @messages = @messages.order( "id desc" ).page( params[:page] ).includes( :from_user, :to_user )
-    respond_to do |format|
+    respond_to do | format |
       format.html do
         if params[:partial]
-          render :partial => "messages"
+          render partial: "messages"
         else
           render
         end
       end
       format.json do
-        results = @messages.map do |m|
+        results = @messages.map do | m |
           merges = {
             from_user: m.from_user&.as_json( only: [:id, :login] ),
-            to_user: m.to_user&.as_json( only: [:id, :login] ),
+            to_user: m.to_user&.as_json( only: [:id, :login] )
           }
           if params[:threads].yesish?
-            merges[:thread_flags] = m.thread_flags.map{|f| f.as_indexed_json}
+            merges[:thread_flags] = m.thread_flags.map( &:as_indexed_json )
           end
           m.as_json.merge( merges )
         end
@@ -89,28 +99,28 @@ class MessagesController < ApplicationController
   end
 
   def sent
-    @messages = current_user.messages.sent.page(params[:page])
+    @messages = current_user.messages.sent.page( params[:page] )
   end
 
   def show
     @messages = Message.where( user_id: @message.user_id, thread_id: @message.thread_id ).order( "id asc" )
     if current_user.is_admin? && current_user.id != @message.user_id
-      flash.now[:notice] =  "You can see this because you're on staff. Please be careful"
+      flash.now[:notice] = "You can see this because you're on staff. Please be careful"
     else
       Message.where( id: @messages, read_at: nil ).update_all( read_at: Time.now )
     end
     @thread_message = @messages.first
     @reply_to = @thread_message.from_user == current_user ? @thread_message.to_user : @thread_message.from_user
-    @flaggable_message = if m = @messages.detect{|m| m.from_user && m.from_user != current_user}
-      m.from_user.messages.where(:thread_id => @message.thread_id).first
+    @flaggable_message = if ( m = @messages.detect {| mes | mes.from_user && mes.from_user != current_user } )
+      m.from_user.messages.where( thread_id: @message.thread_id ).first
     end
-    if @flaggable_message && @flaggable_message.flagged?
-      @flag = @flaggable_message.flags.detect{|f| f.user_id == current_user.id }
+    if @flaggable_message&.flagged?
+      @flag = @flaggable_message.flags.detect {| f | f.user_id == current_user.id }
     end
     @new_correspondent = !Message.
       where( from_user_id: current_user, to_user_id: @reply_to ).
       exists?
-    respond_to do |format|
+    respond_to do | format |
       format.html
       format.json do
         render json: {
@@ -119,7 +129,7 @@ class MessagesController < ApplicationController
           total_results: @messages.count,
           thread_id: @thread_message.id,
           reply_to_user_id: @reply_to.id,
-          flaggable_message_id: @flaggable_message.try(:id),
+          flaggable_message_id: @flaggable_message.try( :id ),
           results: @messages.as_json
         }
       end
@@ -133,33 +143,32 @@ class MessagesController < ApplicationController
     end
     @message = current_user.messages.build
     @contacts = User.
-      select("DISTINCT ON (users.id) users.*").
-      joins("JOIN messages ON messages.to_user_id = users.id").
-      where("messages.from_user_id = ?", current_user).
-      limit(100)
-    @contacts = current_user.followees.limit(100) if @contacts.blank?
+      select( "DISTINCT ON (users.id) users.*" ).
+      joins( "JOIN messages ON messages.to_user_id = users.id" ).
+      where( "messages.from_user_id = ?", current_user ).
+      limit( 100 )
+    @contacts = current_user.followees.limit( 100 ) if @contacts.blank?
     unless @contacts.blank?
-      @contacts.each_with_index do |u,i|
-        @contacts[i].html = view_context.render_in_format(:html, :partial => "users/chooser", :object => u).gsub(/\n/, '')
+      @contacts.each_with_index do | u, i |
+        @contacts[i].html = view_context.render_in_format( :html, partial: "users/chooser", object: u ).gsub( /\n/,
+          "" )
       end
     end
-    unless params[:to].blank?
-      @message.to_user = User.find_by_login(params[:to])
-      @message.to_user ||= User.find_by_id(params[:to])
-    end
+    return if params[:to].blank?
+
+    @message.to_user = User.find_by_login( params[:to] )
+    @message.to_user ||= User.find_by_id( params[:to] )
   end
 
   def create
-    @message = current_user.messages.build(params[:message])
+    @message = current_user.messages.build( params[:message] )
     @message.user = current_user
     @message.from_user = current_user
-    unless params[:preview]
-      if @message.save
-        @message.send_message
-      end
+    if !params[:preview] && @message.save
+      @message.send_message
     end
 
-    respond_to do |format|
+    respond_to do | format |
       format.html do
         if @message.valid?
           redirect_to @message
@@ -186,11 +195,11 @@ class MessagesController < ApplicationController
       current_user.id, @message.thread_id
     )
     if thread_messages.blank?
-      return render_404
+      render_404
     else
       thread_messages.destroy_all
-      msg = t(:message_deleted)
-      respond_to do |format|
+      msg = t( :message_deleted )
+      respond_to do | format |
         format.html do
           flash[:notice] = msg
           redirect_to messages_url
@@ -203,7 +212,7 @@ class MessagesController < ApplicationController
   def count
     count = current_user.messages.inbox.unread.count
     session[:messages_count] = count
-    respond_to do |format|
+    respond_to do | format |
       format.json do
         render json: { count: count }
       end
@@ -211,33 +220,34 @@ class MessagesController < ApplicationController
   end
 
   def new_messages
-    @messages = current_user.messages.inbox.includes(:from_user).unread.order("id desc").limit(200)
-    @messages = current_user.messages.inbox.includes(:from_user).order("id desc").limit(7) if @messages.blank?
+    @messages = current_user.messages.inbox.includes( :from_user ).unread.order( "id desc" ).limit( 200 )
+    @messages = current_user.messages.inbox.includes( :from_user ).order( "id desc" ).limit( 7 ) if @messages.blank?
     session[:messages_count] = 0
-    render :layout => false
+    render layout: false
   end
 
   private
+
   def load_message
-    render_404 unless @message = Message.find_by_id(params[:id])
+    render_404 unless ( @message = Message.find_by_id( params[:id] ) )
   end
 
   def load_box
     @box = params[:box]
-    @box = Message::INBOX unless Message::BOXES.include?(@box) || @box == "any"
+    @box = Message::INBOX unless Message::BOXES.include?( @box ) || @box == "any"
   end
 
   def require_owner
-    return true if current_user && current_user.is_admin?
-    if @message.user != current_user
-      msg = I18n.t(:you_dont_have_permission_to_do_that)
-      respond_to do |format|
-        format.html do
-          flash[:error] = msg
-          return redirect_back_or_default(messages_url)
-        end
-        format.json { render json: { error: msg}, status: :forbidden }
+    return true if current_user&.is_admin?
+    return if @message.user == current_user
+
+    msg = I18n.t( :you_dont_have_permission_to_do_that )
+    respond_to do | format |
+      format.html do
+        flash[:error] = msg
+        return redirect_back_or_default( messages_url )
       end
+      format.json { render json: { error: msg }, status: :forbidden }
     end
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,7 +17,7 @@ class MessagesController < ApplicationController
   def index
     @messages = case @box
     when Message::SENT
-      current_user.messages.sent
+      current_user.messages.outbox
     when "any"
       current_user.messages
     else
@@ -99,7 +99,7 @@ class MessagesController < ApplicationController
   end
 
   def sent
-    @messages = current_user.messages.sent.page( params[:page] )
+    @messages = current_user.messages.outbox.page( params[:page] )
   end
 
   def show

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -135,7 +135,12 @@ class Message < ApplicationRecord
     true
   end
 
-  def flagged_with( flag, _options = {} )
+  def flagged_with( flag, options = {} )
     evaluate_new_flag_for_spam( flag )
+    return unless options[:action] == "resolved" && flag.flag == Flag::SPAM
+
+    Message.
+      delay( priority: USER_INTEGRITY_PRIORITY ).
+      resend_unsent_for_user( user_id )
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,37 +1,38 @@
+# frozen_string_literal: true
+
 class Message < ApplicationRecord
-  acts_as_spammable fields: [ :subject, :body ],
+  acts_as_spammable fields: [:subject, :body],
     user: :from_user
 
-  blockable_by lambda { |message| message.to_user_id },
-    blockable_user_id: lambda { |message| message.from_user_id }
-  
-  requires_privilege :speech, if: Proc.new {|m|
+  blockable_by ->( message ) { message.to_user_id },
+    blockable_user_id: ->( message ) { message.from_user_id }
+
+  requires_privilege :speech, if: proc {| m |
     from_user_id == user_id && ( m.thread_id.blank? || m.thread_id == m.id )
   }
 
   belongs_to :user
-  belongs_to :from_user, :class_name => "User"
-  belongs_to :to_user, :class_name => "User"
+  belongs_to :from_user, class_name: "User"
+  belongs_to :to_user, class_name: "User"
 
   validates_presence_of :user
   validates :from_user_id, presence: true, numericality: { greater_than: 0 }
   validates :to_user_id, presence: true, numericality: { greater_than: 0 }
   validate :validate_to_not_from
-  validates :body, :presence => true
+  validates :body, presence: true
   before_create :set_read_at, :set_subject_for_reply
   after_save :set_thread_id
   after_create :deliver_email
-  
-  scope :inbox, -> { where("user_id = to_user_id") } #.select("DISTINCT ON (thread_id) messages.*")
-  scope :sent, -> { where("user_id = from_user_id") } #.select("DISTINCT ON (thread_id) messages.*")
-  scope :unread, -> { where("read_at IS NULL") }
+
+  scope :inbox, -> { where( "user_id = to_user_id" ) } # .select("DISTINCT ON (thread_id) messages.*")
+  scope :sent, -> { where( "user_id = from_user_id" ) } # .select("DISTINCT ON (thread_id) messages.*")
+  scope :unread, -> { where( "read_at IS NULL" ) }
 
   INBOX = "inbox"
   SENT = "sent"
-  BOXES = [INBOX, SENT]
+  BOXES = [INBOX, SENT].freeze
 
-  attr_accessor :html
-  attr_accessor :skip_email
+  attr_accessor :html, :skip_email
 
   def to_s
     "<Message #{id} user:#{user_id} from:#{from_user_id} to:#{to_user_id} subject:#{subject.to_s[0..10]}>"
@@ -39,6 +40,7 @@ class Message < ApplicationRecord
 
   def send_message
     return if from_user.suspended? || known_spam?
+
     reload
     new_message = dup
     new_message.user = to_user
@@ -48,12 +50,14 @@ class Message < ApplicationRecord
 
   def to_user_copy
     return self if to_user_id == user_id
-    to_user.messages.inbox.where(:thread_id => thread_id).detect{|m| m.body == body}
+
+    to_user.messages.inbox.where( thread_id: thread_id ).detect {| m | m.body == body }
   end
 
   def from_user_copy
     return self if from_user_id == user_id
-    from_user.messages.sent.where(:thread_id => thread_id).detect{|m| m.body == body}
+
+    from_user.messages.sent.where( thread_id: thread_id ).detect {| m | m.body == body }
   end
 
   def set_read_at
@@ -65,7 +69,7 @@ class Message < ApplicationRecord
 
   def set_thread_id
     if thread_id.blank?
-      Message.where(id: id).update_all(thread_id: id)
+      Message.where( id: id ).update_all( thread_id: id )
     end
     true
   end
@@ -79,7 +83,8 @@ class Message < ApplicationRecord
 
   def set_subject_for_reply
     return true if thread_id.blank?
-    first = Message.where(:thread_id => thread_id, :user_id => user_id).order("id asc").first
+
+    first = Message.where( thread_id: thread_id, user_id: user_id ).order( "id asc" ).first
     if first && first != self
       self.subject = first.subject
       self.subject = "Re: #{subject}" unless subject.to_s =~ /^Re:/
@@ -88,9 +93,9 @@ class Message < ApplicationRecord
   end
 
   def validate_to_not_from
-    if to_user_id == from_user_id
-      errors.add(:base, "You can't send a message to yourself")
-    end
+    return unless to_user_id == from_user_id
+
+    errors.add( :base, "You can't send a message to yourself" )
   end
 
   def deliver_email
@@ -99,11 +104,12 @@ class Message < ApplicationRecord
     return true if UserMute.where( user_id: to_user, muted_user_id: from_user ).exists?
     return true if UserBlock.where( user_id: to_user, blocked_user_id: from_user ).exists?
     return true if from_user.suspended? || known_spam?
-    Emailer.delay(:priority => USER_INTEGRITY_PRIORITY).new_message(id)
+
+    Emailer.delay( priority: USER_INTEGRITY_PRIORITY ).new_message( id )
     true
   end
 
-  def flagged_with(flag, options = {})
-    evaluate_new_flag_for_spam(flag)
+  def flagged_with( flag, _options = {} )
+    evaluate_new_flag_for_spam( flag )
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -39,7 +39,7 @@ class Message < ApplicationRecord
   # was suspended or because the receiver manually deleted their copy, so we
   # need this crude date filter to prevent us from redelivering ancient
   # messages that the recipient deleted.
-  RESEND_UNSENT_RELEASE_DATE = Date.parse( "2025-01-28" )
+  RESEND_UNSENT_RELEASE_DATE = Date.parse( "2025-02-03" )
 
   def self.resend_unsent_for_user( user )
     user = User.find_by_id( user ) unless user.is_a?( User )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1318,7 +1318,7 @@ class User < ApplicationRecord
     return true unless suspended?
 
     Message.inbox.unread.where( from_user_id: id ).find_each do | msg |
-      msg.from_user_copy.update( sent_at: nil )
+      msg.from_user_copy&.update( sent_at: nil )
       msg.destroy
     end
     true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1325,13 +1325,12 @@ class User < ApplicationRecord
   end
 
   def send_messages_by_unsuspended_user
-    return true if suspended?
-    return true unless saved_change_to_suspended_at?
+    return if suspended?
+    return unless saved_change_to_suspended_at?
 
     Message.
       delay( priority: USER_INTEGRITY_PRIORITY ).
       resend_unsent_for_user( id )
-    true
   end
 
   def revoke_access_tokens_by_suspended_user

--- a/db/migrate/20250130003627_add_sent_at_to_messages.rb
+++ b/db/migrate/20250130003627_add_sent_at_to_messages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSentAtToMessages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :messages, :sent_at, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2874,7 +2874,7 @@ CREATE TABLE public.observation_accuracy_validators (
     email_date timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    validation_count integer
+    validation_count integer DEFAULT 0
 );
 
 
@@ -5467,9 +5467,9 @@ ALTER SEQUENCE public.user_donations_id_seq OWNED BY public.user_donations.id;
 
 CREATE TABLE public.user_installations (
     id bigint NOT NULL,
-    installation_id character varying(255),
+    installation_id character varying,
     oauth_application_id integer,
-    platform_id character varying(255),
+    platform_id character varying,
     user_id integer,
     created_at date,
     first_logged_in_at date
@@ -11411,8 +11411,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240828123245'),
 ('20240923134239'),
 ('20240923134658'),
+('20241016204033'),
 ('20241127180606'),
 ('20241202092831'),
+('20241217203007'),
 ('20241218164832'),
 ('20250124155306'),
 ('20250127200519'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2511,7 +2511,8 @@ CREATE TABLE public.messages (
     body text,
     read_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    sent_at timestamp without time zone
 );
 
 
@@ -11415,7 +11416,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241218164832'),
 ('20250124155306'),
 ('20250127200519'),
-('20241217203007'),
-('20241016204033');
+('20250130003627');
 
 

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :message do
+    user
+    to_user { create :user }
+    from_user { user }
+    subject { Faker::Lorem.sentence }
+    body { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -87,5 +87,18 @@ describe Message do
       m.reload
       expect( m.to_user_copy ).to be_blank
     end
+    it "should set sent_at" do
+      m = create :message, user: sender
+      expect( m.sent_at ).to be_blank
+      m.send_message
+      expect( m.sent_at ).not_to be_blank
+    end
+    it "should not set sent_at if sender is suspended" do
+      m = create :message, user: sender
+      sender.suspend!
+      expect( m.sent_at ).to be_blank
+      m.send_message
+      expect( m.sent_at ).to be_blank
+    end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,30 +1,31 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe Message do
   it { is_expected.to belong_to :user }
-  it { is_expected.to belong_to(:from_user).class_name "User" }
-  it { is_expected.to belong_to(:to_user).class_name "User" }
+  it { is_expected.to belong_to( :from_user ).class_name "User" }
+  it { is_expected.to belong_to( :to_user ).class_name "User" }
 
   describe "validations" do
-    let(:user) { User.make }
-    let(:subject) { Message.make(user: user) }
+    let( :user ) { User.make }
+    let( :subject ) { Message.make( user: user ) }
 
     it { is_expected.to validate_presence_of :user }
     it { is_expected.to validate_presence_of :body }
     it { is_expected.to validate_presence_of :from_user_id }
     it { is_expected.to validate_presence_of :to_user_id }
-    it { is_expected.to validate_numericality_of(:from_user_id).is_greater_than 0 }
-    it { is_expected.to validate_numericality_of(:to_user_id).is_greater_than 0 }
+    it { is_expected.to validate_numericality_of( :from_user_id ).is_greater_than 0 }
+    it { is_expected.to validate_numericality_of( :to_user_id ).is_greater_than 0 }
   end
-
 
   describe "flagging" do
     it "should suspend the from_user if their messages have been flagged 3 times" do
       offender = UserPrivilege.make!.user
       3.times do
-        m = make_message(user: offender, from_user: offender)
+        m = make_message( user: offender, from_user: offender )
         m.send_message
-        flag = Flag.make(flaggable: m, user: m.to_user, flag: Flag::SPAM)
+        flag = Flag.make( flaggable: m, user: m.to_user, flag: Flag::SPAM )
         flag.save!
       end
       offender.reload
@@ -34,27 +35,27 @@ describe Message do
     it "should not destroy the flagger's copies of the messages in this thread" do
       from_user = UserPrivilege.make!.user
       to_user = UserPrivilege.make!.user
-      m = make_message(from_user: from_user, to_user: to_user, user: from_user)
+      m = make_message( from_user: from_user, to_user: to_user, user: from_user )
       m.send_message
-      flag = Flag.make(flaggable: m, user: m.to_user, flag: Flag::SPAM)
-      expect {
+      flag = Flag.make( flaggable: m, user: m.to_user, flag: Flag::SPAM )
+      expect do
         flag.save!
-      }.not_to change( Message.where(user_id: m.to_user, thread_id: m.thread_id ), :count )
+      end.not_to change( Message.where( user_id: m.to_user, thread_id: m.thread_id ), :count )
     end
 
     it "should not destroy the spammer's copies" do
       from_user = UserPrivilege.make!.user
       to_user = UserPrivilege.make!.user
-      m = make_message(from_user: from_user, to_user: to_user, user: from_user)
+      m = make_message( from_user: from_user, to_user: to_user, user: from_user )
       m.send_message
-      flag = Flag.make(flaggable: m, user: m.to_user, flag: Flag::SPAM)
+      flag = Flag.make( flaggable: m, user: m.to_user, flag: Flag::SPAM )
       flag.save!
-      expect( Message.find_by_id(m.id) ).to_not be_blank
+      expect( Message.find_by_id( m.id ) ).to_not be_blank
     end
   end
 
   describe "send_message" do
-    let(:sender) { make_user_with_privilege( UserPrivilege::SPEECH ) }
+    let( :sender ) { make_user_with_privilege( UserPrivilege::SPEECH ) }
     it "should normally make a copy for the recipient" do
       m = Message.make!( user: sender, from_user: sender )
       m.reload

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,16 +1,17 @@
-# -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/../spec_helper'
+# Not sure why but freezing string literals breaks stub_request
+# rubocop:disable Style/FrozenStringLiteralComment
+require "#{File.dirname( __FILE__ )}/../spec_helper"
 
 # Be sure to include AuthenticatedTestHelper in spec/spec_helper.rb instead.
 # Then, you can remove it from this and the functional test.
-include AuthenticatedTestHelper
+# include AuthenticatedTestHelper
 
 bad_logins = [
-  '12', '123', '1234567890_234567890_234567890_234567890_',
+  "12", "123", "1234567890_234567890_234567890_234567890_",
   "Iñtërnâtiônàlizætiøn hasn't happened to ruby 1.8 yet",
-  'semicolon;', 'quote"', 'tick\'', 'backtick`', 'percent%', 'plus+', 
-  'period.', 'm', 
-  'this_is_the_longest_login_ever_written_by_man',
+  "semicolon;", 'quote"', "tick'", "backtick`", "percent%", "plus+",
+  "period.", "m",
+  "this_is_the_longest_login_ever_written_by_man",
   "password",
   "new",
   "[foo",
@@ -18,87 +19,144 @@ bad_logins = [
 ]
 
 describe User, "associations" do
-  it { is_expected.to belong_to(:curator_sponsor).class_name "User" }
-  it { is_expected.to belong_to(:place).inverse_of :users }
-  it { is_expected.to belong_to(:search_place).inverse_of(:search_users).class_name "Place" }
-  it { is_expected.to belong_to(:site).inverse_of :users }
-  it { is_expected.to belong_to(:suspended_by_user).class_name "User" }
-  it { is_expected.to have_many(:annotations).dependent :destroy }
-  it { is_expected.to have_many(:atlases).inverse_of(:user).dependent :nullify }
-  it { is_expected.to have_many(:comments).dependent :destroy }
-  it { is_expected.to have_many(:created_guide_sections).class_name("GuideSection").with_foreign_key("creator_id").inverse_of(:creator).dependent :nullify }
+  it { is_expected.to belong_to( :curator_sponsor ).class_name "User" }
+  it { is_expected.to belong_to( :place ).inverse_of :users }
+  it { is_expected.to belong_to( :search_place ).inverse_of( :search_users ).class_name "Place" }
+  it { is_expected.to belong_to( :site ).inverse_of :users }
+  it { is_expected.to belong_to( :suspended_by_user ).class_name "User" }
+  it { is_expected.to have_many( :annotations ).dependent :destroy }
+  it { is_expected.to have_many( :atlases ).inverse_of( :user ).dependent :nullify }
+  it { is_expected.to have_many( :comments ).dependent :destroy }
+  it {
+    is_expected.to have_many( :created_guide_sections ).
+      class_name( "GuideSection" ).
+      with_foreign_key( "creator_id" ).
+      inverse_of( :creator ).
+      dependent :nullify
+  }
   it { is_expected.to have_many :deleted_observations }
   it { is_expected.to have_many :deleted_photos }
   it { is_expected.to have_many :deleted_sounds }
-  it { is_expected.to have_many(:editing_guides).through(:guide_users) }
-  it { is_expected.to have_many(:flags_as_flaggable_user).inverse_of(:flaggable_user).class_name("Flag").with_foreign_key("flaggable_user_id").dependent :nullify }
-  it { is_expected.to have_many(:flags_as_flagger).inverse_of(:user).class_name "Flag" }
+  it { is_expected.to have_many( :editing_guides ).through( :guide_users ) }
+  it {
+    is_expected.to have_many( :flags_as_flaggable_user ).
+      inverse_of( :flaggable_user ).
+      class_name( "Flag" ).
+      with_foreign_key( "flaggable_user_id" ).
+      dependent :nullify
+  }
+  it { is_expected.to have_many( :flags_as_flagger ).inverse_of( :user ).class_name "Flag" }
   it { is_expected.to have_many :flow_tasks }
-  it { is_expected.to have_many(:friendships).dependent :destroy }
-  it { is_expected.to have_many(:friendships_as_friend).class_name("Friendship").with_foreign_key("friend_id").inverse_of(:friend).dependent :destroy }
-  it { is_expected.to have_many(:guide_users).inverse_of(:user).dependent :delete_all }
-  it { is_expected.to have_many(:guides).dependent(:destroy).inverse_of :user }
-  it { is_expected.to have_many(:identifications).dependent :destroy }
-  it { is_expected.to have_many(:journal_posts).class_name("Post").dependent :destroy }
-  it { is_expected.to have_many(:listed_taxa).dependent :nullify }
-  it { is_expected.to have_many(:lists).dependent :destroy }
-  it { is_expected.to have_many(:messages).dependent :destroy }
-  it { is_expected.to have_many(:moderator_actions).inverse_of :user }
-  it { is_expected.to have_many(:moderator_notes).inverse_of :user }
-  it { is_expected.to have_many(:moderator_notes_as_subject).class_name("ModeratorNote").with_foreign_key("subject_user_id").inverse_of(:subject_user).dependent :destroy }
-  it { is_expected.to have_many(:observation_field_values).dependent(:nullify).inverse_of :user }
-  it { is_expected.to have_many(:observation_fields).dependent(:nullify).inverse_of :user }
-  it { is_expected.to have_many(:observations).dependent :destroy }
-  it { is_expected.to have_many(:parentages).class_name("UserParent").with_foreign_key("parent_user_id").inverse_of :parent_user }
-  it { is_expected.to have_many(:photos).dependent :destroy }
-  it { is_expected.to have_many(:places).dependent :nullify }
+  it { is_expected.to have_many( :friendships ).dependent :destroy }
+  it {
+    is_expected.to have_many( :friendships_as_friend ).
+      class_name( "Friendship" ).
+      with_foreign_key( "friend_id" ).
+      inverse_of( :friend ).
+      dependent :destroy
+  }
+  it { is_expected.to have_many( :guide_users ).inverse_of( :user ).dependent :delete_all }
+  it { is_expected.to have_many( :guides ).dependent( :destroy ).inverse_of :user }
+  it { is_expected.to have_many( :identifications ).dependent :destroy }
+  it { is_expected.to have_many( :journal_posts ).class_name( "Post" ).dependent :destroy }
+  it { is_expected.to have_many( :listed_taxa ).dependent :nullify }
+  it { is_expected.to have_many( :lists ).dependent :destroy }
+  it { is_expected.to have_many( :messages ).dependent :destroy }
+  it { is_expected.to have_many( :moderator_actions ).inverse_of :user }
+  it { is_expected.to have_many( :moderator_notes ).inverse_of :user }
+  it {
+    is_expected.to have_many( :moderator_notes_as_subject ).
+      class_name( "ModeratorNote" ).
+      with_foreign_key( "subject_user_id" ).
+      inverse_of( :subject_user ).
+      dependent :destroy
+  }
+  it { is_expected.to have_many( :observation_field_values ).dependent( :nullify ).inverse_of :user }
+  it { is_expected.to have_many( :observation_fields ).dependent( :nullify ).inverse_of :user }
+  it { is_expected.to have_many( :observations ).dependent :destroy }
+  it {
+    is_expected.to have_many( :parentages ).
+      class_name( "UserParent" ).
+      with_foreign_key( "parent_user_id" ).
+      inverse_of :parent_user
+  }
+  it { is_expected.to have_many( :photos ).dependent :destroy }
+  it { is_expected.to have_many( :places ).dependent :nullify }
   it { is_expected.to have_many :posts }
   it { is_expected.to have_many :projects }
-  it { is_expected.to have_many(:project_observations).dependent :nullify }
-  it { is_expected.to have_many(:project_user_invitations).dependent :nullify }
-  it { is_expected.to have_many(:project_user_invitations_received).dependent(:delete_all).class_name "ProjectUserInvitation" }
-  it { is_expected.to have_many(:project_users).dependent :destroy }
-  it { is_expected.to have_many(:provider_authorizations).dependent :delete_all }
-  it { is_expected.to have_many(:quality_metrics).dependent :destroy }
-  it { is_expected.to have_many(:saved_locations).inverse_of(:user).dependent :destroy }
-  it { is_expected.to have_many(:site_admins).inverse_of :user }
-  it { is_expected.to have_many(:sounds).dependent :destroy }
-  it { is_expected.to have_many(:sources).dependent :nullify }
-  it { is_expected.to have_many(:subscriptions).dependent :delete_all }
-  it { is_expected.to have_many(:taxa).with_foreign_key("creator_id").inverse_of :creator }
-  it { is_expected.to have_many(:taxon_changes).inverse_of :user }
-  it { is_expected.to have_many(:taxon_curators).inverse_of(:user).dependent :destroy }
+  it { is_expected.to have_many( :project_observations ).dependent :nullify }
+  it { is_expected.to have_many( :project_user_invitations ).dependent :nullify }
+  it {
+    is_expected.to have_many( :project_user_invitations_received ).
+      dependent( :delete_all ).
+      class_name "ProjectUserInvitation"
+  }
+  it { is_expected.to have_many( :project_users ).dependent :destroy }
+  it { is_expected.to have_many( :provider_authorizations ).dependent :delete_all }
+  it { is_expected.to have_many( :quality_metrics ).dependent :destroy }
+  it { is_expected.to have_many( :saved_locations ).inverse_of( :user ).dependent :destroy }
+  it { is_expected.to have_many( :site_admins ).inverse_of :user }
+  it { is_expected.to have_many( :sounds ).dependent :destroy }
+  it { is_expected.to have_many( :sources ).dependent :nullify }
+  it { is_expected.to have_many( :subscriptions ).dependent :delete_all }
+  it { is_expected.to have_many( :taxa ).with_foreign_key( "creator_id" ).inverse_of :creator }
+  it { is_expected.to have_many( :taxon_changes ).inverse_of :user }
+  it { is_expected.to have_many( :taxon_curators ).inverse_of( :user ).dependent :destroy }
   it { is_expected.to have_many :taxon_framework_relationships }
-  it { is_expected.to have_many(:taxon_links).dependent :nullify }
-  it { is_expected.to have_many(:taxon_names).with_foreign_key("creator_id").inverse_of :creator }
-  it { is_expected.to have_many(:updated_guide_sections).class_name("GuideSection").with_foreign_key("updater_id").inverse_of(:updater).dependent :nullify }
-  it { is_expected.to have_many(:updated_observation_field_values).dependent(:nullify).inverse_of(:updater).with_foreign_key("updater_id").class_name "ObservationFieldValue" }
-  it { is_expected.to have_many(:user_blocks).inverse_of(:user).dependent :destroy }
-  it { is_expected.to have_many(:user_blocks_as_blocked_user).class_name("UserBlock").with_foreign_key("blocked_user_id").inverse_of(:blocked_user).dependent :destroy }
-  it { is_expected.to have_many(:user_mutes).inverse_of(:user).dependent :destroy }
-  it { is_expected.to have_many(:user_mutes_as_muted_user).class_name("UserMute").with_foreign_key("muted_user_id").inverse_of(:muted_user).dependent :destroy }
-  it { is_expected.to have_many(:user_privileges).inverse_of(:user).dependent :delete_all }
-  it { is_expected.to have_one(:flickr_identity).dependent :delete }
-  it { is_expected.to have_one(:soundcloud_identity).dependent :delete }
-  it { is_expected.to have_one(:user_daily_active_category).dependent :delete }
-  it { is_expected.to have_one(:user_parent).dependent(:destroy).inverse_of :user }
+  it { is_expected.to have_many( :taxon_links ).dependent :nullify }
+  it { is_expected.to have_many( :taxon_names ).with_foreign_key( "creator_id" ).inverse_of :creator }
+  it {
+    is_expected.to have_many( :updated_guide_sections ).
+      class_name( "GuideSection" ).
+      with_foreign_key( "updater_id" ).
+      inverse_of( :updater ).
+      dependent :nullify
+  }
+  it {
+    is_expected.to have_many( :updated_observation_field_values ).
+      dependent( :nullify ).
+      inverse_of( :updater ).
+      with_foreign_key( "updater_id" ).
+      class_name "ObservationFieldValue"
+  }
+  it { is_expected.to have_many( :user_blocks ).inverse_of( :user ).dependent :destroy }
+  it {
+    is_expected.to have_many( :user_blocks_as_blocked_user ).
+      class_name( "UserBlock" ).
+      with_foreign_key( "blocked_user_id" ).
+      inverse_of( :blocked_user ).
+      dependent :destroy
+  }
+  it { is_expected.to have_many( :user_mutes ).inverse_of( :user ).dependent :destroy }
+  it {
+    is_expected.to have_many( :user_mutes_as_muted_user ).
+      class_name( "UserMute" ).
+      with_foreign_key( "muted_user_id" ).
+      inverse_of( :muted_user ).
+      dependent :destroy
+  }
+  it { is_expected.to have_many( :user_privileges ).inverse_of( :user ).dependent :delete_all }
+  it { is_expected.to have_one( :flickr_identity ).dependent :delete }
+  it { is_expected.to have_one( :soundcloud_identity ).dependent :delete }
+  it { is_expected.to have_one( :user_daily_active_category ).dependent :delete }
+  it { is_expected.to have_one( :user_parent ).dependent( :destroy ).inverse_of :user }
 end
 
 describe User, "validations" do
-  it { is_expected.to validate_exclusion_of(:login).in_array %w(password new edit create update delete destroy) }
-  it { is_expected.to validate_exclusion_of(:password).in_array %w(password) }
-  it { is_expected.to validate_length_of(:login).is_at_least(User::MIN_LOGIN_SIZE).is_at_most User::MAX_LOGIN_SIZE }
-  it { is_expected.to validate_length_of(:name).is_at_most(100).allow_blank }
-  it { is_expected.to validate_length_of(:time_zone).is_at_least(3).allow_nil }
+  it { is_expected.to validate_exclusion_of( :login ).in_array %w(password new edit create update delete destroy) }
+  it { is_expected.to validate_exclusion_of( :password ).in_array %w(password) }
+  it { is_expected.to validate_length_of( :login ).is_at_least( User::MIN_LOGIN_SIZE ).is_at_most User::MAX_LOGIN_SIZE }
+  it { is_expected.to validate_length_of( :name ).is_at_most( 100 ).allow_blank }
+  it { is_expected.to validate_length_of( :time_zone ).is_at_least( 3 ).allow_nil }
   it { is_expected.to validate_presence_of :login }
   it { is_expected.to validate_presence_of :password }
   it { is_expected.to validate_presence_of :email }
-  it { is_expected.to validate_uniqueness_of(:login).case_insensitive }
+  it { is_expected.to validate_uniqueness_of( :login ).case_insensitive }
 end
 
 describe User do
-  before(:all) do
-    DatabaseCleaner.clean_with(:truncation, except: %w[spatial_ref_sys])
+  before( :all ) do
+    DatabaseCleaner.clean_with( :truncation, except: %w(spatial_ref_sys) )
   end
 
   describe "creation" do
@@ -118,26 +176,26 @@ describe User do
 
     it "should set the URI" do
       u = User.make!
-      expect(u.uri).to eq(UrlHelper.user_url(u))
+      expect( u.uri ).to eq( UrlHelper.user_url( u ) )
     end
 
     it "should set a default locale" do
       u = User.make!
-      expect(u.locale).to eq I18n.locale.to_s
+      expect( u.locale ).to eq I18n.locale.to_s
     end
 
     it "should strip the login" do
-      u = User.make(:login => "foo ")
+      u = User.make( login: "foo " )
       u.save
-      expect(u.login).to eq "foo"
-      expect(u).to be_valid
+      expect( u.login ).to eq "foo"
+      expect( u ).to be_valid
     end
 
     it "should strip the email" do
-      u = User.make(:email => "foo@bar.com ")
+      u = User.make( email: "foo@bar.com " )
       u.save
-      expect(u.email).to eq "foo@bar.com"
-      expect(u).to be_valid
+      expect( u.email ).to eq "foo@bar.com"
+      expect( u ).to be_valid
     end
 
     it "generates a canonical email" do
@@ -156,10 +214,10 @@ describe User do
     it "should not allow time_zone to be a blank string" do
       expect( User.make!( time_zone: "" ).time_zone ).to be_nil
     end
-    
+
     it "should set latitude and longitude" do
-      stub_request(:get, /#{INatAPIService::ENDPOINT}/).
-        to_return(status: 200, body: '{
+      stub_request( :get, /#{INatAPIService::ENDPOINT}/ ).
+        to_return( status: 200, body: '{
           "results": {
             "country": "US",
             "city": "Fairhaven",
@@ -168,19 +226,19 @@ describe User do
               -70.8801
             ]
           }
-        }', headers: { "Content-Type" => "application/json" })
-      u = User.make(:last_ip => "128.128.128.128")
-      u.save
-      expect(u.latitude).to eq 41.6318
-      expect(u.longitude).to eq -70.8801
-      expect(u.lat_lon_acc_admin_level).to eq Place::COUNTY_LEVEL
+        }', headers: { "Content-Type" => "application/json" } )
+      u = User.make( last_ip: "128.128.128.128" )
+      u.save!
+      expect( u.latitude ).to eq( 41.6318 )
+      expect( u.longitude ).to eq( -70.8801 )
+      expect( u.lat_lon_acc_admin_level ).to eq Place::COUNTY_LEVEL
     end
 
     it "should validate email address domains" do
-      CONFIG.banned_emails = [ "testban.com" ]
-      expect {
-        User.make!(email: "someone@testban.com")
-      }.to raise_error(ActiveRecord::RecordInvalid)
+      CONFIG.banned_emails = ["testban.com"]
+      expect do
+        User.make!( email: "someone@testban.com" )
+      end.to raise_error( ActiveRecord::RecordInvalid )
     end
 
     it "validates description length only if changed" do
@@ -223,9 +281,9 @@ describe User do
       end
 
       it "should disallow email domains that do not exist" do
-        expect {
+        expect do
           User.make!( email: "someone@sdjgfslkjfgsjfkg.com" )
-        }.to raise_error( ActiveRecord::RecordInvalid )
+        end.to raise_error( ActiveRecord::RecordInvalid )
       end
     end
 
@@ -259,13 +317,13 @@ describe User do
       u.update( name: "#{u.name}<script>foo</script>" )
       expect( u.name ).to eq n
     end
-    
+
     it "should update the site_id on the user's observations" do
       s1 = Site.make!
       s2 = Site.make!
-      u = User.make!(site: s1)
-      o = Observation.make!(user: u, site: s1)
-      without_delay { u.update(site: s2) }
+      u = User.make!( site: s1 )
+      o = Observation.make!( user: u, site: s1 )
+      without_delay { u.update( site: s2 ) }
       o.reload
       expect( o.site ).to eq s2
     end
@@ -273,11 +331,11 @@ describe User do
     it "should update the site_id in the elastic index" do
       s1 = Site.make!
       s2 = Site.make!
-      u = User.make!(site: s1)
-      o = Observation.make!(user: u, site: s1)
-      without_delay { u.update(site: s2) }
+      u = User.make!( site: s1 )
+      o = Observation.make!( user: u, site: s1 )
+      without_delay { u.update( site: s2 ) }
       o.reload
-      es_o = Observation.elastic_paginate(where: {site_id: s2.id}).first
+      es_o = Observation.elastic_paginate( where: { site_id: s2.id } ).first
       expect( es_o ).to eq o
     end
 
@@ -308,7 +366,6 @@ describe User do
       target_u = target_o.user
       other_o = make_research_grade_observation
       other_p = other_o.photos.first
-      other_u = other_o.user
       expect( other_p.native_realname ).to be_blank
       new_login = "zolophon"
       without_delay { target_u.update( login: new_login ) }
@@ -316,12 +373,12 @@ describe User do
       expect( other_p.native_realname ).to be_blank
     end
 
-    describe 'disallows illegitimate logins' do
-      bad_logins.each do |login_str|
+    describe "disallows illegitimate logins" do
+      bad_logins.each do | login_str |
         it "'#{login_str}'" do
           u = User.make!
           u.login = login_str
-          expect(u).not_to be_valid
+          expect( u ).not_to be_valid
         end
       end
     end
@@ -391,9 +448,7 @@ describe User do
         expect( admin_user.taxon_name_priorities[0].lexicon ).to eq "en"
         expect( admin_user.taxon_name_priorities[0].place_id ).to eq place.id
       end
-
     end
-
   end
 
   #
@@ -402,148 +457,149 @@ describe User do
 
   it "should not allow duplicate emails" do
     existing = User.make!
-    u = User.make(:email => existing.email)
-    expect(u).to_not be_valid
-    expect(u.errors['email']).to_not be_blank
+    u = User.make( email: existing.email )
+    expect( u ).to_not be_valid
+    expect( u.errors["email"] ).to_not be_blank
   end
 
-  describe 'allows legitimate logins:' do
-    ['whatisthewhat', 'zoooooolander', 'hello-_therefunnycharcom'].each do |login_str|
+  describe "allows legitimate logins:" do
+    ["whatisthewhat", "zoooooolander", "hello-_therefunnycharcom"].each do | login_str |
       it "'#{login_str}'" do
-        expect {
-          u = create_user(:login => login_str)
-          expect(u.errors[:login]).to be_blank
-        }.to change(User, :count).by(1)
+        expect do
+          u = create_user( login: login_str )
+          expect( u.errors[:login] ).to be_blank
+        end.to change( User, :count ).by( 1 )
       end
     end
   end
-  describe 'disallows illegitimate logins:' do
-    bad_logins.each do |login_str|
+  describe "disallows illegitimate logins:" do
+    bad_logins.each do | login_str |
       it login_str do
-        expect( User.make(login: login_str) ).not_to be_valid
+        expect( User.make( login: login_str ) ).not_to be_valid
       end
     end
   end
 
-  it 'requires password confirmation' do
-    expect {
-      u = create_user(:password_confirmation => "")
-      expect(u.errors[:password_confirmation]).to_not be_blank
-    }.to_not change(User, :count)
+  it "requires password confirmation" do
+    expect do
+      u = create_user( password_confirmation: "" )
+      expect( u.errors[:password_confirmation] ).to_not be_blank
+    end.to_not change( User, :count )
   end
 
-  describe 'allows legitimate emails:' do
-    ['foo@bar.com', 'foo@newskool-tld.museum', 'foo@twoletter-tld.de', 'foo@nonexistant-tld.qq',
-     'r@a.wk', '1234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890@gmail.com',
-     'hello.-_there@funnychar.com', 'uucp%addr@gmail.com', 'hello+routing-str@gmail.com',
-     'domain@can.haz.many.sub.doma.in', 'student.name@university.edu', 'foo@ostal.cat'
-    ].each do |email_str|
+  describe "allows legitimate emails:" do
+    ["foo@bar.com", "foo@newskool-tld.museum", "foo@twoletter-tld.de", "foo@nonexistant-tld.qq",
+     "r@a.wk", "1234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890@gmail.com",
+     "hello.-_there@funnychar.com", "uucp%addr@gmail.com", "hello+routing-str@gmail.com",
+     "domain@can.haz.many.sub.doma.in", "student.name@university.edu", "foo@ostal.cat"].each do | email_str |
       it "'#{email_str}'" do
-        expect {
-          u = create_user(:email => email_str)
-          expect(u.errors[:email]).to     be_blank
-        }.to change(User, :count).by(1)
+        expect do
+          u = create_user( email: email_str )
+          expect( u.errors[:email] ).to be_blank
+        end.to change( User, :count ).by( 1 )
       end
     end
   end
 
-  describe 'allows legitimate names:' do
-    ['Andre The Giant (7\'4", 520 lb.) -- has a posse',
-     '', '1234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890',
-    ].each do |name_str|
+  describe "allows legitimate names:" do
+    [
+      'Andre The Giant (7\'4", 520 lb.) -- has a posse',
+      "",
+      "1234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890"
+    ].each do | name_str |
       it "'#{name_str}'" do
-        expect {
-          u = create_user(:name => name_str)
-          expect(u.errors[:name]).to     be_blank
-        }.to change(User, :count).by(1)
+        expect do
+          u = create_user( name: name_str )
+          expect( u.errors[:name] ).to be_blank
+        end.to change( User, :count ).by( 1 )
       end
     end
   end
   describe "disallows illegitimate names" do
     [
-     '1234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_'
-     ].each do |name_str|
+      "1234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_"
+    ].each do | name_str |
       it "'#{name_str}'" do
-        expect {
-          u = create_user(:name => name_str)
-          expect(u.errors[:name]).not_to be_blank
-        }.not_to change(User, :count)
+        expect do
+          u = create_user( name: name_str )
+          expect( u.errors[:name] ).not_to be_blank
+        end.not_to change( User, :count )
       end
     end
   end
 
-  it 'resets password' do
+  it "resets password" do
     user = User.make!
-    user.update(:password => 'new password', :password_confirmation => 'new password')
-    expect(User.authenticate(user.login, 'new password')).to eq user
+    user.update( password: "new password", password_confirmation: "new password" )
+    expect( User.authenticate( user.login, "new password" ) ).to eq user
   end
 
-  it 'does not rehash password' do
+  it "does not rehash password" do
     pw = "fooosdgsg"
-    user = User.make!(:password => pw, :password_confirmation => pw)
-    user.update(:login => 'quentin2')
-    expect(User.authenticate('quentin2', pw)).to eq user
+    user = User.make!( password: pw, password_confirmation: pw )
+    user.update( login: "quentin2" )
+    expect( User.authenticate( "quentin2", pw ) ).to eq user
   end
 
   describe "authentication" do
-    before(:each) do
+    before( :each ) do
       @pw = "fooosdgsg"
-      @user = User.make!(:password => @pw, :password_confirmation => @pw)
+      @user = User.make!( password: @pw, password_confirmation: @pw )
     end
 
-    it 'authenticates user' do
-      expect(User.authenticate(@user.login, @pw)).to eq @user
+    it "authenticates user" do
+      expect( User.authenticate( @user.login, @pw ) ).to eq @user
     end
 
     it "doesn't authenticate user with bad password" do
-      expect(User.authenticate(@user.login, 'invalid_password')).to be_blank
+      expect( User.authenticate( @user.login, "invalid_password" ) ).to be_blank
     end
 
-    it 'does not authenticate suspended user' do
+    it "does not authenticate suspended user" do
       @user.suspend!
-      expect(User.authenticate(@user.login, @pw)).not_to eq @user
+      expect( User.authenticate( @user.login, @pw ) ).not_to eq @user
     end
   end
 
   describe "remembering" do
-    before(:each) do
+    before( :each ) do
       @user = User.make!
     end
 
-    it 'sets remember token' do
+    it "sets remember token" do
       @user.remember_me!
-      expect(@user.remember_token).not_to be_blank
-      expect(@user.remember_expires_at).not_to be_blank
+      expect( @user.remember_token ).not_to be_blank
+      expect( @user.remember_expires_at ).not_to be_blank
     end
 
-    it 'unsets remember token' do
+    it "unsets remember token" do
       @user.remember_me!
-      expect(@user.remember_token).not_to be_blank
+      expect( @user.remember_token ).not_to be_blank
       @user.forget_me!
-      expect(@user.remember_token).to be_blank
+      expect( @user.remember_token ).to be_blank
     end
 
-    it 'remembers me default two weeks' do
-      Time.use_zone(@user.time_zone) do
+    it "remembers me default two weeks" do
+      Time.use_zone( @user.time_zone ) do
         before = 13.days.from_now.utc
         @user.remember_me!
         after = 15.days.from_now.utc
-        expect(@user.remember_token).not_to be_blank
-        expect(@user.remember_expires_at).not_to be_blank
-        expect(@user.remember_expires_at.between?(before, after)).to be true
+        expect( @user.remember_token ).not_to be_blank
+        expect( @user.remember_expires_at ).not_to be_blank
+        expect( @user.remember_expires_at.between?( before, after ) ).to be true
       end
     end
   end
 
-  it 'suspends user' do
+  it "suspends user" do
     user = User.make!
     user.suspend!
-    expect(user).to be_suspended
+    expect( user ).to be_suspended
   end
-  
+
   describe "deletion" do
     elastic_models( Observation )
-    
+
     before do
       @user = User.make!
     end
@@ -551,10 +607,10 @@ describe User do
     it "should create a deleted user" do
       @user.destroy
       deleted_user = DeletedUser.last
-      expect(deleted_user).not_to be_blank
-      expect(deleted_user.user_id).to eq @user.id
-      expect(deleted_user.login).to eq @user.login
-      expect(deleted_user.email).to eq @user.email
+      expect( deleted_user ).not_to be_blank
+      expect( deleted_user.user_id ).to eq @user.id
+      expect( deleted_user.login ).to eq @user.login
+      expect( deleted_user.email ).to eq @user.email
     end
 
     it "should not update photos by other users" do
@@ -562,9 +618,7 @@ describe User do
       target_u = target_o.user
       other_o = make_research_grade_observation
       other_p = other_o.photos.first
-      other_u = other_o.user
       expect( other_p.native_realname ).to be_blank
-      new_login = "zolophon"
       without_delay { target_u.destroy }
       other_p.reload
       expect( other_p.native_realname ).to be_blank
@@ -590,7 +644,7 @@ describe User do
 
     it "should delete associated project rules" do
       user = User.make!
-      collection = Project.make!(project_type: "collection")
+      collection = Project.make!( project_type: "collection" )
       rule = collection.project_observation_rules.build( operator: "observed_by_user?", operand: user )
       rule.save!
       expect( Project.find( collection.id ).project_observation_rules.length ).to eq 1
@@ -619,10 +673,9 @@ describe User do
   end
 
   describe "sane_destroy" do
-
     elastic_models( Observation )
-    
-    let(:user) { make_user_with_privilege( UserPrivilege::ORGANIZER ) }
+
+    let( :user ) { make_user_with_privilege( UserPrivilege::ORGANIZER ) }
 
     it "should destroy the user" do
       user.sane_destroy
@@ -634,17 +687,17 @@ describe User do
       user.sane_destroy
       jobs = Delayed::Job.all
       # jobs.map(&:handler).each{|h| puts h}
-      expect(jobs.select{ |j| j.handler =~ /'List'.*\:refresh/m }).to be_blank
+      expect( jobs.select {| j | j.handler =~ /'List'.*:refresh/m } ).to be_blank
     end
 
     it "should not queue refresh_with_observation jobs" do
       Delayed::Job.delete_all
       user.sane_destroy
-      expect(Delayed::Job.all.select{ |j| j.handler =~ /refresh_with_observation/m }).to be_blank
+      expect( Delayed::Job.all.select {| j | j.handler =~ /refresh_with_observation/m } ).to be_blank
     end
 
     describe "for user with observations in places" do
-      let(:place) { make_place_with_geom }
+      let( :place ) { make_place_with_geom }
       it "should queue jobs to refresh check lists" do
         o = without_delay do
           Observation.make!(
@@ -674,18 +727,18 @@ describe User do
           ]
         }
         JSON
-        stub_request(:get, /#{INatAPIService::ENDPOINT}/).
-          to_return(status: 200, body: response_json,
-            headers: {"Content-Type" => "application/json"})
+        stub_request( :get, /#{INatAPIService::ENDPOINT}/ ).
+          to_return( status: 200, body: response_json,
+            headers: { "Content-Type" => "application/json" } )
 
         user.sane_destroy
         jobs = Delayed::Job.all
         # jobs.map(&:handler).each{|h| puts h}
-        expect(jobs.select{|j| j.handler =~ /'CheckList'.*\:refresh/m}).not_to be_blank
+        expect( jobs.select {| j | j.handler =~ /'CheckList'.*:refresh/m } ).not_to be_blank
       end
 
       it "should refresh check lists" do
-        t = Taxon.make!(rank: "species")
+        t = Taxon.make!( rank: "species" )
         o = without_delay do
           make_research_grade_observation(
             taxon: t,
@@ -714,10 +767,10 @@ describe User do
           ]
         }
         JSON
-        stub_request(:get, /#{INatAPIService::ENDPOINT}/).
-          to_return(status: 200, body: response_json,
-            headers: {"Content-Type" => "application/json"})
-        
+        stub_request( :get, /#{INatAPIService::ENDPOINT}/ ).
+          to_return( status: 200, body: response_json,
+            headers: { "Content-Type" => "application/json" } )
+
         expect( place.check_list.listed_taxa.find_by_taxon_id( t.id ) ).not_to be_blank
         user.sane_destroy
         Delayed::Worker.new.work_off
@@ -739,12 +792,12 @@ describe User do
         user.sane_destroy
         Delayed::Worker.new.work_off
         Delayed::Worker.new.work_off
-        expect(ListedTaxon.where( place_id: @place, taxon_id: t ) ).to be_blank
+        expect( ListedTaxon.where( place_id: @place, taxon_id: t ) ).to be_blank
       end
     end
 
     describe "for owner of a project" do
-      let(:project) { without_delay { Project.make!( user: user ) } }
+      let( :project ) { without_delay { Project.make!( user: user ) } }
 
       it "should not queue jobs to refresh project lists" do
         expect( project.project_list ).not_to be_blank
@@ -752,11 +805,11 @@ describe User do
         user.sane_destroy
         jobs = Delayed::Job.all
         # jobs.map(&:handler).each{|h| puts h}
-        expect(jobs.select{|j| j.handler =~ /'ProjectList'.*\:refresh/m}).to be_blank
+        expect( jobs.select {| j | j.handler =~ /'ProjectList'.*:refresh/m } ).to be_blank
       end
 
       it "should assign projects to a manager" do
-        po = make_project_observation( project: project )
+        make_project_observation( project: project )
         m = ProjectUser.make!( role: ProjectUser::MANAGER, project: project )
         user.sane_destroy
         project.reload
@@ -772,11 +825,11 @@ describe User do
         end
         it "should generate for new project owners" do
           p = Project.make!( user: user )
-          po = make_project_observation( project: p )
+          make_project_observation( project: p )
           m = without_delay do
             ProjectUser.make!( role: ProjectUser::MANAGER, project: p )
           end
-          expect( UpdateAction.unviewed_by_user_from_query( m.user_id, { } ) ).to eq false
+          expect( UpdateAction.unviewed_by_user_from_query( m.user_id, {} ) ).to eq false
           without_delay { user.sane_destroy }
           expect( UpdateAction.unviewed_by_user_from_query( m.user_id, resource: p ) ).to eq true
         end
@@ -808,7 +861,7 @@ describe User do
       it "should reassess the quality grade of observations the user has identified" do
         o = make_research_grade_candidate_observation( taxon: Taxon.make!( rank: Taxon::SPECIES ) )
         expect( o.quality_grade ).to eq Observation::NEEDS_ID
-        i = Identification.make!( observation: o, taxon: o.taxon, user: user )
+        Identification.make!( observation: o, taxon: o.taxon, user: user )
         o.reload
         expect( o.quality_grade ).to eq Observation::RESEARCH_GRADE
         without_delay { user.sane_destroy }
@@ -863,38 +916,37 @@ describe User do
     it "deletes unread sent messages" do
       fu = UserPrivilege.make!.user # User.make!
       tu = UserPrivilege.make!.user # User.make!
-      m = make_message(:user => fu, :from_user => fu, :to_user => tu)
+      m = make_message( user: fu, from_user: fu, to_user: tu )
       m.send_message
-      expect(m.to_user_copy).not_to be_blank
+      expect( m.to_user_copy ).not_to be_blank
       fu.suspend!
       m.reload
-      expect(m.to_user_copy).to be_blank
+      expect( m.to_user_copy ).to be_blank
     end
 
     it "should not delete the suspended user's messages" do
       fu = UserPrivilege.make!.user # User.make!
       tu = UserPrivilege.make!.user # User.make!
-      m = make_message(:user => fu, :from_user => fu, :to_user => tu)
+      m = make_message( user: fu, from_user: fu, to_user: tu )
       m.send_message
-      expect(m.to_user_copy).not_to be_blank
+      expect( m.to_user_copy ).not_to be_blank
       fu.suspend!
-      expect(Message.find_by_id(m.id)).not_to be_blank
+      expect( Message.find_by_id( m.id ) ).not_to be_blank
     end
   end
 
   describe "being unsuspended" do
-
     before do
       @user = User.make!
       @user.suspend!
     end
 
-    it 'reverts to active state' do
+    it "reverts to active state" do
       @user.unsuspend!
-      expect(@user).to be_active
+      expect( @user ).to be_active
     end
   end
-  
+
   describe "licenses" do
     elastic_models( Observation )
 
@@ -927,30 +979,29 @@ describe User do
       ).any? ).to be true
     end
 
-
     it "should not update GoogleStreetViewPhotos" do
       u = User.make!
-      p = GoogleStreetViewPhoto.make!(:user => u)
+      p = GoogleStreetViewPhoto.make!( user: u )
       u.preferred_photo_license = Observation::CC_BY
-      u.update(:make_photo_licenses_same => true)
+      u.update( make_photo_licenses_same: true )
       p.reload
-      expect(p.license).to eq Photo::COPYRIGHT
+      expect( p.license ).to eq Photo::COPYRIGHT
     end
   end
 
   describe "merge" do
     elastic_models( Observation, Identification )
-    
-    let(:keeper) { User.make! }
-    let(:reject) { User.make! }
+
+    let( :keeper ) { User.make! }
+    let( :reject ) { User.make! }
 
     it "should move observations" do
-      o = Observation.make!(:user => reject)
+      o = Observation.make!( user: reject )
       without_delay do
-        keeper.merge(reject)
+        keeper.merge( reject )
       end
       o.reload
-      expect(o.user_id).to eq keeper.id
+      expect( o.user_id ).to eq keeper.id
     end
 
     it "should update the observations_count" do
@@ -968,12 +1019,12 @@ describe User do
 
     it "should update the identifications_count" do
       Identification.make!( user: reject )
-      Delayed::Job.all.each{ |j| Delayed::Worker.new.run( j ) }
+      Delayed::Job.all.each {| j | Delayed::Worker.new.run( j ) }
       reject.reload
       expect( reject.identifications_count ).to eq 1
       expect( keeper.identifications_count ).to eq 0
       keeper.merge( reject )
-      Delayed::Job.all.each{ |j| Delayed::Worker.new.run( j ) }
+      Delayed::Job.all.each {| j | Delayed::Worker.new.run( j ) }
       keeper.reload
       expect( keeper.identifications_count ).to eq 1
     end
@@ -981,46 +1032,58 @@ describe User do
       o = Observation.make!( user: reject )
       Delayed::Worker.new.work_off
       expect(
-        Observation.elastic_search( filters: [ { term: { id: o.id } } ] ).response.hits.hits[0]._source.user.id
+        Observation.elastic_search( filters: [{ term: { id: o.id } }] ).response.hits.hits[0]._source.user.id
       ).to eq reject.id
       keeper.merge( reject )
       Delayed::Worker.new.work_off
       keeper.reload
       expect(
-        Observation.elastic_search( filters: [ { term: { id: o.id } } ] ).response.hits.hits[0]._source.user.id
+        Observation.elastic_search( filters: [{ term: { id: o.id } }] ).response.hits.hits[0]._source.user.id
       ).to eq keeper.id
     end
     it "should reindex observations identified by the user" do
       o = Identification.make!( user: reject ).observation
       Delayed::Worker.new.work_off
       expect(
-        Observation.elastic_search( filters: [ { term: { id: o.id } } ] ).response.hits.hits[0]._source.identifier_user_ids
+        Observation.
+          elastic_search( filters: [{ term: { id: o.id } }] ).
+          response.
+          hits.
+          hits[0].
+          _source.
+          identifier_user_ids
       ).to include reject.id
       keeper.merge( reject )
       Delayed::Worker.new.work_off
       keeper.reload
       expect(
-        Observation.elastic_search( filters: [ { term: { id: o.id } } ] ).response.hits.hits[0]._source.identifier_user_ids
+        Observation.
+          elastic_search( filters: [{ term: { id: o.id } }] ).
+          response.
+          hits.
+          hits[0].
+          _source.
+          identifier_user_ids
       ).to include keeper.id
     end
     it "should reindex the user" do
-      o = Observation.make!( user: reject )
+      Observation.make!( user: reject )
       Delayed::Worker.new.work_off
       expect(
-        User.elastic_search( filters: [ { term: { id: keeper.id } } ] ).response.hits.hits[0]._source.observations_count
+        User.elastic_search( filters: [{ term: { id: keeper.id } }] ).response.hits.hits[0]._source.observations_count
       ).to eq 0
       keeper.merge( reject )
       Delayed::Worker.new.work_off
       expect(
-        User.elastic_search( filters: [ { term: { id: keeper.id } } ] ).response.hits.hits[0]._source.observations_count
+        User.elastic_search( filters: [{ term: { id: keeper.id } }] ).response.hits.hits[0]._source.observations_count
       ).to eq Observation.by( keeper ).count
     end
 
     it "should remove self friendships" do
-      f = Friendship.make!(:user => reject, :friend => keeper)
-      keeper.merge(reject)
-      expect(Friendship.find_by_id(f.id)).to be_blank
-      expect(keeper.friendships.map(&:friend_id)).not_to include(keeper.id)
+      f = Friendship.make!( user: reject, friend: keeper )
+      keeper.merge( reject )
+      expect( Friendship.find_by_id( f.id ) ).to be_blank
+      expect( keeper.friendships.map( &:friend_id ) ).not_to include( keeper.id )
     end
 
     it "should remove duplicate friendships" do
@@ -1035,16 +1098,16 @@ describe User do
     it "should queue a job to do the slow stuff" do
       Delayed::Job.delete_all
       stamp = Time.now
-      keeper.merge(reject)
-      jobs = Delayed::Job.where("created_at >= ?", stamp)
+      keeper.merge( reject )
+      jobs = Delayed::Job.where( "created_at >= ?", stamp )
       # puts jobs.map(&:handler).inspect
-      expect(jobs.select{|j| j.handler =~ /User.*\:merge_cleanup/m}).not_to be_blank
+      expect( jobs.select {| j | j.handler =~ /User.*:merge_cleanup/m } ).not_to be_blank
     end
 
     it "should not result in duplicate project users" do
       project = Project.make!
-      keeper_pu = ProjectUser.make!( project: project, user: keeper )
-      reject_pu = ProjectUser.make!( project: project, user: reject )
+      ProjectUser.make!( project: project, user: keeper )
+      ProjectUser.make!( project: project, user: reject )
       expect( keeper.project_users.count ).to eq 1
       keeper.merge( reject )
       keeper.reload
@@ -1063,9 +1126,9 @@ describe User do
     end
 
     describe "matching identifications on the same observation" do
-      let(:observation) { Observation.make! }
-      let(:keeper_ident) { Identification.make!( observation: observation, user: keeper ) }
-      let(:reject_ident) { Identification.make!( observation: observation, user: reject, taxon: keeper_ident.taxon ) }
+      let( :observation ) { Observation.make! }
+      let( :keeper_ident ) { Identification.make!( observation: observation, user: keeper ) }
+      let( :reject_ident ) { Identification.make!( observation: observation, user: reject, taxon: keeper_ident.taxon ) }
       it "should withdraw the reject's identification" do
         expect( reject_ident.user_id ).not_to eq keeper_ident.user_id
         keeper.merge( reject )
@@ -1118,48 +1181,49 @@ describe User do
 
   describe "suggest_login" do
     it "should not suggest logins that are too short" do
-      suggestion = User.suggest_login("AJ")
-      expect(suggestion).not_to be_blank
-      expect(suggestion.size).to be >= User::MIN_LOGIN_SIZE
+      suggestion = User.suggest_login( "AJ" )
+      expect( suggestion ).not_to be_blank
+      expect( suggestion.size ).to be >= User::MIN_LOGIN_SIZE
     end
 
     it "should not suggests logins that are too big" do
-      suggestion = User.suggest_login("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor")
-      expect(suggestion).not_to be_blank
-      expect(suggestion.size).to be <= User::MAX_LOGIN_SIZE
+      suggestion = User.suggest_login(
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor"
+      )
+      expect( suggestion ).not_to be_blank
+      expect( suggestion.size ).to be <= User::MAX_LOGIN_SIZE
     end
-    
+
     it "should not suggest logins that begin with a number" do
-      suggestion = User.suggest_login("2bornot2b")
-      expect(suggestion).not_to be_blank
-      expect(suggestion).not_to start_with '2'
+      suggestion = User.suggest_login( "2bornot2b" )
+      expect( suggestion ).not_to be_blank
+      expect( suggestion ).not_to start_with "2"
     end
 
     it "should not suggest purely integer logins" do
-      suggestion = User.suggest_login("")
-      expect(suggestion).not_to be_blank
-      expect(suggestion).to eq "naturalist"
+      suggestion = User.suggest_login( "" )
+      expect( suggestion ).not_to be_blank
+      expect( suggestion ).to eq "naturalist"
 
-      suggestion = User.suggest_login("育")
-      expect(suggestion).not_to be_blank
-      expect(suggestion).to eq "naturalist"
+      suggestion = User.suggest_login( "育" )
+      expect( suggestion ).not_to be_blank
+      expect( suggestion ).to eq "naturalist"
     end
 
     it "should suggest naturalistX for more empty suggestions" do
-      User.make!(login: "naturalist")
-      suggestion = User.suggest_login("")
-      expect(suggestion).not_to be_blank
-      expect(suggestion).to eq "naturalist1"
+      User.make!( login: "naturalist" )
+      suggestion = User.suggest_login( "" )
+      expect( suggestion ).not_to be_blank
+      expect( suggestion ).to eq "naturalist1"
 
       # 9 is forbidden
-      (1..8).each do |i|
-        User.make!(login: "naturalist#{i}")
+      ( 1..8 ).each do | i |
+        User.make!( login: "naturalist#{i}" )
       end
-      allow(User).to receive(:rand).and_return(12345)
-      suggestion = User.suggest_login("")
-      expect(suggestion).to eq "naturalist12345"
+      allow( User ).to receive( :rand ).and_return( 12_345 )
+      suggestion = User.suggest_login( "" )
+      expect( suggestion ).to eq "naturalist12345"
     end
-
   end
 
   describe "community taxa preference" do
@@ -1167,55 +1231,56 @@ describe User do
 
     it "should not remove community taxa when set to false" do
       o = Observation.make!
-      i1 = Identification.make!(:observation => o)
-      i2 = Identification.make!(:observation => o, :taxon => i1.taxon)
+      i1 = Identification.make!( observation: o )
+      Identification.make!( observation: o, taxon: i1.taxon )
       o.reload
-      expect(o.community_taxon).to eq i1.taxon
-      o.user.update(:prefers_community_taxa => false)
+      expect( o.community_taxon ).to eq i1.taxon
+      o.user.update( prefers_community_taxa: false )
       Delayed::Worker.new.work_off
       o.reload
-      expect(o.taxon).to be_blank
+      expect( o.taxon ).to be_blank
     end
 
     it "should set observation taxa to owner's ident when set to false" do
       owners_taxon = Taxon.make!
-      o = Observation.make!(:taxon => owners_taxon)
-      i1 = Identification.make!(:observation => o)
-      i2 = Identification.make!(:observation => o, :taxon => i1.taxon)
-      i3 = Identification.make!(:observation => o, :taxon => i1.taxon)
+      o = Observation.make!( taxon: owners_taxon )
+      i1 = Identification.make!( observation: o )
+      Identification.make!( observation: o, taxon: i1.taxon )
+      Identification.make!( observation: o, taxon: i1.taxon )
       o.reload
-      expect(o.taxon).to eq o.community_taxon
-      o.user.update(:prefers_community_taxa => false)
+      expect( o.taxon ).to eq o.community_taxon
+      o.user.update( prefers_community_taxa: false )
       Delayed::Worker.new.work_off
       o.reload
-      expect(o.taxon).to eq owners_taxon
+      expect( o.taxon ).to eq owners_taxon
     end
 
-    it "should not set observation taxa to owner's ident when set to false for observations that prefer community taxon" do
+    it "should not set observation taxa to owner's ident when set to false for observations that prefer " \
+      "community taxon" do
       owners_taxon = Taxon.make!
-      o = Observation.make!(:taxon => owners_taxon, :prefers_community_taxon => true)
-      i1 = Identification.make!(:observation => o)
-      i2 = Identification.make!(:observation => o, :taxon => i1.taxon)
-      i3 = Identification.make!(:observation => o, :taxon => i1.taxon)
+      o = Observation.make!( taxon: owners_taxon, prefers_community_taxon: true )
+      i1 = Identification.make!( observation: o )
+      Identification.make!( observation: o, taxon: i1.taxon )
+      Identification.make!( observation: o, taxon: i1.taxon )
       o.reload
-      expect(o.taxon).to eq o.community_taxon
-      o.user.update(:prefers_community_taxa => false)
+      expect( o.taxon ).to eq o.community_taxon
+      o.user.update( prefers_community_taxa: false )
       Delayed::Worker.new.work_off
       o.reload
-      expect(o.taxon).to eq o.community_taxon
+      expect( o.taxon ).to eq o.community_taxon
     end
 
     it "should change observation taxa to community taxa when set to true" do
       o = Observation.make!
-      o.user.update(:prefers_community_taxa => false)
-      i1 = Identification.make!(:observation => o)
-      i2 = Identification.make!(:observation => o, :taxon => i1.taxon)
+      o.user.update( prefers_community_taxa: false )
+      i1 = Identification.make!( observation: o )
+      Identification.make!( observation: o, taxon: i1.taxon )
       o.reload
-      expect(o.taxon).to be_blank
-      o.user.update(:prefers_community_taxa => true)
+      expect( o.taxon ).to be_blank
+      o.user.update( prefers_community_taxa: true )
       Delayed::Worker.new.work_off
       o.reload
-      expect(o.taxon).to eq o.community_taxon
+      expect( o.taxon ).to eq o.community_taxon
     end
 
     it "should re-assess quality grade when changed" do
@@ -1258,27 +1323,27 @@ describe User do
 
   describe "active_ids" do
     it "should calculate active users across several classes" do
-      expect(User.active_ids.length).to eq 0
-      expect(Identification.count).to eq 0
+      expect( User.active_ids.length ).to eq 0
+      expect( Identification.count ).to eq 0
       observation = Observation.make!
       # observations are made with identifications, so we'll start fresh
       Identification.delete_all
-      Identification.make!(observation: observation)
-      expect(Identification.count).to eq 1
-      Comment.make!(parent: observation)
-      Post.make!(parent: observation)
-      expect(User.active_ids.length).to eq 4
+      Identification.make!( observation: observation )
+      expect( Identification.count ).to eq 1
+      Comment.make!( parent: observation )
+      Post.make!( parent: observation )
+      expect( User.active_ids.length ).to eq 4
     end
 
     it "should count the same user only once" do
-      expect(User.active_ids.length).to eq 0
+      expect( User.active_ids.length ).to eq 0
       user = User.make!
-      observation = Observation.make!(user: user)
+      observation = Observation.make!( user: user )
       Identification.delete_all
-      Identification.make!(observation: observation, user: user)
-      Comment.make!(parent: observation, user: user)
-      Post.make!(parent: observation, user: user)
-      expect(User.active_ids.length).to eq 1
+      Identification.make!( observation: observation, user: user )
+      Comment.make!( parent: observation, user: user )
+      Post.make!( parent: observation, user: user )
+      expect( User.active_ids.length ).to eq 1
     end
   end
 
@@ -1289,29 +1354,29 @@ describe User do
 
     it "can prefer to not get mentions" do
       u = User.make!
-      expect( UpdateAction.unviewed_by_user_from_query(u.id, { }) ).to eq false
-      c1 = without_delay { Comment.make!(body: "hey @#{ u.login }") }
-      c2 = without_delay { Comment.make!(body: "hey @#{ u.login }") }
-      expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: c1) ).to eq true
-      expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: c2) ).to eq true
+      expect( UpdateAction.unviewed_by_user_from_query( u.id, {} ) ).to eq false
+      c1 = without_delay { Comment.make!( body: "hey @#{u.login}" ) }
+      c2 = without_delay { Comment.make!( body: "hey @#{u.login}" ) }
+      expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: c1 ) ).to eq true
+      expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: c2 ) ).to eq true
 
-      u.update(prefers_receive_mentions: false)
-      c3 = without_delay { Comment.make!(body: "hey @#{ u.login }") }
-      expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: c3) ).to eq false
+      u.update( prefers_receive_mentions: false )
+      c3 = without_delay { Comment.make!( body: "hey @#{u.login}" ) }
+      expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: c3 ) ).to eq false
     end
 
     it "can prefer to not get mentions in emails" do
       u = User.make!
-      expect( UpdateAction.unviewed_by_user_from_query(u.id, { }) ).to eq false
-      c = without_delay { Comment.make!(body: "hey @#{ u.login }") }
-      expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: c) ).to eq true
+      expect( UpdateAction.unviewed_by_user_from_query( u.id, {} ) ).to eq false
+      c = without_delay { Comment.make!( body: "hey @#{u.login}" ) }
+      expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: c ) ).to eq true
       deliveries = ActionMailer::Base.deliveries.size
-      u.update(prefers_mention_email_notification: false)
-      UpdateAction.email_updates_to_user(u, 1.hour.ago, Time.now)
+      u.update( prefers_mention_email_notification: false )
+      UpdateAction.email_updates_to_user( u, 1.hour.ago, Time.now )
       expect( ActionMailer::Base.deliveries.size ).to eq deliveries
-      u.update(prefers_mention_email_notification: true)
-      UpdateAction.email_updates_to_user(u, 1.hour.ago, Time.now)
-      expect( ActionMailer::Base.deliveries.size ).to eq (deliveries + 1)
+      u.update( prefers_mention_email_notification: true )
+      UpdateAction.email_updates_to_user( u, 1.hour.ago, Time.now )
+      expect( ActionMailer::Base.deliveries.size ).to eq( deliveries + 1 )
     end
   end
 
@@ -1320,56 +1385,56 @@ describe User do
     before { enable_has_subscribers }
     after { disable_has_subscribers }
 
-    let(:u) { User.make! }
-    let(:genus) { Taxon.make!(rank: Taxon::GENUS) }
-    let(:species) { Taxon.make!(rank: Taxon::SPECIES, parent: genus) }
-    let(:subspecies) { Taxon.make!(rank: Taxon::SUBSPECIES, parent: species) }
-    let(:o) { Observation.make!(taxon: species) }
-    let(:i) { Identification.make!(observation: o, user: u, taxon: species)}
+    let( :u ) { User.make! }
+    let( :genus ) { Taxon.make!( rank: Taxon::GENUS ) }
+    let( :species ) { Taxon.make!( rank: Taxon::SPECIES, parent: genus ) }
+    let( :subspecies ) { Taxon.make!( rank: Taxon::SUBSPECIES, parent: species ) }
+    let( :o ) { Observation.make!( taxon: species ) }
+    let( :i ) { Identification.make!( observation: o, user: u, taxon: species ) }
 
     describe "true" do
       before do
-        u.update(prefers_redundant_identification_notifications: true)
+        u.update( prefers_redundant_identification_notifications: true )
         expect( i ).to be_persisted
-        expect( u.subscriptions.map(&:resource) ).to include o
+        expect( u.subscriptions.map( &:resource ) ).to include o
       end
       it "should allow identifications that match with the subscriber" do
-        id = without_delay { Identification.make!(observation: o, taxon: species) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq true
+        id = without_delay { Identification.make!( observation: o, taxon: species ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq true
       end
       it "should allow identifications of taxa that are descendants of the subscriber's taxon" do
-        id = without_delay { Identification.make!(observation: o, taxon: subspecies) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq true
+        id = without_delay { Identification.make!( observation: o, taxon: subspecies ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq true
       end
       it "should allow identifications of taxa that are ancestors of the subscriber's taxon" do
-        id = without_delay { Identification.make!(observation: o, taxon: genus) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq true
+        id = without_delay { Identification.make!( observation: o, taxon: genus ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq true
       end
     end
 
     describe "false" do
       before do
-        u.update(prefers_redundant_identification_notifications: false)
+        u.update( prefers_redundant_identification_notifications: false )
         expect( i ).to be_persisted
-        expect( u.subscriptions.map(&:resource) ).to include o
+        expect( u.subscriptions.map( &:resource ) ).to include o
       end
       it "should suppress identifications that match with the subscriber" do
-        id = without_delay { Identification.make!(observation: o, taxon: species) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq false
+        id = without_delay { Identification.make!( observation: o, taxon: species ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq false
       end
       it "should allow identifications of taxa that are descendants of the subscriber's taxon" do
-        id = without_delay { Identification.make!(observation: o, taxon: subspecies) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq true
+        id = without_delay { Identification.make!( observation: o, taxon: subspecies ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq true
       end
       it "should allow identifications of taxa that are ancestors of the subscriber's taxon" do
-        id = without_delay { Identification.make!(observation: o, taxon: genus) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq true
+        id = without_delay { Identification.make!( observation: o, taxon: genus ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq true
       end
       it "should allow notification if subscriber has no identification" do
-        obs = Observation.make!(user: u)
+        obs = Observation.make!( user: u )
         expect( obs.owners_identification ).to be_blank
-        id = without_delay { Identification.make!(observation: obs) }
-        expect( UpdateAction.unviewed_by_user_from_query(u.id, notifier: id) ).to eq true
+        id = without_delay { Identification.make!( observation: obs ) }
+        expect( UpdateAction.unviewed_by_user_from_query( u.id, notifier: id ) ).to eq true
       end
     end
   end
@@ -1377,8 +1442,8 @@ describe User do
   describe "when flagged as spam" do
     elastic_models( Observation, Identification, Project )
 
-    let(:user) { make_user_with_privilege( UserPrivilege::ORGANIZER ) }
-    let(:flagger) { User.make! }
+    let( :user ) { make_user_with_privilege( UserPrivilege::ORGANIZER ) }
+    let( :flagger ) { User.make! }
 
     it "should reindex observations as spam" do
       o = Observation.make!( user: user )
@@ -1418,7 +1483,7 @@ describe User do
     it "should happen on create" do
       Rakismet.disabled = false
       user = User.make( description: "this is spam" )
-      allow( user ).to receive(:spam?).and_return( true )
+      allow( user ).to receive( :spam? ).and_return( true )
       user.save!
       expect( user ).to be_flagged_as_spam
     end
@@ -1426,7 +1491,7 @@ describe User do
       user = User.make!( description: "this is ok" )
       expect( user ).not_to be_flagged_as_spam
       Rakismet.disabled = false
-      allow( user ).to receive(:spam?).and_return( true )
+      allow( user ).to receive( :spam? ).and_return( true )
       user.update( description: "buy this watch!" )
       expect( user ).to be_flagged_as_spam
     end
@@ -1441,7 +1506,7 @@ describe User do
       expect( flag_user_id ).not_to be_blank
       User.forget( f.user_id, skip_aws: true )
       f.reload
-      expect( f.user_id ).to eq -1
+      expect( f.user_id ).to eq( -1 )
       other_f.reload
       expect( other_f.user_id ).to be > 0
     end
@@ -1463,7 +1528,7 @@ describe User do
       u = create :user
       user_id = u.id
       email = u.email
-      es = create :email_suppression, email: u.email
+      create :email_suppression, email: u.email
       expect( u.email_suppressions ).to be_blank
       User.forget( user_id, skip_aws: true )
       expect( EmailSuppression.find_by_email( email ) ).to be_blank
@@ -1483,33 +1548,33 @@ describe User do
 
     it "unsuspended IPs are OK" do
       # 0 suspended, 10 active: 0% suspended, returns false
-      10.times{ User.make!( last_ip: ip ) }
+      10.times { User.make!( last_ip: ip ) }
       expect( User.where( last_ip: ip ).count ).to be 10
       expect( User.ip_address_is_often_suspended( ip ) ).to be false
     end
 
     it "less than two total occurrences is OK" do
       # 2 suspended, 0 active: 100% suspended, but less than 3 total, returns false
-      2.times{ User.make!( last_ip: ip, suspended_at: Time.now ) }
+      2.times { User.make!( last_ip: ip, suspended_at: Time.now ) }
       expect( User.ip_address_is_often_suspended( ip ) ).to be false
     end
 
     it "three or more suspended accounts is not OK" do
       # 3 suspended, 0 active: 100% suspended, returns false
-      3.times{ User.make!( last_ip: ip, suspended_at: Time.now ) }
+      3.times { User.make!( last_ip: ip, suspended_at: Time.now ) }
       expect( User.ip_address_is_often_suspended( ip ) ).to be true
     end
 
     it "under 90% suspended is OK" do
       # 3 suspended, 1 active: 75% suspended, returns false
-      3.times{ User.make!( last_ip: ip, suspended_at: Time.now ) }
+      3.times { User.make!( last_ip: ip, suspended_at: Time.now ) }
       User.make!( last_ip: ip )
       expect( User.ip_address_is_often_suspended( ip ) ).to be false
     end
 
     it "returns true when over 90% of accounts are suspended" do
       # 9 suspended, 1 active: 90% suspended, returns true
-      9.times{ User.make!( last_ip: ip, suspended_at: Time.now ) }
+      9.times { User.make!( last_ip: ip, suspended_at: Time.now ) }
       User.make!( last_ip: ip )
       expect( User.ip_address_is_often_suspended( ip ) ).to be true
     end
@@ -1529,7 +1594,7 @@ describe User do
 
     it "does not return taxa previously observed by the user" do
       taxon = Taxon.make!
-      obs = Observation.make!(
+      Observation.make!(
         user: user,
         taxon: taxon,
         observed_on_string: 1.week.ago.to_s
@@ -1539,18 +1604,20 @@ describe User do
   end
 
   describe "create_from_omniauth" do
-    let(:email) { Faker::Internet.email }
-    let(:auth_info) { {
-      "info" => {
-        "email" => email,
-        "name" => Faker::Name.name
-      },
-      "extra" => {
-        "user_hash" => {
-          "email" => email
+    let( :email ) { Faker::Internet.email }
+    let( :auth_info ) do
+      {
+        "info" => {
+          "email" => email,
+          "name" => Faker::Name.name
+        },
+        "extra" => {
+          "user_hash" => {
+            "email" => email
+          }
         }
       }
-    } }
+    end
     it "should set the confirmation_token" do
       u = User.create_from_omniauth( auth_info )
       expect( u ).not_to be_confirmed
@@ -1576,17 +1643,19 @@ describe User do
     end
 
     describe "with an email in the name field" do
-      let(:auth_info) { {
-        "info" => {
-          "email" => email,
-          "name" => email
-        },
-        "extra" => {
-          "user_hash" => {
-            "email" => email
+      let( :auth_info ) do
+        {
+          "info" => {
+            "email" => email,
+            "name" => email
+          },
+          "extra" => {
+            "user_hash" => {
+              "email" => email
+            }
           }
         }
-      } }
+      end
       it "should not allow an email in the name field" do
         u = User.create_from_omniauth( auth_info )
         expect( u.email ).to eq email
@@ -1689,15 +1758,17 @@ describe User do
   end
 
   protected
-  def create_user(options = {})
+
+  def create_user( options = {} )
     opts = {
-      :login => 'quire',
-      :email => 'quire@example.com',
-      :password => 'quire69',
-      :password_confirmation => 'quire69'
-    }.merge(options)
-    u = User.new(opts)
+      login: "quire",
+      email: "quire@example.com",
+      password: "quire69",
+      password_confirmation: "quire69"
+    }.merge( options )
+    u = User.new( opts )
     u.save
     u
   end
 end
+# rubocop:enable Style/FrozenStringLiteralComment


### PR DESCRIPTION
This only goes part way toward WEB-367 by handling the case where the sender is suspended but their messages are not spam. I'm mostly interested in critiques of the approach using the `sent_at` column in the `messages` table. Overly complicated? Edge cases I'm missing?

Uh, there are a lot of Rubocop changes too, so it might help to look at things commit by commit.

Update: this PR now closes WEB-367.