### PR TITLE
Obs show highlights data are lazy loaded

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1798,83 +1798,6 @@ class ObservationsController < ApplicationController
     render layout: "bootstrap"
   end
 
-  private
-
-  def observation_params(options = {})
-    p = options.blank? ? params : options
-    p.permit(
-      :captive_flag,
-      :coordinate_system,
-      :description,
-      :force_quality_metrics,
-      :geo_x,
-      :geo_y,
-      :geoprivacy,
-      :iconic_taxon_id,
-      :latitude,
-      :license,
-      :license_code,
-      :location_is_exact,
-      :longitude,
-      :make_license_default,
-      :make_licenses_same,
-      :map_scale,
-      :oauth_application_id,
-      :observed_on_string,
-      :place_guess,
-      :positional_accuracy,
-      :positioning_device,
-      :positioning_method,
-      :prefers_community_taxon,
-      :quality_grade,
-      :species_guess,
-      :tag_list,
-      :taxon_id,
-      :taxon_name,
-      :time_zone,
-      :uuid,
-      :zic_time_zone,
-      :site_id,
-      :owners_identification_from_vision,
-      :owners_identification_from_vision_requested,
-      observation_field_values_attributes: [ :_destroy, :id, :observation_field_id, :value ]
-    )
-  end
-
-  def user_obs_counts(scope, limit = 500)
-    user_counts_sql = <<-SQL
-      SELECT
-        o.user_id,
-        count(*) AS count_all
-      FROM
-        (#{scope.to_sql}) AS o
-      GROUP BY
-        o.user_id
-      ORDER BY count_all desc
-      LIMIT #{limit}
-    SQL
-    ActiveRecord::Base.connection.execute(user_counts_sql)
-  end
-
-  def user_taxon_counts(scope, limit = 500)
-    unique_taxon_users_scope = scope.
-      select("DISTINCT observations.taxon_id, observations.user_id").
-      joins(:taxon).
-      where("taxa.rank_level <= ?", Taxon::SPECIES_LEVEL)
-    user_taxon_counts_sql = <<-SQL
-      SELECT
-        o.user_id,
-        count(*) AS count_all
-      FROM
-        (#{unique_taxon_users_scope.to_sql}) AS o
-      GROUP BY
-        o.user_id
-      ORDER BY count_all desc
-      LIMIT #{limit}
-    SQL
-    ActiveRecord::Base.connection.execute(user_taxon_counts_sql)
-  end
-
   def viewed_updates
     user_viewed_updates
     respond_to do |format|
@@ -1969,6 +1892,81 @@ class ObservationsController < ApplicationController
 
 ## Protected / private actions ###############################################
   private
+
+  def observation_params(options = {})
+    p = options.blank? ? params : options
+    p.permit(
+      :captive_flag,
+      :coordinate_system,
+      :description,
+      :force_quality_metrics,
+      :geo_x,
+      :geo_y,
+      :geoprivacy,
+      :iconic_taxon_id,
+      :latitude,
+      :license,
+      :license_code,
+      :location_is_exact,
+      :longitude,
+      :make_license_default,
+      :make_licenses_same,
+      :map_scale,
+      :oauth_application_id,
+      :observed_on_string,
+      :place_guess,
+      :positional_accuracy,
+      :positioning_device,
+      :positioning_method,
+      :prefers_community_taxon,
+      :quality_grade,
+      :species_guess,
+      :tag_list,
+      :taxon_id,
+      :taxon_name,
+      :time_zone,
+      :uuid,
+      :zic_time_zone,
+      :site_id,
+      :owners_identification_from_vision,
+      :owners_identification_from_vision_requested,
+      observation_field_values_attributes: [ :_destroy, :id, :observation_field_id, :value ]
+    )
+  end
+
+  def user_obs_counts(scope, limit = 500)
+    user_counts_sql = <<-SQL
+      SELECT
+        o.user_id,
+        count(*) AS count_all
+      FROM
+        (#{scope.to_sql}) AS o
+      GROUP BY
+        o.user_id
+      ORDER BY count_all desc
+      LIMIT #{limit}
+    SQL
+    ActiveRecord::Base.connection.execute(user_counts_sql)
+  end
+
+  def user_taxon_counts(scope, limit = 500)
+    unique_taxon_users_scope = scope.
+      select("DISTINCT observations.taxon_id, observations.user_id").
+      joins(:taxon).
+      where("taxa.rank_level <= ?", Taxon::SPECIES_LEVEL)
+    user_taxon_counts_sql = <<-SQL
+      SELECT
+        o.user_id,
+        count(*) AS count_all
+      FROM
+        (#{unique_taxon_users_scope.to_sql}) AS o
+      GROUP BY
+        o.user_id
+      ORDER BY count_all desc
+      LIMIT #{limit}
+    SQL
+    ActiveRecord::Base.connection.execute(user_taxon_counts_sql)
+  end
 
   def user_viewed_updates(options={})
     return unless logged_in?

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1874,7 +1874,6 @@ class ObservationsController < ApplicationController
     SQL
     ActiveRecord::Base.connection.execute(user_taxon_counts_sql)
   end
-  public
 
   def viewed_updates
     user_viewed_updates

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -401,7 +401,7 @@ class Observation < ApplicationRecord
         non_owner_identifier_user_ids: current_ids.map(&:user_id) - [user_id],
         identification_categories: current_ids.map(&:category).uniq,
         identifications_count: num_identifications_by_others,
-        comments: comments.map(&:as_indexed_json),
+        comments: comments.map( &:as_indexed_json ).compact,
         comments_count: comments.size,
         obscured: coordinates_obscured? || geoprivacy_obscured?,
         positional_accuracy: positional_accuracy,

--- a/app/webpack/observations/show/components/observations_highlight.jsx
+++ b/app/webpack/observations/show/components/observations_highlight.jsx
@@ -1,84 +1,96 @@
 import _ from "lodash";
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Col, OverlayTrigger, Tooltip } from "react-bootstrap";
 import SplitTaxon from "../../../shared/components/split_taxon";
 import { urlForTaxon } from "../../../taxa/shared/util";
 
-const ObservationsHighlight = ( {
-  title,
-  observations,
-  searchParams,
-  showNewObservation,
-  config
-} ) => {
-  const { testingApiV2 } = config || {};
-  const loadObservationCallback = ( e, observation ) => {
-    if ( e.metaKey || e.ctrlKey ) return;
-    e.preventDefault( );
-    showNewObservation( observation, {
-      useInstance: !testingApiV2
-    } );
-  };
-  const empty = _.isEmpty( observations );
-  let content = <span className="none">{ I18n.t( "none_found" ) }</span>;
-  if ( !empty ) {
-    content = _.filter( observations, o => ( o.photo( ) ) ).map( o => (
-      <Col xs={2} key={`highlight-${o.uuid}`}>
-        <div className="photo">
-          <OverlayTrigger
-            container={$( "#wrapper.bootstrap" ).get( 0 )}
-            placement="top"
-            delayShow={200}
-            overlay={(
-              <Tooltip id={`highlight-link-${o.id}`} className="obs-highlight-link">
-                <SplitTaxon
-                  taxon={o.taxon}
-                  url={urlForTaxon( o.taxon )}
-                  noParens
-                  user={config.currentUser}
-                />
-              </Tooltip>
-            )}
-          >
-            <a
-              href={`/observations/${o.id}`}
-              style={{ backgroundImage: `url( '${o.photo( "small" )}' )` }}
-              onClick={e => loadObservationCallback( e, o )}
-            >
-              &nbsp;
-            </a>
-          </OverlayTrigger>
-        </div>
-      </Col>
-    ) );
+class ObservationsHighlight extends Component {
+  componentDidMount( ) {
+    this.props.contentLoader( );
   }
-  const viewAll = empty ? null : (
-    <a href={`/observations?${$.param( searchParams )}`}>
-      { I18n.t( "view_all" ) }
-    </a>
-  );
-  return (
-    <div className="ObservationsHighlight">
-      <Col xs={12}>
-        <h3>
-          { title }
-          { viewAll }
-        </h3>
-      </Col>
-      <div className={`list ${empty ? "empty" : ""}`}>
-        { content }
+
+  componentDidUpdate( ) {
+    this.props.contentLoader( );
+  }
+
+  render( ) {
+    const {
+      title,
+      observations,
+      searchParams,
+      showNewObservation,
+      config
+    } = this.props;
+    const { testingApiV2 } = config || {};
+    const loadObservationCallback = ( e, observation ) => {
+      if ( e.metaKey || e.ctrlKey ) return;
+      e.preventDefault( );
+      showNewObservation( observation, {
+        useInstance: !testingApiV2
+      } );
+    };
+    const empty = _.isEmpty( observations );
+    let content = <span className="none">{ I18n.t( "none_found" ) }</span>;
+    if ( !empty ) {
+      content = _.filter( observations, o => ( o.photo( ) ) ).map( o => (
+        <Col xs={2} key={`highlight-${o.uuid}`}>
+          <div className="photo">
+            <OverlayTrigger
+              container={$( "#wrapper.bootstrap" ).get( 0 )}
+              placement="top"
+              delayShow={200}
+              overlay={(
+                <Tooltip id={`highlight-link-${o.id}`} className="obs-highlight-link">
+                  <SplitTaxon
+                    taxon={o.taxon}
+                    url={urlForTaxon( o.taxon )}
+                    noParens
+                    user={config.currentUser}
+                  />
+                </Tooltip>
+              )}
+            >
+              <a
+                href={`/observations/${o.id}`}
+                style={{ backgroundImage: `url( '${o.photo( "small" )}' )` }}
+                onClick={e => loadObservationCallback( e, o )}
+              >
+                &nbsp;
+              </a>
+            </OverlayTrigger>
+          </div>
+        </Col>
+      ) );
+    }
+    const viewAll = empty ? null : (
+      <a href={`/observations?${$.param( searchParams )}`}>
+        { I18n.t( "view_all" ) }
+      </a>
+    );
+    return (
+      <div className="ObservationsHighlight">
+        <Col xs={12}>
+          <h3>
+            { title }
+            { viewAll }
+          </h3>
+        </Col>
+        <div className={`list ${empty ? "empty" : ""}`}>
+          { content }
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 ObservationsHighlight.propTypes = {
   title: PropTypes.string,
   searchParams: PropTypes.object,
   observations: PropTypes.array,
   showNewObservation: PropTypes.func,
-  config: PropTypes.object
+  config: PropTypes.object,
+  contentLoader: PropTypes.func
 };
 
 ObservationsHighlight.defaultProps = {

--- a/app/webpack/observations/show/containers/nearby_container.js
+++ b/app/webpack/observations/show/containers/nearby_container.js
@@ -1,12 +1,13 @@
 import { connect } from "react-redux";
 import ObservationsHighlight from "../components/observations_highlight";
 import { showNewObservation } from "../ducks/observation";
+import { fetchNearby } from "../ducks/other_observations";
 
 function mapStateToProps( state ) {
   return {
     title: I18n.t( "nearby_observations_" ),
-    observations: state.otherObservations.nearby.observations,
-    searchParams: state.otherObservations.nearby.params,
+    observations: state.otherObservations.nearby?.observations,
+    searchParams: state.otherObservations.nearby?.params,
     config: state.config
   };
 }
@@ -15,6 +16,9 @@ function mapDispatchToProps( dispatch ) {
   return {
     showNewObservation: ( observation, options ) => {
       dispatch( showNewObservation( observation, options ) );
+    },
+    contentLoader: ( ) => {
+      dispatch( fetchNearby( ) );
     }
   };
 }

--- a/app/webpack/observations/show/containers/similar_container.js
+++ b/app/webpack/observations/show/containers/similar_container.js
@@ -1,12 +1,13 @@
 import { connect } from "react-redux";
 import ObservationsHighlight from "../components/observations_highlight";
 import { showNewObservation } from "../ducks/observation";
+import { fetchMoreFromClade } from "../ducks/other_observations";
 
 function mapStateToProps( state ) {
   return {
     title: I18n.t( "observations_of_relatives" ),
-    observations: state.otherObservations.moreFromClade.observations,
-    searchParams: state.otherObservations.moreFromClade.params,
+    observations: state.otherObservations.moreFromClade?.observations,
+    searchParams: state.otherObservations.moreFromClade?.params,
     config: state.config
   };
 }
@@ -15,6 +16,9 @@ function mapDispatchToProps( dispatch ) {
   return {
     showNewObservation: ( observation, options ) => {
       dispatch( showNewObservation( observation, options ) );
+    },
+    contentLoader: ( ) => {
+      dispatch( fetchMoreFromClade( ) );
     }
   };
 }

--- a/app/webpack/observations/show/ducks/observation.js
+++ b/app/webpack/observations/show/ducks/observation.js
@@ -10,7 +10,7 @@ import { resetControlledTerms, fetchControlledTerms } from "./controlled_terms";
 import {
   fetchMoreFromThisUser, fetchNearby, fetchMoreFromClade,
   setEarlierUserObservations, setLaterUserObservations, setNearby,
-  setMoreFromClade
+  setMoreFromClade, resetOtherObservations
 } from "./other_observations";
 import { fetchQualityMetrics, setQualityMetrics } from "./quality_metrics";
 import { fetchSubscriptions, resetSubscriptions, setSubscriptions } from "./subscriptions";
@@ -391,8 +391,8 @@ export function resetStates( ) {
     dispatch( setQualityMetrics( [] ) );
     dispatch( setEarlierUserObservations( [] ) );
     dispatch( setLaterUserObservations( [] ) );
-    dispatch( setNearby( [] ) );
-    dispatch( setMoreFromClade( [] ) );
+    dispatch( setNearby( null ) );
+    dispatch( setMoreFromClade( null ) );
     dispatch( setSubscriptions( [] ) );
   };
 }
@@ -486,7 +486,7 @@ export function renderObservation( observation, options = { } ) {
     dispatch( setObservation( observation ) );
     if ( taxonUpdated ) {
       dispatch( setIdentifiers( null ) );
-      dispatch( setMoreFromClade( [] ) );
+      dispatch( setMoreFromClade( null ) );
       dispatch( fetchControlledTerms( { reload: true } ) );
     }
     if ( taxonUpdated || fetchAll ) {
@@ -507,12 +507,8 @@ export function renderObservation( observation, options = { } ) {
     // delay these requests for a short while, unless the taxon has changed
     // which is a user-initiated action that should have a quick re-render time
     setTimeout( ( ) => {
-      if ( fetchAll || options.fetchOtherObservations ) {
+      if ( fetchAll ) {
         dispatch( fetchMoreFromThisUser( ) );
-        dispatch( fetchNearby( ) );
-      }
-      if ( fetchAll || options.fetchOtherObservations || taxonUpdated ) {
-        dispatch( fetchMoreFromClade( ) );
       }
       if ( ( fetchAll || taxonUpdated ) && !_.has( observation, "non_traditional_projects" ) ) {
         dispatch( fetchNewProjects( ) );

--- a/app/webpack/taxa/show/components/app.jsx
+++ b/app/webpack/taxa/show/components/app.jsx
@@ -111,30 +111,6 @@ const App = ( { taxon, showNewTaxon, config } ) => (
     <TaxonPageTabsContainer />
     <PhotoModalContainer />
     <PhotoChooserModalContainer />
-    {
-      config
-      && config.currentUser
-      && config.currentUser.roles
-      && (
-        config.currentUser.roles.indexOf( "curator" ) >= 0
-        || config.currentUser.roles.indexOf( "admin" ) >= 0
-        || config.currentUser.sites_admined.length > 0
-      )
-      && (
-        <div className="container upstacked">
-          <div className="row">
-            <div className="cols-xs-12">
-              <TestGroupToggle
-                group="apiv2"
-                joinPrompt="Test API V2? You can also use the test=apiv2 URL param"
-                joinedStatus="Joined API V2 test"
-                user={config.currentUser}
-              />
-            </div>
-          </div>
-        </div>
-      )
-    }
     <RtlTestGroupToggle config={config} />
   </div>
 );


### PR DESCRIPTION
* Data for More from {login}, Nearby observations, and Observations of relatives are lazy loaded
  * The components themselves were already being lazy loaded, but the data for them was being fetched when the observation loads. This wasn't saving us much as the rendering is fast - its the API queries that are the largest performance hit
* Queries for both nearby and relatives are improved by leaving off the `not_id` parameter, and instead fetch 1 extra result in case the loaded observation is one of the 7. This will make it so each query is not unique to the loaded observation, increasing the chance the query might get cached
* The query for nearby observations drops precision of the queried lat/lng to again make the query a little less specific to the loaded observation and might be able to be cached and reused for other nearby observations