### PR TITLE
feat: remove hidden IDs from Community Taxon modal

### DIFF
--- a/app/webpack/observations/show/components/activity_item.jsx
+++ b/app/webpack/observations/show/components/activity_item.jsx
@@ -18,6 +18,7 @@ import util from "../util";
 import { urlForTaxon } from "../../../taxa/shared/util";
 import TextEditor from "../../../shared/components/text_editor";
 import HiddenContentMessageContainer from "../../../shared/containers/hidden_content_message_container";
+import HiddenActivityItem from "./hidden_activity_item";
 
 class ActivityItem extends React.Component {
   constructor( props ) {
@@ -161,38 +162,14 @@ class ActivityItem extends React.Component {
     let className = "comment";
     if ( item.hidden && ( !canSeeHidden || !config.showHidden ) ) {
       return (
-        <div className="ActivityItem">
-          { hideUserIcon ? null : (
-            <div className="icon">
-              <UserImage user={viewerIsActor ? item.user : null} />
-            </div>
-          ) }
-          <Panel className="moderator-hidden">
-            <Panel.Heading>
-              <Panel.Title>
-                <span className="title_text text-muted">
-                  <i>
-                    <HiddenContentMessageContainer
-                      key={`hidden-tooltip-${item.uuid}`}
-                      item={item}
-                      itemType={this.isID ? "identifications" : "comments"}
-                    />
-                  </i>
-                </span>
-                {canSeeHidden && (
-                  <button
-                    href="#"
-                    type="button"
-                    className="btn btn-default btn-xs"
-                    onClick={() => showHidden()}
-                  >
-                    {I18n.t( "show_hidden_content" )}
-                  </button>
-                )}
-              </Panel.Title>
-            </Panel.Heading>
-          </Panel>
-        </div>
+        <HiddenActivityItem
+          canSeeHidden={canSeeHidden}
+          hideUserIcon={hideUserIcon}
+          isID={this.isID}
+          item={item}
+          showHidden={showHidden}
+          viewerIsActor={viewerIsActor}
+        />
       );
     }
     const userLink = (
@@ -473,6 +450,7 @@ class ActivityItem extends React.Component {
     }
     const byClass = viewerIsActor ? "by-current-user" : "by-someone-else";
     let footer;
+
     if ( item.disagreement && !hideDisagreement ) {
       const previousTaxonLink = (
         <SplitTaxon
@@ -596,33 +574,33 @@ class ActivityItem extends React.Component {
 }
 
 ActivityItem.propTypes = {
-  inlineEditing: PropTypes.bool,
-  item: PropTypes.object,
-  config: PropTypes.object,
-  currentUserID: PropTypes.object,
-  observation: PropTypes.object,
   addID: PropTypes.func,
+  config: PropTypes.object,
+  confirmDeleteID: PropTypes.func,
+  currentUserID: PropTypes.object,
   deleteComment: PropTypes.func,
   editComment: PropTypes.func,
-  confirmDeleteID: PropTypes.func,
-  withdrawID: PropTypes.func,
   editID: PropTypes.func,
+  hideAgree: PropTypes.bool,
+  hideCategory: PropTypes.bool,
+  hideCompare: PropTypes.bool,
+  hideContent: PropTypes.func,
+  hideDisagreement: PropTypes.bool,
+  hideMenu: PropTypes.bool,
+  hideUserIcon: PropTypes.bool,
+  inlineEditing: PropTypes.bool,
+  item: PropTypes.object,
+  linkTarget: PropTypes.string,
+  noTaxonLink: PropTypes.bool,
+  observation: PropTypes.object,
+  onClickCompare: PropTypes.func,
   restoreID: PropTypes.func,
   setFlaggingModalState: PropTypes.func,
-  linkTarget: PropTypes.string,
-  hideUserIcon: PropTypes.bool,
-  hideAgree: PropTypes.bool,
-  hideCompare: PropTypes.bool,
-  hideDisagreement: PropTypes.bool,
-  hideCategory: PropTypes.bool,
-  hideMenu: PropTypes.bool,
-  noTaxonLink: PropTypes.bool,
-  onClickCompare: PropTypes.func,
-  trustUser: PropTypes.func,
-  untrustUser: PropTypes.func,
   showHidden: PropTypes.func,
-  hideContent: PropTypes.func,
-  unhideContent: PropTypes.func
+  trustUser: PropTypes.func,
+  unhideContent: PropTypes.func,
+  untrustUser: PropTypes.func,
+  withdrawID: PropTypes.func
 };
 
 export default ActivityItem;

--- a/app/webpack/observations/show/components/activity_item.jsx
+++ b/app/webpack/observations/show/components/activity_item.jsx
@@ -239,8 +239,12 @@ class ActivityItem extends React.Component {
               className="btn btn-default btn-sm"
               onClick={e => {
                 if ( onClickCompare ) {
-                  return onClickCompare( e, taxon, observation,
-                    { currentUser: config.currentUser } );
+                  return onClickCompare(
+                    e,
+                    taxon,
+                    observation,
+                    { currentUser: config.currentUser }
+                  );
                 }
                 return true;
               }}

--- a/app/webpack/observations/show/components/community_id_modal.jsx
+++ b/app/webpack/observations/show/components/community_id_modal.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import { Modal, Button } from "react-bootstrap";
 import SplitTaxon from "../../../shared/components/split_taxon";
 /* global LIFE_TAXON */
-/* global SITE */
 
 class CommunityIDModal extends Component {
   constructor( props, context ) {
@@ -84,7 +83,7 @@ class CommunityIDModal extends Component {
           <td className="score">
             { usages }
             { " / " }
-            { "(" }
+            (
             { usages }
             +
             { disag }
@@ -92,7 +91,7 @@ class CommunityIDModal extends Component {
             { ancDisag }
             =
             { denom }
-            { ")" }
+            )
             { " = " }
             { score }
           </td>
@@ -132,21 +131,37 @@ class CommunityIDModal extends Component {
         this.idTaxonCounts[i.taxon.id] += 1;
         const allAncestors = _.clone( i.taxon.ancestorTaxa || [] );
         allAncestors.push( i.taxon );
-        if ( i.disagreement && i.previous_observation_taxon && _.intersection( i.previous_observation_taxon.ancestor_ids, [i.taxon.id] ).length > 0 ) {
+        if (
+          i.disagreement
+          && i.previous_observation_taxon
+          && _.intersection( i.previous_observation_taxon.ancestor_ids, [i.taxon.id] ).length > 0
+        ) {
           const taxonIDsDisagreedWith = _.difference(
             i.previous_observation_taxon.ancestor_ids,
             ( i.taxon.ancestor_ids || [] ).concat( [i.taxon.id] )
           );
           _.each( taxa, t => {
-            if ( _.intersection( ( t.ancestor_ids || [] ).concat( [t.id] ), taxonIDsDisagreedWith ).length > 0 ) {  
+            if (
+              _.intersection(
+                ( t.ancestor_ids || [] ).concat( [t.id] ),
+                taxonIDsDisagreedWith
+              ).length > 0
+            ) {
               this.ancestorDisagreements[t.id] = this.ancestorDisagreements[t.id] || 0;
               this.ancestorDisagreements[t.id] += 1;
             }
           } );
         } else if ( i.disagreement == null ) {
           _.each( taxa, t => {
-            const first_ident_of_taxon = _.filter( _.sortBy( observation.identifications, oi => oi.id ), oi => ( oi.taxon.id == t.id ) )[0];
-            if ( first_ident_of_taxon && i.id > first_ident_of_taxon.id && _.intersection( _.difference( t.ancestor_ids, [t.id] ), [i.taxon.id] ).length > 0 ) {
+            const firstIdentOfTaxon = _.filter(
+              _.sortBy( observation.identifications, oi => oi.id ),
+              oi => ( oi.taxon.id === t.id )
+            )[0];
+            if (
+              firstIdentOfTaxon
+              && i.id > firstIdentOfTaxon.id
+              && _.intersection( _.difference( t.ancestor_ids, [t.id] ), [i.taxon.id] ).length > 0
+            ) {
               this.ancestorDisagreements[t.id] = this.ancestorDisagreements[t.id] || 0;
               this.ancestorDisagreements[t.id] += 1;
             }

--- a/app/webpack/observations/show/components/community_id_modal.jsx
+++ b/app/webpack/observations/show/components/community_id_modal.jsx
@@ -13,12 +13,19 @@ class CommunityIDModal extends Component {
     this.state = { hoverTaxon: null };
   }
 
+  getUsableIdentifications( ) {
+    const { observation } = this.props;
+    if ( !observation ) return [];
+    return observation.identifications.filter( i => !i.hidden );
+  }
+
   close( ) {
     this.props.setCommunityIDModalState( { show: false } );
   }
 
   renderTaxonomy( currentTaxon, depth = 0 ) {
     const { observation, config } = this.props;
+    const usableIdentifications = this.getUsableIdentifications( );
     const { hoverTaxon } = this.state;
     let rows = [];
     const isLife = !currentTaxon;
@@ -36,7 +43,7 @@ class CommunityIDModal extends Component {
         this.idTaxonAncestorCounts[taxon.id] || 0 );
       const disag = ( taxon.id === LIFE_TAXON.id )
         ? 0
-        : _.filter( observation.identifications, i => (
+        : _.filter( usableIdentifications, i => (
           i.current && i.taxon.id !== taxon.id
           && !_.includes( i.taxon.ancestor_ids, taxon.id )
           && !_.includes( taxon.ancestor_ids, i.taxon.id )
@@ -108,9 +115,10 @@ class CommunityIDModal extends Component {
   render( ) {
     const { observation, show } = this.props;
     if ( !observation ) { return ( <div /> ); }
+    const usableIdentifications = this.getUsableIdentifications( );
     let algorithmSummary;
     const taxa = {};
-    _.each( observation.identifications, i => {
+    _.each( usableIdentifications, i => {
       taxa[i.taxon.id] = taxa[i.taxon.id] || i.taxon;
       _.each( i.taxon.ancestors, a => {
         taxa[a.id] = taxa[a.id] || a;
@@ -124,7 +132,7 @@ class CommunityIDModal extends Component {
       this.idTaxonAncestorCounts = { };
       this.ancestorDisagreements = { };
       const ancestorsUsed = { };
-      _.each( observation.identifications, i => {
+      _.each( usableIdentifications, i => {
         if ( !i.current || !i.taxon || !i.taxon.is_active ) { return; }
         this.currentIDs.push( i );
         this.idTaxonCounts[i.taxon.id] = this.idTaxonCounts[i.taxon.id] || 0;
@@ -154,7 +162,7 @@ class CommunityIDModal extends Component {
         } else if ( i.disagreement == null ) {
           _.each( taxa, t => {
             const firstIdentOfTaxon = _.filter(
-              _.sortBy( observation.identifications, oi => oi.id ),
+              _.sortBy( usableIdentifications, oi => oi.id ),
               oi => ( oi.taxon.id === t.id )
             )[0];
             if (

--- a/app/webpack/observations/show/components/hidden_activity_item.jsx
+++ b/app/webpack/observations/show/components/hidden_activity_item.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Panel } from "react-bootstrap";
+
+import HiddenContentMessageContainer from "../../../shared/containers/hidden_content_message_container";
+import UserImage from "../../../shared/components/user_image";
+
+const HiddenActivityItem = ( {
+  canSeeHidden,
+  hideUserIcon,
+  isID,
+  item,
+  showHidden,
+  viewerIsActor
+} ) => (
+  <div className="ActivityItem">
+    { hideUserIcon ? null : (
+      <div className="icon">
+        <UserImage user={viewerIsActor ? item.user : null} />
+      </div>
+    ) }
+    <Panel className="moderator-hidden">
+      <Panel.Heading>
+        <Panel.Title>
+          <span className="title_text text-muted">
+            <i>
+              <HiddenContentMessageContainer
+                key={`hidden-tooltip-${item.uuid}`}
+                item={item}
+                itemType={isID ? "identifications" : "comments"}
+              />
+            </i>
+          </span>
+          {canSeeHidden && (
+            <button
+              href="#"
+              type="button"
+              className="btn btn-default btn-xs"
+              onClick={() => showHidden()}
+            >
+              {I18n.t( "show_hidden_content" )}
+            </button>
+          )}
+        </Panel.Title>
+      </Panel.Heading>
+    </Panel>
+  </div>
+);
+
+HiddenActivityItem.propTypes = {
+  canSeeHidden: PropTypes.bool,
+  hideUserIcon: PropTypes.bool,
+  isID: PropTypes.bool,
+  item: PropTypes.object,
+  showHidden: PropTypes.func,
+  viewerIsActor: PropTypes.bool
+};
+
+export default HiddenActivityItem;


### PR DESCRIPTION
* remove hidden IDs from Community Taxon modal
* try to remove taxon from a hidden ID in disagreement notices for other
  identifications (specifically, it hides the taxon disagreed with if that
  taxon or its ancestors are associated with a hidden identification AND they
  are *not* associated with a taxon or its ancestors from non-hidden
  identification)

Closes WEB-547