### PR TITLE
fix: taxon page remove name buttons elements for visitors

### DIFF
--- a/app/webpack/taxa/show/components/taxonomy_tab.jsx
+++ b/app/webpack/taxa/show/components/taxonomy_tab.jsx
@@ -187,27 +187,29 @@ const TaxonomyTab = ( {
               </h3>
             </Col>
             <Col xs={4}>
-              <ul className="tab-links list-group">
-                { viewerIsCurator ? (
-                  <li className="list-group-item internal">
-                    <a href={`/taxa/${taxon.id}/names`} rel="nofollow">
-                      <i className="fa fa-gear accessory-icon" />
-                      { I18n.t( "manage_names" ) }
-                    </a>
-                  </li>
-                ) : null }
-                { currentUser && currentUser.content_creation_restrictions ? null : (
-                  <li className="list-group-item internal">
-                    <a
-                      href={`/taxa/${taxon.id}/taxon_names/new`}
-                      rel="nofollow"
-                    >
-                      <i className="fa fa-plus accessory-icon" />
-                      { I18n.t( "add_a_name" ) }
-                    </a>
-                  </li>
-                ) }
-              </ul>
+              { currentUser ? (
+                <ul className="tab-links list-group">
+                  { viewerIsCurator ? (
+                    <li className="list-group-item internal">
+                      <a href={`/taxa/${taxon.id}/names`} rel="nofollow">
+                        <i className="fa fa-gear accessory-icon" />
+                        { I18n.t( "manage_names" ) }
+                      </a>
+                    </li>
+                  ) : null }
+                  { currentUser.content_creation_restrictions ? null : (
+                    <li className="list-group-item internal">
+                      <a
+                        href={`/taxa/${taxon.id}/taxon_names/new`}
+                        rel="nofollow"
+                      >
+                        <i className="fa fa-plus accessory-icon" />
+                        { I18n.t( "add_a_name" ) }
+                      </a>
+                    </li>
+                  ) }
+                </ul>
+              ) : null }
               <h4>{ I18n.t( "about_names" ) }</h4>
               <UserText
                 text={I18n.t( "views.taxa.show.about_names_desc" ).replace( /\n+/gm, " " )}


### PR DESCRIPTION
fixes https://github.com/inaturalist/inaturalist/issues/4428

Removed the whole `ul` element, as both buttons depend on a logged-in user. 


## After change

![image](https://github.com/user-attachments/assets/a21c9b42-5fe6-4fc3-8500-0f2fad43b0e8)
