### PR TITLE
Remove obsolete version attribute

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,4 +1,3 @@
-version: "2"
 services:
   pg:
     container_name: pg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   redis:
     container_name: redis


### PR DESCRIPTION
On make services

```
WARN[0000] /Users/elharo/inaturalist/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /Users/elharo/inaturalist/docker-compose.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
docker compose up -d es memcached redis pg
WARN[0000] /Users/elharo/inaturalist/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /Users/elharo/inaturalist/docker-compose.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```