### PR TITLE
fix: show translations for sort by options in Identify

### DIFF
--- a/app/assets/javascripts/application_bundle.js
+++ b/app/assets/javascripts/application_bundle.js
@@ -3,7 +3,7 @@
 //= require i18n/translations/en
 //= require i18n/pluralizations
 //= require i18n/inflections
-//= require i18n/default_value
+//= require i18n/default_value_pre_fallback
 //= require i18n/to_time
 //= require jquery/plugins/jquery.qtip2.min
 //= require jquery/plugins/jquery.multiselect

--- a/app/assets/javascripts/i18n/default_value_pre_fallback.js
+++ b/app/assets/javascripts/i18n/default_value_pre_fallback.js
@@ -1,7 +1,20 @@
 /* global I18n */
 
-// Override default behavior so that defaultValue gets returned even if there
-// is a fallback value (i.e. how it works in the Rails gem)
+// Add defaultValuePreFallback that gets used if there is no translation in
+// the current locale *before* looking for translations in fallback locales.
+// This might be used in situations when updating strings and the old string
+// is a reasonable alternative before the new string is translated, but we
+// don't want to show an English fallbackm, e.g.
+// ```
+// I18n.t( "new_string", { defaultValue: I18n.t( "old_string" ) } )
+// ```
+// would show the English translation of "new_string" if the current locale is
+// Spanish, because English is the fallback locale of all other locales. If
+// we really want to show "old_string" in situations where "new_string" is
+// not translated into Spanish yet, we can do
+// ```
+// I18n.t( "new_string", { defaultValuePreFallback: I18n.t( "old_string" ) } )
+// ```
 ( function ( ) {
   var originalImplementation = I18n.t;
   I18n.t = function ( key, params ) {
@@ -32,12 +45,12 @@
     }
     if (
       // Needs to be a default value to return on
-      opts.defaultValue
+      opts.defaultValuePreFallback
       // If a locale was explicitly requested, don't bother with this
       && !opts.locale
       && !translation
     ) {
-      return opts.defaultValue;
+      return opts.defaultValuePreFallback;
     }
     return originalImplementation( key, opts );
   };

--- a/app/views/stats/year.html.haml
+++ b/app/views/stats/year.html.haml
@@ -37,8 +37,8 @@
       }
     })
     window._.any = _.some; // Patch so torque won't miss underscore
-  = javascript_include_tag "https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
-  = javascript_include_tag "//unpkg.com/leaflet-gesture-handling"
+  = javascript_include_tag "//cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"
+  = javascript_include_tag "//cdn.jsdelivr.net/npm/leaflet-gesture-handling"
   / required for Altmetric badges
   = javascript_include_tag "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"
   = javascript_include_tag "torque.full.uncompressed"
@@ -46,8 +46,8 @@
   = javascript_include_tag "webpack/stats-year-webpack"
 - content_for :extracss do
   = stylesheet_link_tag "stats/year"
-  = stylesheet_link_tag "https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
-  = stylesheet_link_tag "//unpkg.com/leaflet-gesture-handling/dist/leaflet-gesture-handling.min.css"
+  = stylesheet_link_tag "//cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"
+  = stylesheet_link_tag "//cdn.jsdelivr.net/npm/leaflet-gesture-handling/dist/leaflet-gesture-handling.min.css"
 - content_for :extrahead do
   - if ( ys = @year_statistic ) && ys.year == 2019 && ys.site.blank? && ys.user.blank?
     %meta{ name: "og:image", property: "og:image", content: "https://static.inaturalist.org/misc/yir2019-shareable-v3.png" }

--- a/app/webpack/shared/components/error_boundary.jsx
+++ b/app/webpack/shared/components/error_boundary.jsx
@@ -30,7 +30,7 @@ class ErrorBoundary extends React.Component {
         return renderError( error );
       }
       return (
-        <div className="nocontent">
+        <div className="nocontent alert alert-danger">
           { I18n.t( "doh_something_went_wrong_error", { error } ) }
         </div>
       );

