### PR TITLE
fix: remove notifications about comment when hidden

### DIFF
--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -38,6 +38,7 @@ class ModeratorAction < ApplicationRecord
 
   after_save :touch_resource
   after_save :notify_resource
+  after_save :delete_resource_update_actions, if: ->( moderator_action ) { moderator_action.action == HIDE }
   after_destroy :notify_resource_on_destroy
 
   def self.current_private_actions
@@ -131,6 +132,11 @@ class ModeratorAction < ApplicationRecord
     return unless resource.respond_to?( :moderated_with )
 
     resource.moderated_with( self, action: "destroyed" )
+  end
+
+  def delete_resource_update_actions
+    UpdateAction.where( resource: resource ).destroy_all
+    UpdateAction.where( notifier: resource ).destroy_all
   end
 
   def set_resource_user_id

--- a/lib/has_subscribers.rb
+++ b/lib/has_subscribers.rb
@@ -211,9 +211,19 @@ module HasSubscribers
         options[:before_notify].call( notifier )
       end
 
+      # Do not notify subscribers about comments or IDs that have been hidden
+      return if notifier&.try( :hidden? )
+
       updater_proc = Proc.new {|subscribable|
         next if subscribable.blank?
         next unless subscribable.respond_to?(:update_subscriptions)
+
+        # Do not notify subscribers about resources that have been hidden. As
+        # of this writing I don't think this ever happens, but one can
+        # imagine a situation where an entire observation or journal post
+        # needs to be hidden
+        next if subscribable&.try( :hidden? )
+
         notify_owner = if options[:include_owner].is_a?(Proc)
           options[:include_owner].call(notifier, subscribable)
         elsif options[:include_owner]

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -37,11 +37,9 @@ describe ModeratorAction do
         end
         ua = UpdateAction.where( notifier: comment ).first
         expect( ua ).not_to be_blank
-        puts "creating moderator action"
         after_delayed_job_finishes( ignore_run_at: true ) do
           create( :moderator_action, action: ModeratorAction::HIDE, resource: comment, user: admin )
         end
-        puts "finished creating moderator action"
         ua = UpdateAction.where( notifier: comment ).first
         expect( ua ).to be_blank
         disable_has_subscribers

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -22,11 +22,29 @@ describe ModeratorAction do
             resource: create( :comment ), user: admin )
         ).to be_persisted
       end
+
       it "should not be possible for a user" do
         expect(
           build( :moderator_action, action: ModeratorAction::HIDE,
             resource: create( :user ), user: admin )
         ).not_to be_valid
+      end
+
+      it "should delete update actions for a comment" do
+        enable_has_subscribers
+        comment = after_delayed_job_finishes( ignore_run_at: true ) do
+          create( :comment )
+        end
+        ua = UpdateAction.where( notifier: comment ).first
+        expect( ua ).not_to be_blank
+        puts "creating moderator action"
+        after_delayed_job_finishes( ignore_run_at: true ) do
+          create( :moderator_action, action: ModeratorAction::HIDE, resource: comment, user: admin )
+        end
+        puts "finished creating moderator action"
+        ua = UpdateAction.where( notifier: comment ).first
+        expect( ua ).to be_blank
+        disable_has_subscribers
       end
 
       shared_examples_for "hiding media" do


### PR DESCRIPTION
Creating a HIDE ModeratorAction deletes all UpdateActions where the moderated item is a resource or a notifier, and prevents the creation of new UpdateActions when the resource or the notifier is hidden.

One implication is that if the offending content is later unhidden, the people it notified on creation will not be notified. That strikes me as fine, but kind of up for debate. Another approach might be to update the existing UpdateAction and clear out its subscribers from ES, but that seemed excessively complicated.