### PR TITLE
feat: ✨ add showTimeAgo param to inat-calendar-date directive

### DIFF
--- a/app/assets/javascripts/ang/inaturalist_angular.js
+++ b/app/assets/javascripts/ang/inaturalist_angular.js
@@ -218,7 +218,9 @@ iNatAPI.directive( "inatCalendarDate", ["shared", function ( shared ) {
       timezone: "=",
       obscured: "=",
       short: "=",
-      viewersTimezone: "="
+      viewersTimezone: "=",
+      showTimeAgo: "=",
+      title: "="
     },
     // eslint-disable-next-line no-unused-vars
     link: function ( scope, elt, attr ) {
@@ -238,12 +240,14 @@ iNatAPI.directive( "inatCalendarDate", ["shared", function ( shared ) {
         var date = moment.tz( scope.time || scope.date, timezone );
         var now = moment( new Date( ) );
         var dateString;
-        if ( date.isSame( now, "day" ) ) {
+        if ( scope.showTimeAgo && date.isAfter( moment( ).subtract( 1, "month" ) ) ) {
+          dateString = date.fromNow();
+        } else if ( date.isSame( now, "day" ) ) {
           dateString = I18n.t( "today" );
         } else if ( date.isSame( now.subtract( 1, "day" ), "day" ) ) {
           dateString = I18n.t( "yesterday" );
         } else {
-          dateString = date.format( "ll" );
+          dateString = date.format( scope.short ? I18n.t( "momentjs.month_year_short" ) : "ll" );
         }
         return dateString;
       };
@@ -251,6 +255,7 @@ iNatAPI.directive( "inatCalendarDate", ["shared", function ( shared ) {
       scope.timeString = function ( ) {
         if ( !scope.time ) return "";
         if ( scope.obscured ) return "";
+        if ( scope.short ) return "";
         var timezone = displayTimezone( scope.viewersTimezone, scope.timezone );
         var d = moment.tz( scope.time, timezone );
         // For some time zones, moment cannot output something nice like PDT and
@@ -263,6 +268,9 @@ iNatAPI.directive( "inatCalendarDate", ["shared", function ( shared ) {
       };
       // eslint-disable-next-line no-param-reassign
       scope.titleText = function ( ) {
+        if ( scope.title ) {
+          return scope.title;
+        }
         if ( !scope.time ) {
           return null;
         }
@@ -274,8 +282,10 @@ iNatAPI.directive( "inatCalendarDate", ["shared", function ( shared ) {
         return momentTime.format( );
       };
     },
-    template: "<span class=\"date\">{{ dateString() }}</span>"
-     + "<span class=\"time\" title=\"{{ titleText() }}\">{{ timeString() }}</span>"
+    template: "<div title=\"{{ titleText() }}\">"
+     + "<span class=\"date\">{{ dateString() }}</span>"
+     + "<span class=\"time\">{{ timeString() }}</span>"
+     + "</div>"
   };
 }] );
 

--- a/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml
@@ -30,13 +30,10 @@
                   %i.fa.fa-star
                   %span.meta-text
                     {{ o.faves_count }}
-              %span.meta-item.meta-item-right{ "ng-hide": "o.obscured && !o.private_geojson" }
-                %i.fa.fa-clock-o
-                %span.meta-text{ "am-time-ago" => "(!o.obscured || o.private_geojson ) && ( o.time_observed_at || o.observed_on )", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('observed_on') + ' ' + (o.time_observed_at || o.observed_on ) }}" }
-              %span.meta-item.meta-item-right{ "ng-show": "o.obscured && !o.private_geojson" }
+              %span.meta-item.meta-item-right
                 %i.fa.fa-clock-o
                 %span.meta-text
-                  %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "true", short: "true" }
+                  %inat-calendar-date{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "o.obscured && !o.private_geojson", short: "true", time: "o.time_observed_at", "show-time-ago": "true" }
     .spinner.ng-cloak{ "ng-show": "pagination.searching" }
       %span.fa.fa-spin.fa-refresh
     .noresults.text-muted.ng-cloak{ "ng-show" => "noObservations( )" }

--- a/app/assets/javascripts/ang/templates/shared/observation.html.haml
+++ b/app/assets/javascripts/ang/templates/shared/observation.html.haml
@@ -12,7 +12,7 @@
       %span.location{ title: "{{ o.displayPlace() }}" }
         .hidden-lg {{ o.displayPlace() | characters:6:true }}
         .visible-lg-inline-block {{ o.displayPlace() | characters:18:true }}
-      %inat-calendar-date.hidden-lg{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "o.obscured && !o.private_geojson", short: "true" }
+      %inat-calendar-date.hidden-lg{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "o.obscured && !o.private_geojson", short: "o.obscured && !o.private_geojson" }
       %inat-calendar-date.visible-lg-inline-block{ date: "o.observed_on_details.date", timezone: "o.observed_time_zone", obscured: "o.obscured && !o.private_geojson" }
     .meta.ng-cloak
       %span{ :class => "quality_grade {{ o.quality_grade }}" }
@@ -26,6 +26,5 @@
       %span.favorites{ "ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}" }
         %i.fa.fa-star
         {{ o.faves_count }}
-      %span.created_at.pull-right{ "am-time-ago" => "(!o.obscured || o.private_geojson ) && o.created_at", title: "{{ (!o.obscured || o.private_geojson ) && shared.t('added_on_datetime', { datetime: shared.l('datetime.formats.long', o.created_at )}) }}", "ng-hide": "o.obscured && !o.private_geojson"}
-      %span.created_at.pull-right{ "ng-show": "o.obscured && !o.private_geojson" }
-        %inat-calendar-date{ date: "o.created_at_details.date", timezone: "o.created_time_zone", obscured: "true", short: "true", "ng-show": "o.obscured && !o.private_geojson" }
+      %span.created_at.pull-right
+        %inat-calendar-date{ date: "o.created_at_details.date", timezone: "o.created_time_zone", obscured: "o.obscured && !o.private_geojson", short: "true", title: "(!o.obscured || o.private_geojson ) && shared.t('added_on_datetime', { datetime: shared.l('datetime.formats.long', o.created_at )})", "show-time-ago": "true" }


### PR DESCRIPTION
Follow-up on the discussion in: https://github.com/inaturalist/inaturalist/pull/4404

As a result of the changes I made, there are some global updates affecting all instances where the directive is used.

## Affected Components

- `/app/assets/javascripts/ang/templates/observation_search/results_grid.html.haml`
- `/app/assets/javascripts/ang/templates/observation_search/results_table.html.haml`
- `/app/assets/javascripts/ang/templates/shared/observation.html.haml`

## Global Changes

- The title is now wrapped around both `span` elements, resulting in a hover effect over the entire title.
- Previously, the `short` flag only had an effect when used with `obscured`. With my changes, it now also affects output without the `obscured` flag. In instances where this change should not occur, I applied the same logic to `short` as for `obscured` (`short: "o.obscured && !o.private_geojson"`).

## Specific Changes

- The directive now has an optional `title` parameter, which will override the title in all cases if provided. This is used for the `created_at` instances in `shared/observation.html.haml`.
- The directive now has an optional `showTimeAgo` parameter. It will display the same string as the `am-time-ago` Angular directive for up to 30 days ago. After that, it will use the default settings.

## Discussion

Do we actually need `created_at` in the `shared/observation.html.haml` template? When looking at the map grid, it seems more logical to style it the same way as the grid view. At first glance, I did not realize that the bottom value is `created_at` and not `observed_at`. In my opinion, we should remove `observed_at` after the location string and only show `observed_at` after the icons, as in the grid view, while removing the `created_at` information.

## Images

### Map Grid

![image](https://github.com/user-attachments/assets/793340cf-9960-440c-bc53-ec747ea317b4)

## View Grid

![image](https://github.com/user-attachments/assets/92f190e7-b908-4a7b-a9c9-10efaeef025e)


## Hover effect now over the whole div

![image](https://github.com/user-attachments/assets/9dacb1b0-fc91-42a2-8680-f39f4b1b33c6)
