### PR TITLE
fix: separate & wrap metadata items better in Explore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ We will probably close pull requests that don't address open issues. Again, if y
 
 The development environment for iNaturalist is set up to run containerized services in Docker. Furthermore this configuration allows running the [API](https://github.com/inaturalist/iNaturalistAPI) alongside the services. 
 
-1. Install [Docker](https://www.docker.com/)
+1. Install and launch [Docker](https://www.docker.com/). Make sure your current user has access to the docker daemon with `docker run hello-world`.
 1. Copy `docker-compose.override.yml.example` to `docker-compose.override.yml` and customize credentials
 1. Run `make services` to start Elasticsearch, memcached, redis, and PostgeSQL. Run `make services-api` to include the API and run in the foreground (see note above; you'll also need to add working versions of `docker-compose.override.yml` and `config.js` to that directory to get the API to run).
 
-   **Note**: If iNaturalistAPI is not in a sibling directory to this repository specify the path as such: `make services-api API_PATH=path/to/api`.
+   **Note**: If iNaturalistAPI is not in a sibling directory to this repository, specify the path as such: `make services-api API_PATH=path/to/api`.
 
 1. Run `ruby bin/setup` to set up gems, config files, and database
 1. Start the server: `rails server -b 127.0.0.1`

--- a/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
@@ -14,28 +14,29 @@
           .meta
             %span{:class => "quality_grade {{ o.quality_grade }}"}
               {{ o.qualityGrade( ) }}
-            %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}"}
-              %span.meta-item
-                %i.icon-identification
+            %span.meta-stats
+              %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}"}
+                %span.meta-item
+                  %i.icon-identification
+                  %span.meta-text
+                    {{ o.identifications_count }}
+              %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
+                %span.meta-item
+                  %i.icon-chatbubble
+                  %span.meta-text
+                    {{ o.comments_count }}
+              %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
+                %span.meta-item
+                  %i.fa.fa-star
+                  %span.meta-text
+                    {{ o.faves_count }}
+              %span.meta-item.meta-item-right{ "ng-hide": "o.obscured && !o.private_geojson" }
+                %i.fa.fa-clock-o
+                %span.meta-text{ "am-time-ago" => "(!o.obscured || o.private_geojson ) && ( o.time_observed_at || o.observed_on )", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('observed_on') + ' ' + (o.time_observed_at || o.observed_on ) }}" }
+              %span.meta-item.meta-item-right{ "ng-show": "o.obscured && !o.private_geojson" }
+                %i.fa.fa-clock-o
                 %span.meta-text
-                  {{ o.identifications_count }}
-            %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
-              %span.meta-item
-                %i.icon-chatbubble
-                %span.meta-text
-                  {{ o.comments_count }}
-            %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
-              %span.meta-item
-                %i.fa.fa-star
-                %span.meta-text
-                  {{ o.faves_count }}
-            %span.meta-item.meta-item-right{ "ng-hide": "o.obscured && !o.private_geojson" }
-              %i.fa.fa-clock-o
-              %span.meta-text{ "am-time-ago" => "(!o.obscured || o.private_geojson ) && ( o.time_observed_at || o.observed_on )", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('observed_on') + ' ' + (o.time_observed_at || o.observed_on ) }}" }
-            %span.meta-item.meta-item-right{ "ng-show": "o.obscured && !o.private_geojson" }
-              %i.fa.fa-clock-o
-              %span.meta-text
-                %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "true", short: "true" }
+                  %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "true", short: "true" }
     .spinner.ng-cloak{ "ng-show": "pagination.searching" }
       %span.fa.fa-spin.fa-refresh
     .noresults.text-muted.ng-cloak{ "ng-show" => "noObservations( )" }

--- a/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml
@@ -27,21 +27,22 @@
           .meta
             %span{:class => "quality_grade {{ o.quality_grade }}"}
               {{ o.qualityGrade( ) }}
