### PR TITLE
fix: repair announcement targeting

### DIFF
--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -7,11 +7,16 @@ $( function ( ) {
   $( "#announcement_placement" ).change( function ( ) {
     var placement = $( "#announcement_placement" ).val( );
     var clientsSelect = $( "#announcement_clients" );
+    var valuesToSelect = clientsSelect.val( ) || clientsSelect.data( "originalValues" ) || [];
     clientsSelect.empty( );
     clientsSelect.append( $( "<option value>" + I18n.t( "all" ) + "</option>" ) );
     if ( PLACEMENT_CLIENTS[placement] ) {
       _.each( PLACEMENT_CLIENTS[placement], function ( placementClient ) {
-        clientsSelect.append( $( "<option value='" + placementClient + "'>" + placementClient + "</option>" ) );
+        var option = $( "<option value='" + placementClient + "'>" + placementClient + "</option>" );
+        if ( valuesToSelect.indexOf( placementClient ) >= 0 ) {
+          option.attr( "selected", true );
+        }
+        clientsSelect.append( option );
       } );
       clientsSelect.attr( "size", _.min( [_.size( PLACEMENT_CLIENTS[placement] ) + 1, 5] ) );
       $( ".clients_field" ).show( );
@@ -23,6 +28,7 @@ $( function ( ) {
 
   // Show / hide the clients on load
   $( "#announcement_placement" ).change();
+  $( "#announcement_clients" ).data( "originalValues", $( "#announcement_clients" ).val( ) );
 
   $( "#announcement_target_group_type" ).change( function ( ) {
     var targetGroupType = $( "#announcement_target_group_type" ).val( );

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -48,6 +48,7 @@ class Announcement < ApplicationRecord
   YES_NO_ANY = [YES, NO, ANY].freeze
 
   has_and_belongs_to_many :sites
+  has_many :announcement_impressions, dependent: :delete_all
   validates_presence_of :placement, :start, :end, :body
   validate :valid_placement_clients
   validates_inclusion_of :target_group_type, in: TARGET_GROUPS.keys, if: :target_group_type?
@@ -119,6 +120,14 @@ class Announcement < ApplicationRecord
     user_id = user.id if user.is_a?( User )
     user_id = user_id.to_i
     dismiss_user_ids.include?( user_id )
+  end
+
+  def impressions_count
+    announcement_impressions.sum( :impressions_count )
+  end
+
+  def dismissals_count
+    dismiss_user_ids.count
   end
 
   def targeted_to_user?( user )

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -38,7 +38,7 @@
     .col-xs-4
       = f.select :placement, Announcement::PLACEMENTS
       - clients = Announcement::CLIENTS[@announcement.placement] || []
-      = f.select :clients, clients, { include_blank: t( :all ) }, { multiple: true, description: t( "views.announcements.clients_desc" ),description_tip: true, size: [clients.length + 1, 5].min, wrapper: {style: "display: none;"} }
+      = f.select :clients, clients, { include_blank: t( :all ) }, { multiple: true, description: t( "views.announcements.clients_desc" ),description_tip: true, size: [clients.length + 1, 5].min }
       = f.datetime_select :start, use_month_names: month_names, order: [:year, :month, :day], description: t( "views.announcements.start_desc" ), description_tip: true
       = f.datetime_select :end, use_month_names: month_names, order: [:year, :month, :day], description: t( "views.announcements.end_desc" ), description_tip: true
       = f.check_box :dismissible, label_after: true

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -38,7 +38,7 @@
     .col-xs-4
       = f.select :placement, Announcement::PLACEMENTS
       - clients = Announcement::CLIENTS[@announcement.placement] || []
-      = f.select :clients, clients, { include_blank: t( :all ) }, { multiple: true, description: t( "views.announcements.clients_desc" ),description_tip: true, size: [clients.length + 1, 5].min }
+      = f.select :clients, clients, { include_blank: t( :all ) }, { multiple: true, description: t( "views.announcements.clients_desc" ),description_tip: true, size: [clients.length + 1, 5].min, wrapper: { style: "display: none;" } }
       = f.datetime_select :start, use_month_names: month_names, order: [:year, :month, :day], description: t( "views.announcements.start_desc" ), description_tip: true
       = f.datetime_select :end, use_month_names: month_names, order: [:year, :month, :day], description: t( "views.announcements.end_desc" ), description_tip: true
       = f.check_box :dismissible, label_after: true

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -12,6 +12,8 @@
     site_ids
     ip_countries
     dismissible
+    dismissals_count
+    impressions_count
     prefers_target_staff
     prefers_target_unconfirmed_users
     target_logged_in

--- a/spec/controllers/announcements_controller_api_spec.rb
+++ b/spec/controllers/announcements_controller_api_spec.rb
@@ -210,6 +210,19 @@ describe AnnouncementsController do
         expect( annc_ids ).not_to include( other_site_announcement.id )
       end
 
+      it "does not allow dismissed site-specific announcements to exclude undismissed non-site ones" do
+        create( :site ) unless Site.default
+        user_site = create :site
+        user = create :user, site: user_site
+        site_announcement = create :announcement, sites: [user_site], dismissible: true, dismiss_user_ids: [user.id]
+        nosite_announcement = create :announcement
+        sign_in user
+        get :active, format: :json
+        annc_ids = response.parsed_body.map {| a | a["id"] }
+        expect( annc_ids ).not_to include( site_announcement.id )
+        expect( annc_ids ).to include( nosite_announcement.id )
+      end
+
       it "targets unconfirmed user" do
         unconfirmed_user = create( :user, confirmed_at: nil )
         unconfirmed_announcement = create :announcement, prefers_target_unconfirmed_users: true

--- a/spec/controllers/announcements_controller_api_spec.rb
+++ b/spec/controllers/announcements_controller_api_spec.rb
@@ -223,6 +223,17 @@ describe AnnouncementsController do
         expect( annc_ids ).to include( nosite_announcement.id )
       end
 
+      it "does not allow dismissed locale-specific announcements to exclude undismissed non-locale ones" do
+        user = create :user
+        locale_announcement = create :announcement, locales: ["en"], dismissible: true, dismiss_user_ids: [user.id]
+        no_locale_announcement = create :announcement
+        sign_in user
+        get :active, format: :json, params: { locale: "en" }
+        annc_ids = response.parsed_body.map {| a | a["id"] }
+        expect( annc_ids ).not_to include( locale_announcement.id )
+        expect( annc_ids ).to include( no_locale_announcement.id )
+      end
+
       it "targets unconfirmed user" do
         unconfirmed_user = create( :user, confirmed_at: nil )
         unconfirmed_announcement = create :announcement, prefers_target_unconfirmed_users: true


### PR DESCRIPTION
* fix: exclude siteless anncs after excluding dismissed anncs
* fix: include no-locale anncs even if user dismissed locale-specific ones
* fix: show current client choice when editing announcement
* feat: add impressions count to announcements/:id