### PR TITLE
feat: default new 3rd party auth users into content licensing

### DIFF
--- a/app/assets/stylesheets/users/registrations.scss
+++ b/app/assets/stylesheets/users/registrations.scss
@@ -275,3 +275,7 @@
     }
   }
 }
+
+#license-fields {
+  visibility: hidden;
+}

--- a/app/controllers/provider_authorizations_controller.rb
+++ b/app/controllers/provider_authorizations_controller.rb
@@ -81,7 +81,7 @@ class ProviderAuthorizationsController < ApplicationController
       end
     else
       create_provider_authorization( auth_info )
-      return redirect_back_or_default @landing_path || home_url
+      sign_in( @provider_authorization.user )
     end
 
     if @provider_authorization&.valid? && ( scope = get_session_omniauth_scope )
@@ -93,17 +93,6 @@ class ProviderAuthorizationsController < ApplicationController
       @landing_path ||= session[:return_to]
     end
 
-    # registering via an invite link in a flickr comment. see /flickr/invite
-    if session[:invite_params]
-      invite_params = session[:invite_params]
-      session[:invite_params] = nil
-      if @provider_authorization&.valid? && @provider_authorization.created_at > 15.minutes.ago
-        flash[:notice] = "Welcome to #{@site.name}! If these options look good, " \
-          "click \"Save observation\" below and you'll be good to go!"
-        invite_params.merge!( welcome: true )
-      end
-      @landing_path = new_observation_url( invite_params )
-    end
     redirect_to @landing_path || home_url
   end
 
@@ -174,12 +163,9 @@ class ProviderAuthorizationsController < ApplicationController
       end
       @provider_authorization = user.provider_authorizations.last
       user.update( site: @site ) if @site
-      if session[:invite_params].nil?
-        flash[:allow_edit_after_auth] = true
-        @landing_path = edit_after_auth_url
-        return @provider_authorization
-      end
-      @landing_path = root_path
+      flash[:allow_edit_after_auth] = true
+      @landing_path = edit_after_auth_url
+      return @provider_authorization
     end
 
     @landing_path ||= edit_user_path( current_user )

--- a/app/controllers/provider_authorizations_controller.rb
+++ b/app/controllers/provider_authorizations_controller.rb
@@ -106,6 +106,8 @@ class ProviderAuthorizationsController < ApplicationController
   end
 
   def get_session_omniauth_scope
+    return unless request.env["omniauth.strategy"]
+
     session["omniauth_#{request.env['omniauth.strategy'].name}_scope"]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -903,7 +903,10 @@ class User < ApplicationRecord
       :name => auth_info["info"]["name"],
       :password => autogen_pw,
       :password_confirmation => autogen_pw,
-      :icon_url => icon_url
+      :icon_url => icon_url,
+      preferred_observation_license: Observation::CC_BY_NC,
+      preferred_photo_license: Observation::CC_BY_NC,
+      preferred_sound_license: Observation::CC_BY_NC
     )
     if oauth_application.try( :trusted? )
       u.oauth_application_id = oauth_application.id

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -98,6 +98,15 @@ describe ProviderOauthController do
         expect( response_json["error_description"] ).not_to be_blank
       end
 
+      it "should default to CC BY-NC licensing" do
+        expect( User.find_by_email( google_response[:email] ) ).to be_blank
+        post :assertion, format: :json, params: assertion_params
+        u = User.find_by_email( google_response[:email] )
+        expect( u.preferred_observation_license ).to eq Observation::CC_BY_NC
+        expect( u.preferred_photo_license ).to eq Observation::CC_BY_NC
+        expect( u.preferred_sound_license ).to eq Observation::CC_BY_NC
+      end
+
       describe "with a bad assertion_type" do
         let( :assertion_params ) do
           {

--- a/spec/controllers/registrations_controller_api_spec.rb
+++ b/spec/controllers/registrations_controller_api_spec.rb
@@ -87,7 +87,7 @@ describe Users::RegistrationsController, "create" do
   end
 
   it "should assign a user to a site using inat_site_id param" do
-    site1 = Site.make!( url: "http://test.host" )
+    Site.make!( url: "http://test.host" )
     site2 = Site.make!
     u = User.make
     post :create, params: { inat_site_id: site2.id, user: {
@@ -106,7 +106,7 @@ describe Users::RegistrationsController, "create" do
   end
 
   it "should give the user the locale of the site specified by inat_site_id" do
-    site1 = Site.make!( url: "http://test.host" )
+    Site.make!( url: "http://test.host" )
     site2 = Site.make!( preferred_locale: "es-MX" )
     u = User.make
     post :create, params: { inat_site_id: site2.id, user: {
@@ -168,7 +168,8 @@ describe Users::RegistrationsController, "create" do
   it "should set the oauth_application_id based on the Seek User-Agent" do
     a = OauthApplication.make!( name: "iNaturalist Android App" )
     request.env["HTTP_USER_AGENT"] =
-      "iNaturalist/1.23.4 (Build 493; Android 4.14.190-20973144-abA715WVLU2CUB5 A715WVLU2CUB5; SDK 30; a71 SM-A715W a71cs; OS Version 11)"
+      "iNaturalist/1.23.4 (Build 493; Android 4.14.190-20973144-abA715WVLU2CUB5 A715WVLU2CUB5; SDK 30; " \
+        "a71 SM-A715W a71cs; OS Version 11)"
     u = register_user_with_params
     expect( u.oauth_application_id ).to eq a.id
   end


### PR DESCRIPTION
* feat: defaults new 3rd party auth users into CC BY-NC licensing
* fix: allow users to opt-out of licensing at signup, which was apparently
  broken
* fix: sign in new 3rd party auth users immediately; previously there was a
  bug where auth would work but you wouldn't be signed in and you'd have to
  try again before it would work
* fix: restore partial signup form displayed to new 3rd party auth users after
  they first sign in, requiring an email address and consents, but also
  providing an opportunity to opt out of licensing