-            %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}" }
-              %span.meta-item
-                %i.icon-identification
-                %span.meta-text
-                  {{ o.identifications_count }}
-            %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
-              %span.meta-item
-                %i.icon-chatbubble
-                %span.meta-text
-                  {{ o.comments_count }}
-            %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
-              %span.meta-item
-                %i.fa.fa-star
-                %span.meta-text
-                  {{ o.faves_count }}
+            %span.meta-stats
+              %span.identifications{"ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}" }
+                %span.meta-item
+                  %i.icon-identification
+                  %span.meta-text
+                    {{ o.identifications_count }}
+              %span.comments{"ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}"}
+                %span.meta-item
+                  %i.icon-chatbubble
+                  %span.meta-text
+                    {{ o.comments_count }}
+              %span.favorites{"ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}"}
+                %span.meta-item
+                  %i.fa.fa-star
+                  %span.meta-text
+                    {{ o.faves_count }}
         %td.user
           %a.user.userimage{ href: "/people/{{ o.user.login }}", "ng-style": "shared.backgroundIf( o.user.icon_url )", title: "{{ o.user.login }}", target: "_self" }
             %i.icon-person{"ng-hide" => "o.user.icon_url"}

--- a/app/assets/stylesheets/observations.scss
+++ b/app/assets/stylesheets/observations.scss
@@ -827,14 +827,22 @@
 .meta {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
   gap: 5px;
+
+  .meta-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    flex-grow: 1;
+  }
 
   .meta-item {
     display: flex;
     align-items: center;
 
     i {
-      margin-right: 3px;
+      margin-inline-end: 3px;
     }
 
     .meta-text {
@@ -843,6 +851,6 @@
   }
   
   .meta-item-right {
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 }

--- a/app/assets/stylesheets/observations/search.scss
+++ b/app/assets/stylesheets/observations/search.scss
@@ -261,13 +261,30 @@ inat-taxon.split-taxon .icon {display: none;}
 .bootstrap .userimage:active {opacity: 1; color: #eee;}
 #result-grid .meta {color: #a3a3a3; font-size: 12px; overflow: hidden;}
 #result-grid .meta .comments i,
-#result-grid .meta .identifications i {font-size: 110%;}
+#result-grid .meta .identifications i,
+#result-grid .meta .favorites i {font-size: 110%;}
 #result-grid .meta .pull-right {
   position: relative;
   top: 2px;
 }
-#result-grid .favorites { margin-inline-start: 5px;}
-#result-grid .comments {margin-inline-start: 5px;}
+#result-grid .favorites {
+  margin-inline-start: 5px;
+  .meta-text {
+    position: relative;
+    top: 1px;
+  }
+}
+#result-grid .comments {
+  margin-inline-start: 5px;
+  i {
+    position: relative;
+    top: -1px;
+  }
+}
+#result-grid .meta .identifications i {
+  position: relative;
+  top: -1px;
+}
 
 .form {
   background: #fff;
@@ -881,6 +898,7 @@ inat-taxon.split-taxon .icon {display: none;}
   line-height: 16px !important;
   z-index: 1;
   margin-inline-end: 20px;
+  white-space: nowrap;
 }
 .quality_grade:after {
   content: "";
@@ -925,19 +943,27 @@ inat-taxon.split-taxon .icon {display: none;}
   border-inline-end-color: transparent;
 }
 
+#result-table table {
+  // This is a weird trick that allows table cells to set height to 100% when
+  // display: flex
+  height: 100%;
+}
 #result-table th.media {
  width: 5%;
 }
 #result-table td {
   padding: 10px;
   position: relative;
+  height: 100%;
 }
 #result-table td.taxon {
-  padding: 10px 10px 35px 10px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 #result-table {
   .meta {
-    position: absolute;
     bottom: 10px;
     .icon-chatbubble {
       position: relative;


### PR DESCRIPTION
* Add an icon before the time to avoid confusion with other numbers like ID count
* Wrap metadata when quality grade label is too wide
* Avoid layout overlaps in list view

Closes WEB-506