### PR TITLE
fix: localize GMaps using browser locale if no region in user locale

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1504,10 +1504,14 @@ module ApplicationHelper
     request.env["HTTP_ACCEPT_LANGUAGE"]&.scan( /[a-z]{2}-[A-Z]{2}/ )&.first&.downcase
   end
 
-  # Mostly for Google API regions
+  # Specifies the region parameter for the Google API
+  # Defaults to US if not set
+  # Available regions: https://developers.google.com/maps/coverage
   def cctld_from_locale( locale )
     # return "il" if locale.to_s == "he"
     if locale.nil? || locale.to_s.split( "-" ).size < 2
+      # Most user language preferences do not include a region
+      # Therefore, we attempt to infer the region from the request
       locale = locale_from_request || ""
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1500,7 +1500,7 @@ module ApplicationHelper
     }.to_query
   end
 
-  def region_from_browser
+  def locale_from_request
     request.env["HTTP_ACCEPT_LANGUAGE"]&.scan( /[a-z]{2}-[A-Z]{2}/ )&.first&.downcase
   end
 
@@ -1508,7 +1508,7 @@ module ApplicationHelper
   def cctld_from_locale( locale )
     # return "il" if locale.to_s == "he"
     if locale.nil? || locale.to_s.split( "-" ).size < 2
-      locale = region_from_browser || ""
+      locale = locale_from_request || ""
     end
 
     region = locale.to_s.split( "-" ).last

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1507,8 +1507,8 @@ module ApplicationHelper
   # Mostly for Google API regions
   def cctld_from_locale( locale )
     # return "il" if locale.to_s == "he"
-    if locale.to_s.split( "-" ).size < 2
-      locale = region_from_browser
+    if locale.nil? || locale.to_s.split( "-" ).size < 2
+      locale = region_from_browser || ""
     end
 
     region = locale.to_s.split( "-" ).last

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1500,10 +1500,16 @@ module ApplicationHelper
     }.to_query
   end
 
+  def region_from_browser
+    request.env["HTTP_ACCEPT_LANGUAGE"]&.scan( /[a-z]{2}-[A-Z]{2}/ )&.first&.downcase
+  end
+
   # Mostly for Google API regions
   def cctld_from_locale( locale )
     # return "il" if locale.to_s == "he"
-    return if locale.to_s.split( "-" ).size < 2
+    if locale.to_s.split( "-" ).size < 2
+      locale = region_from_browser
+    end
 
     region = locale.to_s.split( "-" ).last
     case region


### PR DESCRIPTION
Most language codes in `I18n.locale` do not include a region, therefore returning an empty string for `cctld_from_locale`.

This fix uses the request header `HTTP_ACCEPT_LANGUAGE` as a sane fallback for this cases.

Cheers
Hannes