### PR TITLE
fix: set num_identification_agreements when agreeing w/ observer ID

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2485,7 +2485,7 @@ class Observation < ApplicationRecord
       num_agreements    = 0
       num_disagreements = 0
     else
-      nodes = community_taxon_nodes
+      nodes = community_taxon_nodes( force: true )
       if node = nodes.detect{|n| n[:taxon].try(:id) == taxon_id}
         num_agreements = node[:cumulative_count]
         num_disagreements = node[:disagreement_count] + node[:conservative_disagreement_count]


### PR DESCRIPTION
Previously if you agreed with the observer's ID, `num_identification_agreements` would be zero... despite tests to the contrary. This does fix it, but I wasn't able to write a test to prove it was broken. Easy to repro on a working site, though.

Related to WEB-612