### PR TITLE
Some umbrella projects can sync project rules to subprojects

### DIFF
--- a/app/assets/stylesheets/projects/new2.scss
+++ b/app/assets/stylesheets/projects/new2.scss
@@ -175,6 +175,13 @@ body>div>.popover[role="tooltip"].popover-error {
       }
     }
   }
+  div.disabled {
+    opacity: 0.4;
+    cursor: not-allowed !important;
+    * {
+      pointer-events: none;
+    }
+  }
   .row {
     padding-bottom: 43px;
     &.text, &.separator-row {

--- a/app/es_indices/place_index.rb
+++ b/app/es_indices/place_index.rb
@@ -58,7 +58,8 @@ class Place < ApplicationRecord
 
   def as_indexed_json(options={})
     preload_for_elastic_index
-    universal_search_rank = if obs_result = INatAPIService.observations( per_page: 0, verifiable: true, place_id: id )
+    obs_result = Rails.env.test? ? nil : INatAPIService.observations( per_page: 0, verifiable: true, place_id: id )
+    universal_search_rank = if obs_result
       if admin_level.nil?
         obs_result.total_results / 2
       else

--- a/app/es_indices/project_index.rb
+++ b/app/es_indices/project_index.rb
@@ -83,6 +83,10 @@ class Project < ApplicationRecord
         indexes :operand_type, type: "keyword"
       end
       indexes :project_type, type: "keyword"
+      indexes :delegated_project_id, type: "integer" do
+        indexes :keyword, type: "keyword"
+      end
+      indexes :is_delegated_umbrella, type: "boolean"
       indexes :rule_place_ids, type: "integer"
       indexes :rule_preferences, type: :nested do
         indexes :field, type: "keyword"
@@ -158,7 +162,7 @@ class Project < ApplicationRecord
     # This will effect search rankings, so first we try to get a count of obs by
     # people who have joined the project. Otherwise you could get a high-ranking
     # project just by using an expansive set of obs requirements.
-    obs_count = begin
+    obs_count = Rails.env.test? ? 0 : begin
       r = INatAPIService.observations(
         project_id: id,
         user_id: project_user_ids.join( "," ),
@@ -191,6 +195,8 @@ class Project < ApplicationRecord
       slug: slug,
       slug_keyword: slug,
       project_type: project_type,
+      delegated_project_id: preferred_delegated_project_id,
+      is_delegated_umbrella: prefers_delegation,
       banner_color: preferred_banner_color,
       ancestor_place_ids: place ? place.ancestor_place_ids : nil,
       place_ids: place ? place.self_and_ancestor_ids : nil,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,6 @@
-class Project < ApplicationRecord
+# frozen_string_literal: true
 
+class Project < ApplicationRecord
   acts_as_elastic_model
   include HasJournal
 
@@ -15,13 +16,14 @@ class Project < ApplicationRecord
   has_many :taxa, through: :listed_taxa
   has_many :project_assets, dependent: :delete_all
   has_one :custom_project, dependent: :delete
-  has_many :project_observation_fields, -> { order("position") }, dependent: :destroy, inverse_of: :project
+  has_many :project_observation_fields, -> { order( "position" ) },
+    dependent: :destroy, inverse_of: :project
   has_many :observation_fields, through: :project_observation_fields
   has_many :posts, as: :parent, dependent: :destroy
   has_many :assessments, dependent: :destroy
   has_many :site_featured_projects, dependent: :destroy
   has_many :project_observation_rules_as_operand, class_name: "ProjectObservationRule", as: :operand
-  
+
   before_save :strip_title
   before_save :reset_last_aggregated_at
   before_save :remove_times_from_non_bioblitzes
@@ -31,6 +33,7 @@ class Project < ApplicationRecord
   after_save :notify_trusting_members_about_changes_if_rules_changed
   before_update :set_updated_at_if_preferences_changed
   around_save :add_admins
+  after_save :sync_delegated_projects
 
   after_destroy :destroy_project_rules
 
@@ -57,15 +60,15 @@ class Project < ApplicationRecord
     "render_spam_notice", "set_spam_flash_error", "browse",
     "set_akismet_params_on_record", "change_role", "logged_in?", "set_locale",
     "ping"
-  ]
+  ].freeze
 
   requires_privilege :organizer, on: :create,
-    if: Proc.new {|project|
+    if: Proc.new {| project |
       !project.is_new_project? && !project.user.is_curator? && !project.user.is_admin?
     }
 
   extend FriendlyId
-  friendly_id :title, use: [ :slugged, :history, :finders ],
+  friendly_id :title, use: [:slugged, :history, :finders],
     reserved_words: PROJECTS_CONTROLLER_ACTION_METHODS
 
   def normalize_friendly_id( string )
@@ -74,17 +77,16 @@ class Project < ApplicationRecord
     candidate = super_candidate if candidate.blank? || candidate == super_candidate
     if candidate =~ /^\d+$/
       candidate = string.gsub( /[^\p{Word}0-9\-_]+/, "-" ).downcase
-    
       if candidate =~ /^\d+$/
         candidate = ["project", id, candidate].compact.join( "-" )
       end
     end
     candidate
   end
-  
+
   preference :count_from_list, :boolean, default: false
   preference :place_boundary_visible, :boolean, default: false
-  preference :count_by, :string, default: 'species'
+  preference :count_by, :string, default: "species"
   preference :display_checklist, :boolean, default: false
   preference :range_by_date, :boolean, default: false
   preference :aggregation, :boolean, default: false
@@ -104,21 +106,23 @@ class Project < ApplicationRecord
   preference :rule_native, :boolean
   preference :rule_introduced, :boolean
   preference :rule_members_only, :boolean
+  preference :delegation, :boolean, default: false
+  preference :delegated_project_id, :integer
   RULE_PREFERENCES = [
     "rule_quality_grade", "rule_photos", "rule_sounds",
     "rule_observed_on", "rule_d1", "rule_d2", "rule_month",
     "rule_term_id", "rule_term_value_id", "rule_native",
     "rule_introduced", "rule_members_only"
-  ]
-  
-  SUBMISSION_BY_ANYONE = 'any'
-  SUBMISSION_BY_CURATORS = 'curators'
-  SUBMISSION_MODELS = [SUBMISSION_BY_ANYONE, SUBMISSION_BY_CURATORS]
+  ].freeze
+
+  SUBMISSION_BY_ANYONE = "any"
+  SUBMISSION_BY_CURATORS = "curators"
+  SUBMISSION_MODELS = [SUBMISSION_BY_ANYONE, SUBMISSION_BY_CURATORS].freeze
   preference :submission_model, :string, default: SUBMISSION_BY_ANYONE
 
-  MEMBERSHIP_OPEN = 'open'
-  MEMBERSHIP_INVITE_ONLY = 'inviteonly'
-  MEMBERSHIP_MODELS = [MEMBERSHIP_OPEN, MEMBERSHIP_INVITE_ONLY]
+  MEMBERSHIP_OPEN = "open"
+  MEMBERSHIP_INVITE_ONLY = "inviteonly"
+  MEMBERSHIP_MODELS = [MEMBERSHIP_OPEN, MEMBERSHIP_INVITE_ONLY].freeze
   preference :membership_model, :string, default: MEMBERSHIP_OPEN
 
   preference :user_trust, :boolean, default: false
@@ -263,7 +267,7 @@ class Project < ApplicationRecord
   end
 
   def is_new_project?
-    project_type === "umbrella" || project_type === "collection"
+    project_type == "umbrella" || project_type == "collection"
   end
 
   def preferred_start_date_or_time
@@ -1136,15 +1140,112 @@ class Project < ApplicationRecord
   end
 
   def aggregation_preference_allowed?
-    return if is_new_project?
+    return false if is_new_project?
     return true unless prefers_aggregation?
     return true if aggregation_allowed?
-    errors.add(:base, I18n.t(:project_aggregator_filter_error))
+
+    errors.add( :base, I18n.t( :project_aggregator_filter_error ) )
     true
   end
 
   def within_umbrella_ids
-    return project_observation_rules_as_operand.map( &:ruler_id )
+    project_observation_rules_as_operand.map( &:ruler_id )
+  end
+
+  def sync_delegated_projects
+    return unless project_type == "umbrella"
+    return unless prefers_delegation
+
+    subproject_ids = []
+    project_observation_rules.each do | rule |
+      subproject_ids << rule.operand_id if rule.operator == "in_project?"
+    end
+    subprojects = Project.where( id: subproject_ids.compact.uniq ).includes(
+      :project_observation_rules, :stored_preferences
+    ).select do | subproject |
+      subproject.preferred_delegated_project_id == id
+    end
+
+    Project.preload_associations( self, :stored_preferences )
+    allowed_taxon_ids = project_observation_rules.
+      where( operator: "in_taxon?" ).map( &:operand_id )
+    disallowed_taxon_ids = project_observation_rules.
+      where( operator: "not_in_taxon?" ).map( &:operand_id )
+    subprojects.each do | subproject |
+      subproject.skip_indexing = true
+
+      # sync rule-based preferences
+      rule_preference_updates = {}
+      RULE_PREFERENCES.each do | rule |
+        umbrella_rule_value = send( "prefers_#{rule}" )
+        next if subproject.send( "prefers_#{rule}" ) == umbrella_rule_value
+
+        rule_preference_updates["prefers_#{rule}"] = umbrella_rule_value
+      end
+      unless rule_preference_updates.empty?
+        subproject.update( rule_preference_updates )
+      end
+
+      # sync ProjectObservationRules. Subproject inherit in_taxon? and not_in_taxon? rules,
+      # and all other non-place rules are removed as they are not allowed when collections
+      # delegate rule handling to an umbrella
+      subproject_allowed_taxon_ids = []
+      subproject_disallowed_taxon_ids = []
+      subproject.project_observation_rules.each do | rule |
+        if rule.operator == "in_taxon?"
+          subproject_allowed_taxon_ids << rule.operand_id
+        elsif rule.operator == "not_in_taxon?"
+          subproject_disallowed_taxon_ids << rule.operand_id
+        elsif rule.operator != "observed_in_place?" && rule.operator != "not_observed_in_place?"
+          # any existing non-taxon, non-place rules are destroyed
+          rule.destroy
+        end
+      end
+
+      # destroy in_taxon? rules not applied to the umbrella
+      allowed_taxa_unique_to_subproject = ( subproject_allowed_taxon_ids - allowed_taxon_ids )
+      if allowed_taxa_unique_to_subproject.any?
+        subproject.project_observation_rules.where(
+          operator: "in_taxon?", operand_id: allowed_taxa_unique_to_subproject
+        ).destroy_all
+      end
+
+      # destroy not_in_taxon? rules not applied to the umbrella
+      disallowed_taxa_unique_to_subproject = ( subproject_disallowed_taxon_ids - disallowed_taxon_ids )
+      if disallowed_taxa_unique_to_subproject.any?
+        subproject.project_observation_rules.where(
+          operator: "not_in_taxon?", operand_id: disallowed_taxa_unique_to_subproject
+        ).destroy_all
+      end
+
+      # create in_taxon? rules not applied to the subproject
+      allowed_taxa_unique_to_umbrella = ( allowed_taxon_ids - subproject_allowed_taxon_ids )
+      allowed_taxa_unique_to_umbrella.each do | taxon_id |
+        ProjectObservationRule.create(
+          ruler: subproject,
+          operator: "in_taxon?",
+          operand_type: "Taxon",
+          operand_id: taxon_id
+        )
+      end
+
+      # create not_in_taxon? rules not applied to the subproject
+      disallowed_taxa_unique_to_umbrella = ( disallowed_taxon_ids - subproject_disallowed_taxon_ids )
+      disallowed_taxa_unique_to_umbrella.each do | taxon_id |
+        ProjectObservationRule.create(
+          ruler: subproject,
+          operator: "not_in_taxon?",
+          operand_type: "Taxon",
+          operand_id: taxon_id
+        )
+      end
+    end
+    # delay the indexing of subprojects as there may be many of them, and indexing projects requires
+    # API querues. Use a high priority so the indexing is done as soon as possible
+    Project.delay(
+      priority: USER_PRIORITY,
+      unique_hash: { "Project::elastic_index": subprojects.map( &:id ) }
+    ).elastic_index!( ids: subprojects.map( &:id ) )
   end
 
   def notify_trusting_members_about_changes_unique_hash

--- a/app/webpack/projects/form/components/project_form.jsx
+++ b/app/webpack/projects/form/components/project_form.jsx
@@ -39,12 +39,16 @@ class ProjectForm extends React.Component {
     const coordinatesAccessible = project.prefers_user_trust
       && project.observation_requirements_updated_at
       && moment( project.observation_requirements_updated_at ) < moment( ).subtract( 1, "week" );
+    const isDelegatedUmbrella = project.is_delegated_umbrella;
     return (
       <div className="Form">
         <SharedForm {...this.props} />
         { project.project_type === "umbrella"
           ? <UmbrellaForm {...this.props} />
           : <RegularForm {...this.props} /> }
+        { project.project_type === "umbrella" && project.is_delegated_umbrella && (
+          <RegularForm {...this.props} />
+        )}
         <Grid>
           <Row>
             <Col xs={12}>
@@ -61,7 +65,7 @@ class ProjectForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col xs={12}>
+            <Col xs={12} className={`members-only${isDelegatedUmbrella ? " disabled" : ""}`}>
               <h2>{ I18n.t( "members" ) }</h2>
               <label className="section-label">
                 { I18n.t( "trust" ) }

--- a/app/webpack/projects/form/components/project_form.jsx
+++ b/app/webpack/projects/form/components/project_form.jsx
@@ -39,7 +39,6 @@ class ProjectForm extends React.Component {
     const coordinatesAccessible = project.prefers_user_trust
       && project.observation_requirements_updated_at
       && moment( project.observation_requirements_updated_at ) < moment( ).subtract( 1, "week" );
-    const usingDelegation = !!project.delegated_project_id;
     const isDelegatedUmbrella = project.is_delegated_umbrella;
     return (
       <div className="Form">
@@ -66,7 +65,7 @@ class ProjectForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col xs={12} className={`members-only${isDelegatedUmbrella || usingDelegation ? " disabled" : ""}`}>
+            <Col xs={12} className={`members-only${isDelegatedUmbrella ? " disabled" : ""}`}>
               <h2>{ I18n.t( "members" ) }</h2>
               <label className="section-label">
                 { I18n.t( "trust" ) }

--- a/app/webpack/projects/form/components/project_form.jsx
+++ b/app/webpack/projects/form/components/project_form.jsx
@@ -39,6 +39,7 @@ class ProjectForm extends React.Component {
     const coordinatesAccessible = project.prefers_user_trust
       && project.observation_requirements_updated_at
       && moment( project.observation_requirements_updated_at ) < moment( ).subtract( 1, "week" );
+    const usingDelegation = !!project.delegated_project_id;
     const isDelegatedUmbrella = project.is_delegated_umbrella;
     return (
       <div className="Form">
@@ -65,7 +66,7 @@ class ProjectForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col xs={12} className={`members-only${isDelegatedUmbrella ? " disabled" : ""}`}>
+            <Col xs={12} className={`members-only${isDelegatedUmbrella || usingDelegation ? " disabled" : ""}`}>
               <h2>{ I18n.t( "members" ) }</h2>
               <label className="section-label">
                 { I18n.t( "trust" ) }

--- a/app/webpack/projects/form/components/regular_form.jsx
+++ b/app/webpack/projects/form/components/regular_form.jsx
@@ -42,12 +42,16 @@ class RegularForm extends React.Component {
     }
     const chosenTerm = project.rule_term_id
       ? allControlledTerms.find( t => t.id === _.toInteger( project.rule_term_id ) ) : null;
+    const usingDelegation = !!project.delegated_project_id;
+    const isDelegatedUmbrella = project.is_delegated_umbrella;
     return (
       <div id="RegularForm" className="Form">
         <Grid>
           <Row className="text">
             <Col xs={12}>
-              <h2>{ I18n.t( "observation_requirements" ) }</h2>
+              {!isDelegatedUmbrella && (
+                <h2>{ I18n.t( "observation_requirements" ) }</h2>
+              ) }
               <div className="help-text">
                 <p>
                   { I18n.t( "views.projects.new.specify_project_filters" ) }
@@ -63,13 +67,13 @@ class RegularForm extends React.Component {
           <Row>
             <Col xs={12} className="autocompletes">
               <Row>
-                <Col xs={4}>
+                <Col xs={4} className={usingDelegation ? "disabled" : null}>
                   <TaxonSelector {...this.props} />
                 </Col>
-                <Col xs={4}>
+                <Col xs={4} className={isDelegatedUmbrella ? "disabled" : null}>
                   <PlaceSelector {...this.props} />
                 </Col>
-                <Col xs={4}>
+                <Col xs={4} className={usingDelegation || isDelegatedUmbrella ? "disabled" : null}>
                   <UserSelector {...this.props} />
                 </Col>
               </Row>
@@ -94,13 +98,13 @@ class RegularForm extends React.Component {
               >
                 <Panel.Collapse>
                   <Row>
-                    <Col xs={4}>
+                    <Col xs={4} className={usingDelegation ? "disabled" : null}>
                       <TaxonSelector {...this.props} inverse />
                     </Col>
-                    <Col xs={4}>
+                    <Col xs={4} className={isDelegatedUmbrella ? "disabled" : null}>
                       <PlaceSelector {...this.props} inverse />
                     </Col>
-                    <Col xs={4}>
+                    <Col xs={4} className={usingDelegation || isDelegatedUmbrella ? "disabled" : null}>
                       <UserSelector {...this.props} inverse />
                     </Col>
                   </Row>
@@ -109,7 +113,12 @@ class RegularForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col xs={12} className="members-only">
+            <Col
+              xs={12}
+              className={
+              `members-only${usingDelegation || isDelegatedUmbrella ? " disabled" : ""}`
+              }
+            >
               <label className="sectionlabel">
                 { I18n.t( "project_members_only" ) }
               </label>
@@ -130,7 +139,12 @@ class RegularForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col xs={12}>
+            <Col
+              xs={12}
+              className={
+                `members-only${usingDelegation || isDelegatedUmbrella ? " disabled" : ""}`
+              }
+            >
               <div className="form-group annotations-form-group">
                 <label className="sectionlabel">{ I18n.t( "with_annotation" ) }</label>
                 <div className="help-text">
@@ -187,7 +201,7 @@ class RegularForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col xs={4}>
+            <Col xs={4} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <label>{ I18n.t( "data_quality" ) }</label>
               <div
                 className="help-text"
@@ -232,7 +246,7 @@ class RegularForm extends React.Component {
                 { I18n.t( "casual_" ) }
               </label>
             </Col>
-            <Col xs={4}>
+            <Col xs={4} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <label>{ I18n.t( "media_type" ) }</label>
               <div className="help-text">
                 { I18n.t( "views.projects.new.optionally_filter_media" ) }
@@ -290,7 +304,7 @@ class RegularForm extends React.Component {
                 { I18n.t( "has_photo_and_sound" ) }
               </label>
             </Col>
-            <Col xs={4}>
+            <Col xs={4} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <label>{ I18n.t( "establishment_means" ) }</label>
               <div className="help-text">
                 { I18n.t( "views.projects.new.select_native_to_include" ) }
@@ -361,7 +375,7 @@ class RegularForm extends React.Component {
             </Col>
           </Row>
           <Row className="date-row">
-            <Col xs={12}>
+            <Col xs={12} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <label>{ I18n.t( "date_observed_" ) }</label>
               <div className="help-text">
                 { I18n.t( "views.projects.new.use_this_for_a_time_limited_event" ) }
@@ -401,7 +415,7 @@ class RegularForm extends React.Component {
             </Col>
           </Row>
           <Row className="date-row">
-            <Col xs={12} className="date-range-col">
+            <Col xs={12} className="date-range-col" className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <input
                 type="radio"
                 id="project-date-type-range"
@@ -443,7 +457,7 @@ class RegularForm extends React.Component {
             </Col>
           </Row>
           <Row className="date-row">
-            <Col xs={12}>
+            <Col xs={12} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <input
                 type="radio"
                 id="project-date-type-months"

--- a/app/webpack/projects/form/form_reducer.js
+++ b/app/webpack/projects/form/form_reducer.js
@@ -5,6 +5,7 @@ import { setConfirmModalState } from "../../observations/show/ducks/confirm_moda
 
 const SET_ATTRIBUTES = "projects-form/project/SET_ATTRIBUTES";
 const UMBRELLA_SUBPROJECT_LIMIT = 500;
+const DELEGATED_UMBRELLA_SUBPROJECT_LIMIT = 1000;
 
 export default function reducer( state = { }, action ) {
   switch ( action.type ) {
@@ -170,9 +171,15 @@ export function validateSubprojects( ) {
   return ( dispatch, getState ) => {
     const { project } = getState( ).form;
     if ( !project ) { return void null; }
-    const subprojectLimit = (
-      project.initialSubprojectCount && project.initialSubprojectCount > UMBRELLA_SUBPROJECT_LIMIT
-    ) ? project.initialSubprojectCount : UMBRELLA_SUBPROJECT_LIMIT;
+    let subprojectLimit = UMBRELLA_SUBPROJECT_LIMIT;
+    if ( project.is_delegated_umbrella ) {
+      subprojectLimit = DELEGATED_UMBRELLA_SUBPROJECT_LIMIT;
+    }
+    if ( project.initialSubprojectCount
+      && project.initialSubprojectCount > subprojectLimit
+    ) {
+      subprojectLimit = project.initialSubprojectCount;
+    }
     const countActiveSubprojects = _.filter(
       project.project_observation_rules,
       rule => rule.operand_type === "Project" && !rule._destroy
@@ -422,6 +429,10 @@ export function submitProject( ) {
     _.each( project.project_observation_rules, rule => {
       if (
         ( project.project_type === "umbrella" && rule.operand_type === "Project" )
+        || (
+          project.project_type === "umbrella"
+          && project.is_delegated_umbrella
+          && rule.operand_type === "Taxon" )
         || (
           project.project_type !== "umbrella"
           && (

--- a/app/webpack/projects/shared/models/project.js
+++ b/app/webpack/projects/shared/models/project.js
@@ -190,7 +190,8 @@ const Project = class Project extends inatjs.Project {
           r => r.operand_id
         ).join( "," );
       }
-    } else {
+    }
+    if ( !this.is_umbrella || this.is_delegated_umbrella ) {
       this.previewSearchParamsObject = _.fromPairs(
         _.map( _.filter( this.rule_preferences, p => p.value !== null ), p => [p.field, p.value] )
       );

--- a/app/webpack/projects/show/components/app.jsx
+++ b/app/webpack/projects/show/components/app.jsx
@@ -28,7 +28,10 @@ const App = ( {
 } ) => {
   let view;
   let tab = config.selectedTab;
-  const showingCountdown = ( project.startDate && !project.started && tab !== "about"
+  const showingCountdown = ( project.startDate
+    && !project.started
+    && tab !== "about"
+    && !project.is_delegated_umbrella
     && !( project.recent_observations && !_.isEmpty( project.recent_observations.results ) ) );
   if ( showingCountdown ) {
     tab = "before_event";
@@ -158,7 +161,9 @@ const App = ( {
       </div>
     </div>
   );
-  const inProgress = ( project.startDate && !showingCountdown ) && !project.ended;
+  const inProgress = ( project.startDate && !showingCountdown )
+    && !project.ended
+    && !project.is_delegated_umbrella;
   const headerInProgress = inProgress ? (
     <div className="header-in-progress">
       { I18n.t( "event_in_progress" ) }

--- a/app/webpack/projects/show/ducks/project.jsx
+++ b/app/webpack/projects/show/ducks/project.jsx
@@ -514,8 +514,10 @@ export function fetchIdentificationCategories( ) {
 export function fetchOverviewData( ) {
   return async ( dispatch, getState ) => {
     const { project, config } = getState( );
-    if ( project.hasInsufficientRequirements( )
-      || ( project.startDate && !project.started && project.durationToEvent.asDays( ) > 1 ) ) {
+    if ( !project.is_delegated_umbrella && (
+      project.hasInsufficientRequirements( )
+      || ( project.startDate && !project.started && project.durationToEvent.asDays( ) > 1 )
+    ) ) {
       dispatch( fetchMembers( ) );
       dispatch( fetchPosts( ) );
       return;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10044,6 +10044,14 @@ en:
                 must be observed after %{time}
               must_be_observed_before: |
                 must be observed before %{time}
+        project_observation_rule:
+          attributes:
+            ruler_id:
+              # The ruler (instance against which rules are being applied), must
+              # be an instance of a project
+              must_be_a_project: must be a project
+              # Umbrella projects can only have project-related rules, i.e. subprojects
+              umbrella_projects_only_allow_project_rules: only allows project rules
         quality_metric:
           attributes:
             base:

--- a/spec/lib/elastic_model/indices/project_index_spec.rb
+++ b/spec/lib/elastic_model/indices/project_index_spec.rb
@@ -22,7 +22,7 @@ describe "Project Index" do
     expect( project ).to be_known_spam
     expect( project.as_indexed_json[:spam] ).to be true
   end
-  
+
   it "should index as spam if project owned by a spammer" do
     expect( project.as_indexed_json[:spam] ).to be false
     Flag.make!( flag: Flag::SPAM, flaggable: project.user )
@@ -30,6 +30,20 @@ describe "Project Index" do
     expect( project.user ).to be_known_spam
     expect( project ).to be_owned_by_spammer
     expect( project.as_indexed_json[:spam] ).to be true
+  end
+
+  it "indexes is_delegated_umbrella" do
+    umbrella = Project.make!( project_type: "umbrella" )
+    umbrella.update( prefers_delegation: true )
+    expect( umbrella.as_indexed_json[:is_delegated_umbrella] ).to be true
+  end
+
+  it "indexes delegated_project_id" do
+    umbrella = Project.make!( project_type: "umbrella" )
+    umbrella.update( prefers_delegation: true )
+    collection = Project.make!( project_type: "collection" )
+    collection.update( preferred_delegated_project_id: umbrella.id )
+    expect( collection.as_indexed_json[:delegated_project_id] ).to eq umbrella.id
   end
 
   describe "associated_place_ids" do

--- a/spec/models/project_observation_rule_spec.rb
+++ b/spec/models/project_observation_rule_spec.rb
@@ -111,4 +111,48 @@ describe ProjectObservationRule do
     end
   end
 
+  it "ruler must be a project" do
+    expect( ProjectObservationRule.make( ruler: User.make! ) ).not_to be_valid
+    expect( ProjectObservationRule.make( ruler: Project.make! ) ).to be_valid
+  end
+
+  describe "umbrella_projects_only_allow_project_rules" do
+    it "non-umbrellas allow any rules" do
+      project = Project.make!
+      expect( ProjectObservationRule.make(
+        ruler: project, operator: "in_taxon?", operand: Taxon.make!
+      ) ).to be_valid
+      expect( ProjectObservationRule.make(
+        ruler: project, operator: "not_in_taxon?", operand: Taxon.make!
+      ) ).to be_valid
+    end
+
+    it "delegated umbrellas allow any rules" do
+      umbrella = Project.make!( project_type: "umbrella" )
+      umbrella.update( prefers_delegation: true )
+      expect( ProjectObservationRule.make(
+        ruler: umbrella, operator: "in_taxon?", operand: Taxon.make!
+      ) ).to be_valid
+      expect( ProjectObservationRule.make(
+        ruler: umbrella, operator: "not_in_taxon?", operand: Taxon.make!
+      ) ).to be_valid
+    end
+
+    it "umbrellas allow project rules" do
+      umbrella = Project.make!( project_type: "umbrella" )
+      expect( ProjectObservationRule.make(
+        ruler: umbrella, operator: "in_project?", operand: Project.make!
+      ) ).to be_valid
+    end
+
+    it "umbrellas do not allow non-project rules" do
+      umbrella = Project.make!( project_type: "umbrella" )
+      expect( ProjectObservationRule.make(
+        ruler: umbrella, operator: "in_taxon?", operand: Taxon.make!
+      ) ).not_to be_valid
+      expect( ProjectObservationRule.make(
+        ruler: umbrella, operator: "not_in_taxon?", operand: Taxon.make!
+      ) ).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
* When enabled via project preferences, collection projects can delegate observation requirement defining to an umbrella project
* When enabled, the delegated umbrella project can define rules and sync them to delegating subprojects