### PR TITLE
fix: don't ask consent for every google oauth2 signins (only at signup)

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -72,7 +72,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       # Apparently this just triggers scary permissions errors until we're a "verified" app on Google
       # :scope => "userinfo.email,userinfo.profile,plus.me,https://picasaweb.google.com/data/,https://www.googleapis.com/auth/photoslibrary.readonly",
       :scope => "userinfo.email,userinfo.profile,plus.me,https://www.googleapis.com/auth/photoslibrary.readonly",
-      :prompt => "consent",
+      :prompt => "select_account",
       :access_type => "offline"
     }
     provider :google_oauth2, CONFIG.google.client_id, CONFIG.google.secret, opts


### PR DESCRIPTION
It seems to me I often need to signin again, and each time I signin again with google, the site asks for consent to access services I already consented. It seems to me, most sites on internet doesn't behave like this and I find this signin flow annoying.

I tested with a local sinatra app with omniauth and a omniauth-google-oauth2 strategy.
I first used the same settings (`:prompt => "consent"`) , authenticated with my 1st user.
Then I re-opened, re logged in , and had the consent again.
Then, I switched to `:prompt => "select_account"`, re-opened the app, and logged in, with selecting my account like previsously, but without seeing the consent again.
I then tested with another google account, with `select_account`, the 1st login prompt for selecting account and consenting to used service, and later on, no consent again.