### PR TITLE
fix: prevent overlaps in Explore map view observations

### DIFF
--- a/app/assets/javascripts/ang/templates/shared/observation.html.haml
+++ b/app/assets/javascripts/ang/templates/shared/observation.html.haml
@@ -17,14 +17,24 @@
     .meta.ng-cloak
       %span{ :class => "quality_grade {{ o.quality_grade }}" }
         {{ o.qualityGrade( ) }}
-      %span.identifications{ "ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}" }
-        %i.icon-identification
-        {{ o.identifications_count }}
-      %span.comments{ "ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}" }
-        %i.icon-chatbubble
-        {{ o.comments_count }}
-      %span.favorites{ "ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}" }
-        %i.fa.fa-star
-        {{ o.faves_count }}
-      %span.created_at.pull-right
-        %inat-calendar-date{ date: "o.created_at_details.date", timezone: "o.created_time_zone", obscured: "o.obscured && !o.private_geojson", short: "true", title: "(!o.obscured || o.private_geojson ) && shared.t('added_on_datetime', { datetime: shared.l('datetime.formats.long', o.created_at )})", "show-time-ago": "true" }
+      %span.meta-stats
+        %span.identifications{ "ng-show" => "o.identifications_count > 0", title: "{{ shared.t('x_identifications', {count: o.identifications_count}) }}" }
+          %span.meta-item
+            %i.icon-identification
+            %span.meta-text
+              {{ o.identifications_count }}
+        %span.comments{ "ng-show" => "o.comments_count > 0", title: "{{ shared.t('x_comments', {count: o.comments_count}) }}" }
+          %span.meta-item
+            %i.icon-chatbubble
+            %span.meta-text
+              {{ o.comments_count }}
+        %span.favorites{ "ng-show" => "o.faves_count > 0", title: "{{ shared.t('x_faves', {count: o.faves_count}) }}" }
+          %span.meta-item
+            %i.fa.fa-star
+            %span.meta-text
+              {{ o.faves_count }}
+        %span.meta-item.meta-item-right
+          %i.fa.fa-calendar-plus-o{ "ng-show" => "!o.obscured" }
+          %span{ "ng-bind-html": "o.placeIcon() | sanitize", "ng-show" => "o.obscured" }
+          %span.meta-text
+            %inat-calendar-date{ date: "o.created_at_details.date", timezone: "o.created_time_zone", obscured: "o.obscured && !o.private_geojson", short: "true", title: "(!o.obscured || o.private_geojson ) && shared.t('added_on_datetime', { datetime: shared.l('datetime.formats.long', o.created_at )})", "show-time-ago": "true" }

--- a/app/assets/stylesheets/observations.scss
+++ b/app/assets/stylesheets/observations.scss
@@ -846,6 +846,11 @@
         margin-inline-end: 3px;
       }
 
+      i.fa-calendar-plus-o {
+        position: relative;
+        top: -1px;
+      }
+
       .meta-text {
         white-space: nowrap;
       }

--- a/app/assets/stylesheets/observations/search.scss
+++ b/app/assets/stylesheets/observations/search.scss
@@ -580,11 +580,6 @@ inat-taxon.split-taxon .icon {display: none;}
   display: inline-block;
   white-space: nowrap;
 }
-#obs-container .observation .date:before {
-  content: '\2022';
-  font-weight: bold;
-  margin: 0 3px 0 2px;
-}
 #obs-container .observation .pull-right .date:before {
   content: none;
 }
@@ -643,7 +638,8 @@ inat-taxon.split-taxon .icon {display: none;}
 }
 #obs-container .media-body {
   padding: 5px 10px 26px 10px;
-  border-top: 1px solid #eee
+  border-top: 1px solid #eee;
+  position: relative;
 }
 
 #obs-container .userimage {
@@ -660,6 +656,8 @@ inat-taxon.split-taxon .icon {display: none;}
   clear: both;
   position: absolute;
   bottom: 7px;
+  padding-inline-end: 20px;
+  width: 100%;
 }
 
 .bootstrap label.sectionlabel {


### PR DESCRIPTION
Map view was not benefiting from revised styles in grid and list views. Also added an icon to clarify that the date in the metadata is date added, not date observed.

Closes WEB-648