### PR TITLE
feat: :sparkles: flex styling for observation results meta information

### DIFF
--- a/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
@@ -15,17 +15,27 @@
             %span{:class => "quality_grade {{ o.quality_grade }}"}
               {{ o.qualityGrade( ) }}
             %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}"}
-              %i.icon-identification
-              {{ o.identifications_count }}
+              %span.meta-item
+                %i.icon-identification
+                %span.meta-text
+                  {{ o.identifications_count }}
             %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
-              %i.icon-chatbubble
-              {{ o.comments_count }}
+              %span.meta-item
+                %i.icon-chatbubble
+                %span.meta-text
+                  {{ o.comments_count }}
             %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
-              %i.fa.fa-star
-              {{ o.faves_count }}
-            %span.pull-right{"am-time-ago" => "(!o.obscured || o.private_geojson ) && ( o.time_observed_at || o.observed_on )", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('observed_on') + ' ' + (o.time_observed_at || o.observed_on ) }}", "ng-hide": "o.obscured && !o.private_geojson"}
-            %span.pull-right{"ng-show": "o.obscured && !o.private_geojson"}
-              %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "true", short: "true", "ng-show": "o.obscured && !o.private_geojson" }
+              %span.meta-item
+                %i.fa.fa-star
+                %span.meta-text
+                  {{ o.faves_count }}
+            %span.meta-item.meta-item-right{ "ng-hide": "o.obscured && !o.private_geojson" }
+              %i.fa.fa-clock-o
+              %span.meta-text{ "am-time-ago" => "(!o.obscured || o.private_geojson ) && ( o.time_observed_at || o.observed_on )", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('observed_on') + ' ' + (o.time_observed_at || o.observed_on ) }}" }
+            %span.meta-item.meta-item-right{ "ng-show": "o.obscured && !o.private_geojson" }
+              %i.fa.fa-clock-o
+              %span.meta-text
+                %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "true", short: "true" }
     .spinner.ng-cloak{ "ng-show": "pagination.searching" }
       %span.fa.fa-spin.fa-refresh
     .noresults.text-muted.ng-cloak{ "ng-show" => "noObservations( )" }

--- a/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml
@@ -28,14 +28,20 @@
             %span{:class => "quality_grade {{ o.quality_grade }}"}
               {{ o.qualityGrade( ) }}
             %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}" }
-              %i.icon-identification
-              {{ o.identifications_count }}
+              %span.meta-item
+                %i.icon-identification
+                %span.meta-text
+                  {{ o.identifications_count }}
             %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
-              %i.icon-chatbubble
-              {{ o.comments_count }}
+              %span.meta-item
+                %i.icon-chatbubble
+                %span.meta-text
+                  {{ o.comments_count }}
             %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
-              %i.fa.fa-star
-              {{ o.faves_count }}
+              %span.meta-item
+                %i.fa.fa-star
+                %span.meta-text
+                  {{ o.faves_count }}
         %td.user
           %a.user.userimage{ href: "/people/{{ o.user.login }}", "ng-style": "shared.backgroundIf( o.user.icon_url )", title: "{{ o.user.login }}", target: "_self" }
             %i.icon-person{"ng-hide" => "o.user.icon_url"}

--- a/app/assets/stylesheets/observations.scss
+++ b/app/assets/stylesheets/observations.scss
@@ -823,3 +823,26 @@
     color: #888;
     line-height: 1.1;
 }
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+
+  .meta-item {
+    display: flex;
+    align-items: center;
+
+    i {
+      margin-right: 3px;
+    }
+
+    .meta-text {
+      white-space: nowrap;
+    }
+  }
+  
+  .meta-item-right {
+    margin-left: auto;
+  }
+}


### PR DESCRIPTION
Closes: https://github.com/inaturalist/inaturalist/issues/4165#issuecomment-2619792256
Previous idea now closed: https://github.com/inaturalist/inaturalist/pull/4220

- added flex style for meta info items
- added new icon in front of date (results_grid)
- some minor adjusments to the two date variants and their `ng-show` | `ng-hide` logic. (We could do a `ngIf-Else` and template but yeah, don't actually know what this old angular can handle safely)

## Tasks

- [x] icons should remain before counts, please don't change their order
- [x] if/when counts are large or the quality grade is wide, the counts should wrap to a new line
- [x] icons and their counts should wrap together; the icon and the count it symbolizes should never appear on different lines
- [x] add the fa-clock-o icon in front of the date to separate it from the other numbers
- [x] ensure all counts have some margin between the icon and the number, at least 3px

## Grid: obscured

![Screenshot 2025-02-14 at 13 57 35](https://github.com/user-attachments/assets/ba4a3732-632d-46af-b1e8-72714ada987d)

## Grid: english

![Screenshot 2025-02-14 at 13 50 44](https://github.com/user-attachments/assets/c3bc52ca-9cc3-4786-a9e0-33ff54c4836a)

## Grid: german with overflow

![Screenshot 2025-02-14 at 13 50 02](https://github.com/user-attachments/assets/2dd6d57c-4a54-421a-9de8-11c4314ca781)

## Table: english

![Screenshot 2025-02-14 at 13 47 51](https://github.com/user-attachments/assets/afe2abed-33cc-49c8-9dc1-02a9ff585639)

## Table: german

![Screenshot 2025-02-14 at 13 48 32](https://github.com/user-attachments/assets/2742fe37-b03a-4946-8c60-eadccfd59e2d)

## Table: wide overflow

![Screenshot 2025-02-14 at 13 49 16](https://github.com/user-attachments/assets/7b749379-ae83-4a70-933f-f3949fff0188)

