### PR TITLE
Add canonical email to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "elasticsearch", "~> 8"
 gem "elasticsearch-api", "~> 8"
 gem "elasticsearch-model", "~> 8"
 gem "elasticsearch-rails", "8.0.0.pre"
+gem "email_address"
 gem "exifr", require: ["exifr", "exifr/jpeg", "exifr/tiff"]
 gem "exiftool_vendored" # Vendored version includes exiftool and exiftool gem
 gem "fastimage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.2.0)
     bcrypt (3.1.16)
     bcrypt_pbkdf (1.1.0)
     better_errors (2.9.1)
@@ -327,6 +328,9 @@ GEM
       elasticsearch (~> 8)
       hashie
     elasticsearch-rails (8.0.0.pre)
+    email_address (0.2.5)
+      base64
+      simpleidn
     erubi (1.13.0)
     execjs (2.8.1)
     exifr (1.3.9)
@@ -653,6 +657,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
+    simpleidn (0.2.3)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -766,6 +771,7 @@ DEPENDENCIES
   elasticsearch-api (~> 8)
   elasticsearch-model (~> 8)
   elasticsearch-rails (= 8.0.0.pre)
+  email_address
   exifr
   exiftool_vendored
   factory_bot_rails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1365,7 +1365,6 @@ class User < ApplicationRecord
   def check_privileges_if_confirmed
     return unless saved_change_to_confirmed_at?
 
-    UserPrivilege.check( id, UserPrivilege::INTERACTION )
     UserPrivilege.check( id, UserPrivilege::ORGANIZER )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -273,6 +273,7 @@ class User < ApplicationRecord
   before_validation :download_remote_icon, :if => :icon_url_provided?
   before_validation :strip_name, :strip_login
   before_validation :set_time_zone
+  before_validation :set_canonical_email
   before_create :skip_confirmation_if_child
   before_save :allow_some_licenses
   before_save :get_lat_lon_from_ip_if_last_ip_changed
@@ -291,6 +292,7 @@ class User < ApplicationRecord
   after_save :update_taxon_name_priorities
   after_update :set_observations_taxa_if_pref_changed
   after_update :send_welcome_email
+  after_update :check_privileges_if_confirmed
   after_create :set_uri
   after_destroy :remove_oauth_access_tokens
   after_destroy :destroy_project_rules
@@ -772,6 +774,12 @@ class User < ApplicationRecord
   def set_time_zone
     self.time_zone = nil if time_zone.blank?
     true
+  end
+
+  def set_canonical_email
+    return unless new_record? || email_changed?
+
+    self.canonical_email = EmailAddress.canonical( email )
   end
 
   def set_uri
@@ -1352,6 +1360,13 @@ class User < ApplicationRecord
     )
       Emailer.welcome( self ).deliver_now
     end
+  end
+
+  def check_privileges_if_confirmed
+    return unless saved_change_to_confirmed_at?
+
+    UserPrivilege.check( id, UserPrivilege::INTERACTION )
+    UserPrivilege.check( id, UserPrivilege::ORGANIZER )
   end
 
   def revoke_authorizations_after_password_change

--- a/app/models/user_privilege.rb
+++ b/app/models/user_privilege.rb
@@ -8,11 +8,13 @@ class UserPrivilege < ApplicationRecord
   SPEECH = "speech"
   ORGANIZER = "organizer"
   COORDINATE_ACCESS = "coordinate_access"
+  INTERACTION = "interaction"
 
   PRIVILEGES = [
     SPEECH,
     ORGANIZER,
-    COORDINATE_ACCESS
+    COORDINATE_ACCESS,
+    INTERACTION
   ].freeze
 
   # The earned_#{privilege}? methods are intended to calculate whether the user
@@ -50,6 +52,10 @@ class UserPrivilege < ApplicationRecord
       ]
     ).total_entries
     improving_ids_count >= 1000
+  end
+
+  def self.earned_interaction?( user )
+    user.confirmed?
   end
 
   def self.check( user, privilege )