--- a/app/webpack/stats/year/components/app.jsx
+++ b/app/webpack/stats/year/components/app.jsx
@@ -70,7 +70,7 @@ const App = ( {
             <Col xs={12}>
               <center>
                 <a href="#sharing" className="btn btn-default btn-share btn-bordered">
-                  { I18n.t( "share_caps", { defaultValue: I18n.t( "share" ) } ) }
+                  { I18n.t( "share_caps", { defaultValuePreFallback: I18n.t( "share" ) } ) }
                   { " " }
                   <i className="fa fa-share-square-o" />
                 </a>
@@ -220,7 +220,7 @@ const App = ( {
                       rel="noopener noreferrer"
                     >
                       <i className="fa fa-download" />
-                      { I18n.t( "download_caps", { defaultValue: I18n.t( "download" ) } ) }
+                      { I18n.t( "download_caps", { defaultValuePreFallback: I18n.t( "download" ) } ) }
                     </a>
                   ) }
                 </center>
@@ -339,7 +339,7 @@ const App = ( {
               <p>
                 { I18n.t( "year_in_review2", {
                   year,
-                  defaultValue: I18n.t( "year_in_review", { year } )
+                  defaultValuePreFallback: I18n.t( "year_in_review", { year } )
                 } ) }
               </p>
             </h1>
@@ -361,7 +361,7 @@ const App = ( {
                     { " " }
                     { I18n.t( "view_your_personal_year_in_review_caps", {
                       year,
-                      defaultValue: I18n.t( "view_your_personal_year_in_review", { year } )
+                      defaultValuePreFallback: I18n.t( "view_your_personal_year_in_review", { year } )
                     } ) }
                   </a>
                   { site && defaultSite && site.id !== defaultSite.id && (

--- a/app/webpack/stats/year/components/donate_content_2022.jsx
+++ b/app/webpack/stats/year/components/donate_content_2022.jsx
@@ -70,7 +70,7 @@ const DonateContent2022 = ( {
                       I18n.t(
                         "views.donate.monthly_supporters.thank_you_for_being_a_monthly_supporter_caps",
                         {
-                          defaultValue: I18n.t(
+                          defaultValuePreFallback: I18n.t(
                             "views.donate.monthly_supporters.thank_you_for_being_a_monthly_supporter"
                           )
                         }
@@ -87,7 +87,7 @@ const DonateContent2022 = ( {
                       I18n.t(
                         "views.donate.monthly_supporters.become_a_monthly_supporter_of_inaturalist_caps",
                         {
-                          defaultValue: I18n.t(
+                          defaultValuePreFallback: I18n.t(
                             "views.donate.monthly_supporters.become_a_monthly_supporter_of_inaturalist"
                           )
                         }

--- a/app/webpack/stats/year/components/observations.jsx
+++ b/app/webpack/stats/year/components/observations.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import _ from "lodash";
 import moment from "moment";
 import DateHistogram from "../../../shared/components/date_histogram";
+import ErrorBoundary from "../../../shared/components/error_boundary";
 import TorqueMap from "../../../shared/components/torque_map";
 import GlobalMap from "./global_map";
 import ObservationsGrid from "./observations_grid";
@@ -170,31 +171,40 @@ const Observations = ( {
           window.open( url, "_blank", "noopener,noreferrer" );
         }}
       />
-      { user ? (
-        <TorqueMap
-          params={{ user_id: user.id, year }}
-          interval={user ? "weekly" : "monthly"}
-          basemap="dark_nolabels"
-          color="#74ac00"
-        /> )
-        : ( <GlobalMap year={year} site={site} /> )
-      }
+      <ErrorBoundary>
+        {
+          user
+            ? (
+              <TorqueMap
+                params={{ user_id: user.id, year }}
+                interval={user ? "weekly" : "monthly"}
+                basemap="dark_nolabels"
+                color="#74ac00"
+              />
+            )
+            : <GlobalMap year={year} site={site} />
+        }
+      </ErrorBoundary>
       { popular && (
-        <div>
-          <h3>
-            <a name="popular" href="#popular">
-              <span>{ I18n.t( "most_comments_and_faves" ) }</span>
-            </a>
-          </h3>
-          { popular }
-        </div>
+        <ErrorBoundary>
+          <div>
+            <h3>
+              <a name="popular" href="#popular">
+                <span>{ I18n.t( "most_comments_and_faves" ) }</span>
+              </a>
+            </h3>
+            { popular }
+          </div>
+        </ErrorBoundary>
       ) }
       { data.streaks && data.streaks.length > 0 && (
-        <Streaks
-          year={year}
-          data={data.streaks.slice( 0, 20 )}
-          hideUsers={!!user}
-        />
+        <ErrorBoundary>
+          <Streaks
+            year={year}
+            data={data.streaks.slice( 0, 20 )}
+            hideUsers={!!user}
+          />
+        </ErrorBoundary>
       ) }
     </div>
   );

--- a/app/webpack/stats/year/components/observations_grid.jsx
+++ b/app/webpack/stats/year/components/observations_grid.jsx
@@ -105,8 +105,8 @@ class ObservationsGrid extends React.Component {
             }}
           >
             { I18n.t( "more__context_observations_caps", {
-              defaultValue: I18n.t( "more_caps", {
-                defaultValue: I18n.t( "more" )
+              defaultValuePreFallback: I18n.t( "more_caps", {
+                defaultValuePreFallback: I18n.t( "more" )
               } )
             } ) }
           </button>

--- a/app/webpack/stats/year/components/publications.jsx
+++ b/app/webpack/stats/year/components/publications.jsx
@@ -94,7 +94,7 @@ const Publications = ( { data, year } ) => {
             <a href={data.url} className="btn btn-default btn-bordered inlineblock">
               { I18n.t( "views.stats.year.view_all_publications_count_caps2", {
                 count: data.count,
-                defaultValue: I18n.t( "view_all_caps", { defaultValue: I18n.t( "view_all" ) } )
+                defaultValuePreFallback: I18n.t( "view_all_caps", { defaultValuePreFallback: I18n.t( "view_all" ) } )
               } ) }
             </a>
           </center>

--- a/app/webpack/stats/year/components/store_content.jsx
+++ b/app/webpack/stats/year/components/store_content.jsx
@@ -23,7 +23,7 @@ const StoreContent = ( { isTouchDevice } ) => (
             className="btn btn-default btn-donate btn-bordered"
           >
             <i className="fa fa-shopping-cart" />
-            { I18n.t( "store_caps", { defaultValue: I18n.t( "store" ) } ) }
+            { I18n.t( "store_caps", { defaultValuePreFallback: I18n.t( "store" ) } ) }
           </a>
         </div>
       </Col>

--- a/app/webpack/stats/year/components/translators.jsx
+++ b/app/webpack/stats/year/components/translators.jsx
@@ -219,7 +219,7 @@ class Translators extends React.Component {
             }}
           >
             { I18n.t( "more__context_translators_caps", {
-              defaultValue: I18n.t( "more_caps", { defaultValue: I18n.t( "more" ) } )
+              defaultValuePreFallback: I18n.t( "more_caps", { defaultValuePreFallback: I18n.t( "more" ) } )
             } ) }
           </button>
         ) }


### PR DESCRIPTION
* Replace override of defaultValue behavior in I18n.js with
  defaultValuePreFallback
* Switch to jsdelivr from unpkgs for some YIR libs due to flaky loading
* Wrap some YIR components in ErrorBoundaries so errors there don't take out
  the entire page

Re: defaultValue, we had overridden this option so that the default value
would be used even if fallback translations existed, which is *not* how it
works in Rails, and is frankly just kind of confusing. Instead, I've changed
the option to defaultValuePreFallback to be explicit about the fact that it
gets used before even checking for fallback translations.

FWIW, this is meant for use in situations where an alternate translation
exists in the current locale that would be better than the default English
fallback that exists for all locales.

Closes WEB-593