### PR TITLE
feat: hide some project req. behind collapse

### DIFF
--- a/app/webpack/projects/show/components/collapse_button.jsx
+++ b/app/webpack/projects/show/components/collapse_button.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const CollapseButton = ( { isCollapsed, onToggle, ariaLabel } ) => (
+  <button
+    type="button"
+    className="btn btn-nostyle toggle-collapse"
+    onClick={onToggle}
+    aria-label={ariaLabel}
+    style={{
+      position: "absolute",
+      top: "0",
+      right: "0"
+    }}
+  >
+    <i className={`fa ${isCollapsed ? "fa-chevron-down" : "fa-chevron-up"}`} />
+  </button>
+);
+
+CollapseButton.propTypes = {
+  isCollapsed: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  ariaLabel: PropTypes.string.isRequired
+};
+
+export default CollapseButton;

--- a/app/webpack/projects/show/components/requirements.jsx
+++ b/app/webpack/projects/show/components/requirements.jsx
@@ -1,8 +1,9 @@
 import _ from "lodash";
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import moment from "moment-timezone";
 import SplitTaxon from "../../../shared/components/split_taxon";
+import CollapseButton from "./collapse_button";
 /* global TIMEZONE */
 
 function dateToString( date, spansYears = false ) {
@@ -23,6 +24,10 @@ function dateToString( date, spansYears = false ) {
 const Requirements = ( {
   project, setSelectedTab, includeArrowLink, config
 } ) => {
+  const [isTaxaCollapsed, setIsTaxaCollapsed] = useState( true );
+  const [isLocationCollapsed, setIsLocationCollapsed] = useState( true );
+  const [isUserCollapsed, setIsUserCollapsed] = useState( true );
+
   const taxonRules = _.isEmpty( project.taxonRules ) ? I18n.t( "all_taxa_" )
     : _.map( _.sortBy( project.taxonRules, r => r.taxon.name ), r => (
       <SplitTaxon
@@ -86,8 +91,10 @@ const Requirements = ( {
       </a>
     ) );
   const qualityGradeRules = _.isEmpty( project.rule_quality_grade ) ? I18n.t( "any_quality_grade" )
-    : _.map( _.keys( project.rule_quality_grade ),
-      q => I18n.t( q === "research" ? "research_grade" : `${q}_` ) ).join( ", " );
+    : _.map(
+      _.keys( project.rule_quality_grade ),
+      q => I18n.t( q === "research" ? "research_grade" : `${q}_` )
+    ).join( ", " );
   const media = [];
   if ( project.rule_photos ) {
     media.push( I18n.t( "photo" ) );
@@ -129,9 +136,10 @@ const Requirements = ( {
         </td>
         <td className="value">
           <a href={`/observations?term_id=${project.rule_term_id}`}>
-            { I18n.t( `controlled_term_labels.${_.snakeCase( project.rule_term_id_instance.label )}`,
-              { default: project.rule_term_id_instance.label } )
-            }
+            { I18n.t(
+              `controlled_term_labels.${_.snakeCase( project.rule_term_id_instance.label )}`,
+              { default: project.rule_term_id_instance.label }
+            )}
           </a>
           { project.rule_term_value_id_instance && (
             <span className="term-value">
@@ -139,9 +147,10 @@ const Requirements = ( {
                 &rarr;
               </span>
               <a href={`/observations?term_id=${project.rule_term_id}&term_value_id=${project.rule_term_value_id}`}>
-                { I18n.t( `controlled_term_labels.${_.snakeCase( project.rule_term_value_id_instance.label )}`,
-                  { default: project.rule_term_value_id_instance.label } )
-                }
+                { I18n.t(
+                  `controlled_term_labels.${_.snakeCase( project.rule_term_value_id_instance.label )}`,
+                  { default: project.rule_term_value_id_instance.label }
+                )}
               </a>
             </span>
           )}
@@ -181,54 +190,81 @@ const Requirements = ( {
         <table>
           <tbody>
             <tr>
-              <td className="param">
+              <td className="param" style={{ position: "relative" }}>
                 <i className="fa fa-leaf" />
                 { I18n.t( "taxa" ) }
+                <CollapseButton
+                  isCollapsed={isTaxaCollapsed}
+                  onToggle={() => setIsTaxaCollapsed( !isTaxaCollapsed )}
+                  ariaLabel={isTaxaCollapsed ? I18n.t( "expand" ) : I18n.t( "collapse" )}
+                />
               </td>
               <td className="value">
-                { taxonRules }
-                { exceptTaxonRules && (
-                  <div className="except">
-                    <div className="bold">
-                      { I18n.t( "except" ) }
-                    </div>
-                    { exceptTaxonRules }
-                  </div>
-                ) }
+                {!isTaxaCollapsed && (
+                  <>
+                    { taxonRules }
+                    { exceptTaxonRules && (
+                      <div className="except">
+                        <div className="bold">
+                          { I18n.t( "except" ) }
+                        </div>
+                        { exceptTaxonRules }
+                      </div>
+                    ) }
+                  </>
+                )}
               </td>
             </tr>
             <tr>
-              <td className="param">
+              <td className="param" style={{ position: "relative" }}>
                 <i className="fa fa-map-marker" />
                 { I18n.t( "location" ) }
+                <CollapseButton
+                  isCollapsed={isLocationCollapsed}
+                  onToggle={() => setIsLocationCollapsed( !isLocationCollapsed )}
+                  ariaLabel={isLocationCollapsed ? I18n.t( "expand" ) : I18n.t( "collapse" )}
+                />
               </td>
               <td className="value location-rules">
-                { locationRules }
-                { exceptLocationRules && (
+                {!isLocationCollapsed && (
+                <>
+                  { locationRules }
+                  { exceptLocationRules && (
                   <div className="except">
                     <div className="bold">
                       { I18n.t( "except" ) }
                     </div>
                     { exceptLocationRules }
                   </div>
-                ) }
+                  ) }
+                </>
+                )}
               </td>
             </tr>
             <tr>
-              <td className="param">
+              <td className="param" style={{ position: "relative" }}>
                 <i className="fa fa-user" />
                 { I18n.t( "users" ) }
+                <CollapseButton
+                  isCollapsed={isUserCollapsed}
+                  onToggle={() => setIsUserCollapsed( !isUserCollapsed )}
+                  ariaLabel={isUserCollapsed ? I18n.t( "expand" ) : I18n.t( "collapse" )}
+                />
               </td>
               <td className="value">
-                { userRules }
-                { exceptUserRules && (
+                {!isUserCollapsed && (
+                <>
+                  { userRules }
+                  { exceptUserRules && (
                   <div className="except">
                     <div className="bold">
                       { I18n.t( "except" ) }
                     </div>
                     { exceptUserRules }
                   </div>
-                ) }
+                  ) }
+                </>
+                )}
               </td>
             </tr>
             { projectsRequirement }
@@ -263,7 +299,8 @@ const Requirements = ( {
             { annotationRequirement }
           </tbody>
         </table>
-      </div> );
+      </div>
+    );
   return (
     <div className="Requirements">
       <h2>

--- a/app/webpack/projects/show/components/requirements.jsx
+++ b/app/webpack/projects/show/components/requirements.jsx
@@ -309,6 +309,7 @@ const Requirements = ( {
           <button
             type="button"
             className="btn btn-nostyle"
+            aria-label={I18n.t( "about" )}
             onClick={( ) => setSelectedTab( "about" )}
           >
             <i className="fa fa-arrow-circle-right" />


### PR DESCRIPTION
# Implements Collapsible Project Req Details (WIP)

Fixes: https://github.com/inaturalist/inaturalist/issues/4373

## Caveats

This is a work in progress due to time constraints. Could not finish it in my given time frame but wanted to give others the chance to finish it up. Additionally I believe my linter setup is currently not working correctly again because it flagged a lot as errors, I did fix it with the local eslint but unsure if it takes my global settings or the local ones.

## Features

- Added a generic React collapse button component
- Made taxa, location, and users sections collapsible
- Positioned the collapse arrow on the left intentionally to avoid z-index issues and layout shifts when container size changes with long text (and not like the example images in the issue given by loarie)

## To Do

- Add threshold to only show collapse functionality when entries exceed a certain number (or default to expanded when few entries)
- Check for existing i18n labels for "expand" & "collapse"
- Verify functionality with different language directions (RTL support)

## Example Image

![image](https://github.com/user-attachments/assets/143752fb-cfba-41ad-81c9-23d55d33ddf3)





