### PR TITLE
fix: zoom bug in Identify images

### DIFF
--- a/app/assets/stylesheets/observations/identify/observation_modal.scss
+++ b/app/assets/stylesheets/observations/identify/observation_modal.scss
@@ -409,9 +409,9 @@ body > [role="dialog"] .ObservationModal {
   }
   
   .image-gallery-content .easyzoom-flyout.short img {
-    width: 100%;
+    height: 100%;
   }
-
+  
   .image-gallery-content .easyzoom-flyout.narrow img {
     width: 100%;
   }

--- a/app/assets/stylesheets/observations/identify/observation_modal.scss
+++ b/app/assets/stylesheets/observations/identify/observation_modal.scss
@@ -407,7 +407,15 @@ body > [role="dialog"] .ObservationModal {
     opacity: 1;
     cursor: zoom-out;
   }
+  
+  .image-gallery-content .easyzoom-flyout.short img {
+    width: 100%;
+  }
 
+  .image-gallery-content .easyzoom-flyout.narrow img {
+    width: 100%;
+  }
+  
   .easyzoom-zoomed img {
     visibility: hidden;
   }

--- a/app/assets/stylesheets/shared/easyzoom.scss
+++ b/app/assets/stylesheets/shared/easyzoom.scss
@@ -89,6 +89,13 @@
   cursor: zoom-out;
 }
 
+.image-gallery-content .easyzoom-flyout.short img {
+  width: 100%;
+}
+
+.image-gallery-content .easyzoom-flyout.narrow img {
+  width: 100%;
+}
 .easyzoom-zoomed img {
   visibility: hidden;
 }

--- a/app/assets/stylesheets/shared/easyzoom.scss
+++ b/app/assets/stylesheets/shared/easyzoom.scss
@@ -90,7 +90,7 @@
 }
 
 .image-gallery-content .easyzoom-flyout.short img {
-  width: 100%;
+  height: 100%;
 }
 
 .image-gallery-content .easyzoom-flyout.narrow img {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4178,8 +4178,7 @@
     },
     "node_modules/EasyZoom": {
       "version": "2.4.2",
-      "resolved": "git+ssh://git@github.com/inaturalist/EasyZoom.git#bfecccceff13687b2d32cda1a70d2cac75c3d490",
-      "integrity": "sha512-nH5wC4Cba4mdLdW91WnI4tYvhsXvJfvM5rHGPUfTcLn0uR9WpV2+VyUVV9JV7/0jaYjEh0j1OIwjG+EvpigKCw=="
+      "resolved": "git+ssh://git@github.com/inaturalist/EasyZoom.git#36efbb3a6491a940d0d8af8e5b53ab90843303b4"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.816",
@@ -11914,8 +11913,7 @@
       }
     },
     "EasyZoom": {
-      "version": "git+ssh://git@github.com/inaturalist/EasyZoom.git#bfecccceff13687b2d32cda1a70d2cac75c3d490",
-      "integrity": "sha512-nH5wC4Cba4mdLdW91WnI4tYvhsXvJfvM5rHGPUfTcLn0uR9WpV2+VyUVV9JV7/0jaYjEh0j1OIwjG+EvpigKCw==",
+      "version": "git+ssh://git@github.com/inaturalist/EasyZoom.git#36efbb3a6491a940d0d8af8e5b53ab90843303b4",
       "from": "EasyZoom@github:inaturalist/EasyZoom#click-toggle"
     },
     "electron-to-chromium": {


### PR DESCRIPTION
fix #4424
I'm not a CSS master, so I hope I'm not falling into any bad practices, but this apparently fixes the bug.

I've also found another possible bug. Some images (in my case, it's the first one, but I think it doesn't depend on the order but rather on the image size) don't allow zooming when viewed on my ultrawide monitor, but they do on a smaller monitor. I'm investigating the reason why. Is this behavior familiar to you?