--- a/app/models/user_privilege.rb
+++ b/app/models/user_privilege.rb
@@ -8,13 +8,11 @@ class UserPrivilege < ApplicationRecord
   SPEECH = "speech"
   ORGANIZER = "organizer"
   COORDINATE_ACCESS = "coordinate_access"
-  INTERACTION = "interaction"
 
   PRIVILEGES = [
     SPEECH,
     ORGANIZER,
-    COORDINATE_ACCESS,
-    INTERACTION
+    COORDINATE_ACCESS
   ].freeze
 
   # The earned_#{privilege}? methods are intended to calculate whether the user
@@ -52,10 +50,6 @@ class UserPrivilege < ApplicationRecord
       ]
     ).total_entries
     improving_ids_count >= 1000
-  end
-
-  def self.earned_interaction?( user )
-    user.confirmed?
   end
 
   def self.check( user, privilege )

--- a/db/migrate/20241217203007_add_canonical_email_to_users.rb
+++ b/db/migrate/20241217203007_add_canonical_email_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCanonicalEmailToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :canonical_email, :string, limit: 100
+    add_index :users, :canonical_email
+  end
+end
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5701,7 +5701,8 @@ CREATE TABLE public.users (
     data_transfer_consent_at timestamp without time zone,
     unconfirmed_email character varying,
     annotated_observations_count integer DEFAULT 0,
-    icon_path_version smallint DEFAULT 0 NOT NULL
+    icon_path_version smallint DEFAULT 0 NOT NULL,
+    canonical_email character varying(100)
 );
 
 
@@ -10604,6 +10605,13 @@ CREATE UNIQUE INDEX index_user_signups_on_user_id ON public.user_signups USING b
 
 
 --
+-- Name: index_users_on_canonical_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_canonical_email ON public.users USING btree (canonical_email);
+
+
+--
 -- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11392,6 +11400,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240923134658'),
 ('20241127180606'),
 ('20241202092831'),
-('20241218164832');
+('20241218164832'),
+('20241217203007');
 
 

--- a/spec/models/user_privilege_spec.rb
+++ b/spec/models/user_privilege_spec.rb
@@ -121,25 +121,6 @@ describe UserPrivilege do
     end
   end
 
-  describe "interaction" do
-    it "users do not have interaction privilege if email is not confirmed" do
-      expect( UserPrivilege.earned_interaction?( User.make!( confirmed_at: nil ) ) ).to be false
-    end
-
-    it "users have interaction privilege if email is confirmed" do
-      expect(
-        UserPrivilege.earned_interaction?( User.make!( confirmed_at: Time.now ) )
-      ).to be true
-    end
-
-    it "users earn interaction privilege when email is confirmed" do
-      user = User.make!( confirmed_at: nil )
-      expect( UserPrivilege.earned_interaction?( user ) ).to be false
-      user.update( confirmed_at: Time.now )
-      expect( UserPrivilege.earned_interaction?( user ) ).to be true
-    end
-  end
-
   describe "requires_privilege" do
     # This might belong in the message spec
     # describe "for message" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,6 +140,19 @@ describe User do
       expect(u).to be_valid
     end
 
+    it "generates a canonical email" do
+      emails_with_shared_canonical = [
+        "test@gmail.com",
+        "T.e.sT@gmail.com",
+        "test+1@gmail.com",
+        "T.est+2@gmail.com",
+        "t..est+test2@gmail.com"
+      ]
+      emails_with_shared_canonical.each do | email |
+        expect( User.make!( email: email ).canonical_email ).to eq "test@gmail.com"
+      end
+    end
+
     it "should not allow time_zone to be a blank string" do
       expect( User.make!( time_zone: "" ).time_zone ).to be_nil
     end


### PR DESCRIPTION
* Adds canonical_email column to the users table and populates for new users and those that change their email address
* Fixes bug preventing users from earning Organizer privilege after confirming their email address