### PR TITLE
fix: prevent unexpected nav back to Info tab on Identify

### DIFF
--- a/app/assets/stylesheets/bootstrap-inat.scss
+++ b/app/assets/stylesheets/bootstrap-inat.scss
@@ -376,7 +376,6 @@ input[type="color"]:focus,
   padding: 0;
   background-color: transparent;
   border: 0 transparent;
-  text-align: start;
   white-space: normal;
   overflow-wrap: anywhere;
   line-height: inherit;

--- a/app/assets/stylesheets/observations/identify/observation_modal.scss
+++ b/app/assets/stylesheets/observations/identify/observation_modal.scss
@@ -559,6 +559,7 @@ body > [role="dialog"] .ObservationModal {
     display: block;
     flex: 1;
     line-height: 45px;
+    text-align: center;
   }
   .inat-tabs li a:focus,
   .inat-tabs li .btn-nostyle:focus {

--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -658,6 +658,9 @@ h3, h4 {
     }
     &.collapsible {
       cursor: pointer;
+      .btn-nostyle {
+        text-align: start;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/observations/uploader.scss
+++ b/app/assets/stylesheets/observations/uploader.scss
@@ -1060,7 +1060,6 @@ label {
   padding: 0;
   background-color: transparent;
   border: 0 transparent;
-  text-align: start;
   white-space: normal;
   overflow-wrap: anywhere;
   line-height: inherit;

--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -32,17 +32,19 @@ import {
 } from "../../shared/ducks/observation";
 import { updateSession } from "../../show/ducks/users";
 
-const SHOW_CURRENT_OBSERVATION = "show_current_observation";
-const HIDE_CURRENT_OBSERVATION = "hide_current_observation";
-const FETCH_CURRENT_OBSERVATION = "fetch_current_observation";
-const RECEIVE_CURRENT_OBSERVATION = "receive_current_observation";
-const UPDATE_CURRENT_OBSERVATION = "update_current_observation";
-const SHOW_NEXT_OBSERVATION = "show_next_observation";
-const SHOW_PREV_OBSERVATION = "show_prev_observation";
-const ADD_IDENTIFICATION = "add_identification";
-const ADD_COMMENT = "add_comment";
-const LOADING_DISCUSSION_ITEM = "loading_discussion_item";
-const STOP_LOADING_DISCUSSION_ITEM = "stop_loading_discussion_item";
+import {
+  SHOW_CURRENT_OBSERVATION,
+  HIDE_CURRENT_OBSERVATION,
+  FETCH_CURRENT_OBSERVATION,
+  RECEIVE_CURRENT_OBSERVATION,
+  UPDATE_CURRENT_OBSERVATION,
+  SHOW_NEXT_OBSERVATION,
+  SHOW_PREV_OBSERVATION,
+  ADD_IDENTIFICATION,
+  ADD_COMMENT,
+  LOADING_DISCUSSION_ITEM,
+  STOP_LOADING_DISCUSSION_ITEM
+} from "./current_observation_actions_names";
 
 // order matters...
 const TABS = ["info", "suggestions", "annotations", "data-quality"];

--- a/app/webpack/observations/identify/actions/current_observation_actions_names.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions_names.js
@@ -1,0 +1,12 @@
+// Separated to remove cyclic imports
+export const SHOW_CURRENT_OBSERVATION = "show_current_observation";
+export const HIDE_CURRENT_OBSERVATION = "hide_current_observation";
+export const FETCH_CURRENT_OBSERVATION = "fetch_current_observation";
+export const RECEIVE_CURRENT_OBSERVATION = "receive_current_observation";
+export const UPDATE_CURRENT_OBSERVATION = "update_current_observation";
+export const SHOW_NEXT_OBSERVATION = "show_next_observation";
+export const SHOW_PREV_OBSERVATION = "show_prev_observation";
+export const ADD_IDENTIFICATION = "add_identification";
+export const ADD_COMMENT = "add_comment";
+export const LOADING_DISCUSSION_ITEM = "loading_discussion_item";
+export const STOP_LOADING_DISCUSSION_ITEM = "stop_loading_discussion_item";

--- a/app/webpack/observations/identify/actions/identification_actions.js
+++ b/app/webpack/observations/identify/actions/identification_actions.js
@@ -210,12 +210,12 @@ const onSubmitIdentification = ( observation, identification, options = {} ) => 
       if ( _.isNil( ident.disagreement ) ) {
         params.disagreement = disagreement || false;
       }
+      dispatch( updateCurrentObservation( { tab: "info" } ) );
       dispatch( postIdentification( params ) )
         .catch( ( ) => {
           dispatch( stopLoadingDiscussionItem( ident ) );
         } )
         .then( ( ) => {
-          dispatch( updateCurrentObservation( { tab: "info" } ) );
           dispatch( updateEditorContent( "obsIdentifyIdComment", "" ) );
           dispatch( fetchCurrentObservation( observation ) ).then( ( ) => {
             $( ".ObservationModal:first" ).find( ".sidebar" ).scrollTop( $( window ).height( ) );

--- a/app/webpack/observations/identify/actions/identification_actions.js
+++ b/app/webpack/observations/identify/actions/identification_actions.js
@@ -1,13 +1,12 @@
 import inatjs from "inaturalistjs";
 import _ from "lodash";
 import {
-  loadingDiscussionItem,
-  stopLoadingDiscussionItem,
+  addIdentification,
   fetchCurrentObservation,
   fetchObservation,
-  addIdentification,
-  updateCurrentObservation,
-  hideCurrentObservation
+  loadingDiscussionItem,
+  stopLoadingDiscussionItem,
+  updateCurrentObservation
 } from "./current_observation_actions";
 import { fetchObservationsStats } from "./observations_stats_actions";
 import { updateObservationInCollection } from "./observations_actions";
@@ -262,7 +261,6 @@ const onSubmitIdentification = ( observation, identification, options = {} ) => 
 const chooseSuggestedTaxon = ( taxon, options = { } ) => (
   ( dispatch, getState ) => {
     const s = getState( );
-    console.log( [taxon, options] );
     const { observation } = options;
     const params = {
       observation_id: s.config.testingApiV2 ? observation.uuid : observation.id,

--- a/app/webpack/observations/identify/actions/observations_actions.js
+++ b/app/webpack/observations/identify/actions/observations_actions.js
@@ -5,12 +5,14 @@ import { setConfig } from "../../../shared/ducks/config";
 import { showAlert, hideAlert } from "../../../shared/ducks/alert_modal";
 import { paramsForSearch } from "../reducers/search_params_reducer";
 
-const RECEIVE_OBSERVATIONS = "receive_observations";
-const UPDATE_OBSERVATION_IN_COLLECTION = "update_observation_in_collection";
-const UPDATE_ALL_LOCAL = "update_all_local";
-const SET_REVIEWING = "identify/observations/set-reviewing";
-const SET_PLACES_BY_ID = "identify/observations/set-places-by-id";
-const SET_LAST_REQUEST_AT = "identify/observations/set-last-request-at";
+import {
+  RECEIVE_OBSERVATIONS,
+  UPDATE_OBSERVATION_IN_COLLECTION,
+  UPDATE_ALL_LOCAL,
+  SET_REVIEWING,
+  SET_PLACES_BY_ID,
+  SET_LAST_REQUEST_AT
+} from "./observations_actions_names";
 
 const OBSERVATION_FIELDS = {
   id: true,

--- a/app/webpack/observations/identify/actions/observations_actions_names.js
+++ b/app/webpack/observations/identify/actions/observations_actions_names.js
@@ -1,0 +1,7 @@
+// Separated to remove cyclic imports
+export const RECEIVE_OBSERVATIONS = "receive_observations";
+export const UPDATE_OBSERVATION_IN_COLLECTION = "update_observation_in_collection";
+export const UPDATE_ALL_LOCAL = "update_all_local";
+export const SET_REVIEWING = "identify/observations/set-reviewing";
+export const SET_PLACES_BY_ID = "identify/observations/set-places-by-id";
+export const SET_LAST_REQUEST_AT = "identify/observations/set-last-request-at";

--- a/app/webpack/observations/identify/containers/progress_chart_container.js
+++ b/app/webpack/observations/identify/containers/progress_chart_container.js
@@ -2,7 +2,6 @@ import { connect } from "react-redux";
 import ProgressChart from "../components/progress_chart";
 import { fetchObservationsStats } from "../actions/observations_stats_actions";
 
-
 function mapStateToProps( state ) {
   const reviewed = state.observationsStats.reviewed || 0;
   const total = state.observationsStats.total || 0;

--- a/app/webpack/observations/identify/containers/quality_metrics_container.js
+++ b/app/webpack/observations/identify/containers/quality_metrics_container.js
@@ -8,9 +8,11 @@ function mapStateToProps( state ) {
   return {
     observation: state.currentObservation.observation,
     config: state.config,
-    qualityMetrics: Object.assign( { },
+    qualityMetrics: Object.assign(
+      { },
       _.groupBy( state.qualityMetrics, "metric" ),
-      _.groupBy( state.currentObservation.observation.votes, "vote_scope" ) ),
+      _.groupBy( state.currentObservation.observation.votes, "vote_scope" )
+    ),
     tableOnly: true
   };
 }

--- a/app/webpack/observations/identify/containers/search_bar_container.js
+++ b/app/webpack/observations/identify/containers/search_bar_container.js
@@ -1,5 +1,4 @@
 import { connect } from "react-redux";
-import { setConfig } from "../../../shared/ducks/config";
 import SearchBar from "../components/search_bar";
 import {
   updateSearchParams,

--- a/app/webpack/observations/identify/ducks/suggestions.js
+++ b/app/webpack/observations/identify/ducks/suggestions.js
@@ -4,7 +4,7 @@ import { updateSession } from "../../show/ducks/users";
 
 import {
   UPDATE_CURRENT_OBSERVATION
-} from "../actions/current_observation_actions";
+} from "../actions/current_observation_actions_names";
 
 /* global LIFE_TAXON */
 

--- a/app/webpack/observations/identify/reducers/search_params_reducer.js
+++ b/app/webpack/observations/identify/reducers/search_params_reducer.js
@@ -1,11 +1,11 @@
 import _ from "lodash";
+import { RECEIVE_OBSERVATIONS } from "../actions/observations_actions_names";
 import {
   UPDATE_SEARCH_PARAMS,
-  RECEIVE_OBSERVATIONS,
   UPDATE_SEARCH_PARAMS_WITHOUT_HISTORY,
   UPDATE_DEFAULT_PARAMS,
   REPLACE_SEARCH_PARAMS
-} from "../actions";
+} from "../actions/search_params_actions";
 
 const DEFAULT_PARAMS = {
   reviewed: false,

--- a/app/webpack/observations/identify/webpack-entry.js
+++ b/app/webpack/observations/identify/webpack-entry.js
@@ -135,6 +135,7 @@ observeStore( store, s => s.searchParams.params, ( ) => {
 } );
 
 render(
+  // eslint-disable-next-line react/jsx-filename-extension
   <Provider store={store}>
     <AppContainer />
   </Provider>,


### PR DESCRIPTION
Prevents an unexpected nav back to the Info tab after you've added an identification and navigated to another tab before the ident creation request completes.

Also fixes some minor Identify layout problems.

Closes WEB-614