### PR TITLE
fix: allow Turkic tag reuse

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9969,6 +9969,10 @@ en:
           attributes:
             base:
               coordinates_cannot_be_zero_zero: "coordinates cannot be 0,0"
+              # Message that might be displayed if an observation fails to
+              # save for an unknown reason, generally indicates a bug
+              cannot_be_saved_for_unknown_reason: |
+                cannot be saved for unknown reason, please take a screenshot and report to staff
             observed_on:
               cannot_be_greater_than_date_created: |
                 cannot be greater than the date the observation was added

--- a/db/migrate/20250204222646_change_collation_on_tags_name.rb
+++ b/db/migrate/20250204222646_change_collation_on_tags_name.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChangeCollationOnTagsName < ActiveRecord::Migration[6.1]
+  def up
+    # This makes LOWER() behave the same way on Turkic characters as Ruby's
+    # downcase method, which allows existing Turkic tags to be found
+    change_column :tags, :name, :string, limit: 255, collation: "und-x-icu"
+  end
+
+  def down
+    change_column :tags, :name, :string, limit: 255, collation: "default"
+  end
+end

--- a/db/migrate/20250204222646_change_collation_on_tags_name.rb
+++ b/db/migrate/20250204222646_change_collation_on_tags_name.rb
@@ -5,9 +5,17 @@ class ChangeCollationOnTagsName < ActiveRecord::Migration[6.1]
     # This makes LOWER() behave the same way on Turkic characters as Ruby's
     # downcase method, which allows existing Turkic tags to be found
     change_column :tags, :name, :string, limit: 255, collation: "und-x-icu"
+    execute <<~SQL
+      REINDEX INDEX index_tags_on_name;
+      REINDEX INDEX index_tags_on_lower_name;
+    SQL
   end
 
   def down
     change_column :tags, :name, :string, limit: 255, collation: "default"
+    execute <<~SQL
+      REINDEX INDEX index_tags_on_name;
+      REINDEX INDEX index_tags_on_lower_name;
+    SQL
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4675,7 +4675,7 @@ ALTER SEQUENCE public.taggings_id_seq OWNED BY public.taggings.id;
 
 CREATE TABLE public.tags (
     id integer NOT NULL,
-    name character varying(255),
+    name character varying(255) COLLATE pg_catalog."und-x-icu",
     taggings_count integer DEFAULT 0
 );
 
@@ -11418,6 +11418,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241218164832'),
 ('20250124155306'),
 ('20250127200519'),
-('20250130003627');
+('20250130003627'),
+('20250204222646');
 
 

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -2325,6 +2325,17 @@ describe Observation, "interpolate_coordinates" do
   end
 end
 
+describe Observation, "tags" do
+  it "should allow reuse of a Turkic tag" do
+    turkish_tag = "İç Anadolu"
+    o1 = create( :observation, tag_list: [turkish_tag] )
+    expect( o1 ).to be_persisted
+    o2 = create( :observation, tag_list: [turkish_tag] )
+    expect( o2 ).to be_persisted
+    expect( o2.tags.detect {| t | t.name == turkish_tag } ).not_to be_blank
+  end
+end
+
 def setup_test_case_taxonomy
   # Tree:
   #          sf


### PR DESCRIPTION
Took a little digging, but the underlying problem is that acts_as_taggable_on assumes tags are case-insensitive, and when it tries to find an existing tag, it does something like `where( "LOWER(name) = ?", new_tag_name.downcase )`. However, with the default Postgres collation for a VARCHAR column, `LOWER()` behaves differently for some Turkic characters than Ruby's `downcase` method, so in the case of the photo in the issue, the keyword "İç Anadolu Bölgesi" gets lowercased in different ways:

Postgres `LOWER()`: iç anadolu bölgesi
Ruby `downcase`: i̇ç anadolu bölgesi

(the first letters are slightly different)

When acts_as_taggable_on received that as a potential tag, it tried to find an existing tag, failed b/c of the different lowercasing behavior, tried to create a *new* tag, but that failed to pass the uniqueness constraint on `name`. Curiously, this error on the tag did not apply to the observation, so while the observation did not save, it also did not appear invalid and POST /observations suceeded without creating the observation.

We could probably solve this by patching acts_as_taggable_on, but this seemed like a simpler and easier-to-maintain approach, albeit with some performance impact during the migration.

Definitely curious about an overall critique, but also curious about performance impact and whether this requires rebuilding postgres indices or if that happens automatically (I think it did for me locally).

Closes WEB-576