### PR TITLE
fix: restore include / exclude ancestor button in Explore

### DIFF
--- a/app/assets/stylesheets/bootstrap-inat.scss
+++ b/app/assets/stylesheets/bootstrap-inat.scss
@@ -376,9 +376,6 @@ input[type="color"]:focus,
   padding: 0;
   background-color: transparent;
   border: 0 transparent;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  line-height: inherit;
   font-size: inherit;
 }
 

--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -660,6 +660,9 @@ h3, h4 {
       cursor: pointer;
       .btn-nostyle {
         text-align: start;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        line-height: inherit;
       }
     }
   }

--- a/app/assets/stylesheets/observations/uploader.scss
+++ b/app/assets/stylesheets/observations/uploader.scss
@@ -1060,9 +1060,6 @@ label {
   padding: 0;
   background-color: transparent;
   border: 0 transparent;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  line-height: inherit;
   font-size: inherit;
 }
 


### PR DESCRIPTION
Restrict previous changes to btn-nostyle to obs detail.