### PR TITLE
feat: target announcements to curators, project admins, & by obs app

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -5,6 +5,7 @@ class AnnouncementsController < ApplicationController
   before_action :site_admin_required, except: [:active, :dismiss]
   before_action :load_announcement, only: [:show, :edit, :update, :destroy, :dismiss]
   before_action :load_sites, only: [:new, :edit, :create]
+  before_action :load_oauth_applications, only: [:new, :edit, :create]
 
   layout "bootstrap"
 
@@ -119,6 +120,13 @@ class AnnouncementsController < ApplicationController
 
   def load_sites
     @sites = Site.limit( 100 )
+  end
+
+  def load_oauth_applications
+    @oauth_applications = [OauthApplication.new( id: 0, name: "Web" )] + OauthApplication.where(
+      "official AND scopes LIKE '%write%'"
+    )
+    @oauth_applications.sort_by!( &:name )
   end
 
   def user_agent_client

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -214,24 +214,26 @@ class Announcement < ApplicationRecord
 
     # If we're including obs apps, look for any obs the user has created with those apps
     if user && !include_observation_oauth_application_ids.blank?
-      return Observation.elastic_search(
+      num_obs_from_included_apps = Observation.elastic_search(
         filters: [
           { term: { "user.id" => user.id } },
           { terms: { oauth_application_id: include_observation_oauth_application_ids } }
         ],
         size: 0
-      ).total_entries.positive?
+      ).total_entries
+      return false if num_obs_from_included_apps.zero?
     end
 
     # If we're excluding obs apps, look for any obs the user has created with those apps
     if user && !exclude_observation_oauth_application_ids.blank?
-      return Observation.elastic_search(
+      num_obs_from_excluded_apps = Observation.elastic_search(
         filters: [
           { term: { "user.id" => user.id } },
           { terms: { oauth_application_id: exclude_observation_oauth_application_ids } }
         ],
         size: 0
-      ).total_entries.zero?
+      ).total_entries
+      return false if num_obs_from_excluded_apps.positive?
     end
     true
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -204,6 +204,27 @@ class Announcement < ApplicationRecord
       return false if last_observation_end_date && last_observation_created_at > last_observation_end_date
     end
 
+    # If we're including obs apps, look for any obs the user has created with those apps
+    if user && !include_observation_oauth_application_ids.blank?
+      return Observation.elastic_search(
+        filters: [
+          { term: { "user.id" => user.id } },
+          { terms: { oauth_application_id: include_observation_oauth_application_ids } }
+        ],
+        size: 0
+      ).total_entries.positive?
+    end
+
+    # If we're excluding obs apps, look for any obs the user has created with those apps
+    if user && !exclude_observation_oauth_application_ids.blank?
+      return Observation.elastic_search(
+        filters: [
+          { term: { "user.id" => user.id } },
+          { terms: { oauth_application_id: exclude_observation_oauth_application_ids } }
+        ],
+        size: 0
+      ).total_entries.zero?
+    end
     true
   end
 

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -54,6 +54,7 @@ class Announcement < ApplicationRecord
   validates_inclusion_of :target_group_type, in: TARGET_GROUPS.keys, if: :target_group_type?
   validates_inclusion_of :target_logged_in, in: YES_NO_ANY
   validates_inclusion_of :target_curators, in: YES_NO_ANY
+  validates_inclusion_of :target_project_admins, in: YES_NO_ANY
   validates_presence_of :target_group_partition, if: :target_group_type?
   validate :valid_target_group_partition, if: :target_group_type?
   validates :min_identifications,
@@ -184,6 +185,9 @@ class Announcement < ApplicationRecord
 
     return false if target_curators == YES && !user&.is_curator?
     return false if target_curators == NO && user&.is_curator?
+
+    return false if target_project_admins == YES && !user&.projects&.any?
+    return false if target_project_admins == NO && user&.projects&.any?
 
     return false if ( include_donor_start_date || include_donor_end_date ) && (
       !user || user.user_donations.

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -23,6 +23,10 @@ class OauthApplication < Doorkeeper::Application
   validate :redirect_uri_has_no_params
 
   WEB_APP_ID = 0
+  ANDROID_APP_NAME = "iNaturalist Android App"
+  IPHONE_APP_NAME = "iNaturalist iPhone App"
+  SEEK_APP_NAME = "Seek"
+  INAT_NEXT_APP_NAME = "iNat Next"
 
   def redirect_uri_has_no_params
     if redirect_uri.to_s.split( "?" ).size > 1
@@ -31,19 +35,19 @@ class OauthApplication < Doorkeeper::Application
   end
 
   def self.inaturalist_android_app
-    @@inaturalist_android_app ||= OauthApplication.where( name: "iNaturalist Android App" ).first
+    @@inaturalist_android_app ||= OauthApplication.where( name: ANDROID_APP_NAME ).first
   end
 
   def self.inaturalist_iphone_app
-    @@inaturalist_iphone_app ||= OauthApplication.where( name: "iNaturalist iPhone App" ).first
+    @@inaturalist_iphone_app ||= OauthApplication.where( name: IPHONE_APP_NAME ).first
   end
 
   def self.seek_app
-    @@seek_app ||= OauthApplication.where( name: "Seek" ).first
+    @@seek_app ||= OauthApplication.where( name: SEEK_APP_NAME ).first
   end
 
   def self.inat_next_app
-    @@inat_next_app ||= OauthApplication.where( name: "iNat Next" ).first
+    @@inat_next_app ||= OauthApplication.where( name: INAT_NEXT_APP_NAME ).first
   end
 
   def set_scopes

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -115,6 +115,10 @@
                 = f.radio_button :target_logged_in, Announcement::ANY, label: t( :any_ ), inline: true
                 = f.radio_button :target_logged_in, Announcement::YES, label: t( :yes ), inline: true
                 = f.radio_button :target_logged_in, Announcement::NO, label: t( :no ), inline: true
+              = f.form_field :target_curators, builder: BootstrapFormBuilder do
+                = f.radio_button :target_curators, Announcement::ANY, label: t( :any_ ), inline: true
+                = f.radio_button :target_curators, Announcement::YES, label: t( :yes ), inline: true
+                = f.radio_button :target_curators, Announcement::NO, label: t( :no ), inline: true
             .col-xs-4
               = f.select :target_group_type, Announcement::TARGET_GROUPS.keys, include_blank: t( :none )
               - target_group_partitions = Announcement::TARGET_GROUPS[@announcement.target_group_type] || []

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -85,6 +85,10 @@
               .row
                 .col-xs-12
                   %p.text-muted=t "views.announcements.last_observation_date_desc"
+            .col-xs-2
+              = f.select :include_observation_oauth_application_ids, @oauth_applications.map {| oa | [oa.name, oa.id] }, { include_blank: t(:all) }, multiple: true, description: t( "views.announcements.observation_oauth_application_ids_desc" ), description_tip: true
+            .col-xs-2
+              = f.select :exclude_observation_oauth_application_ids, @oauth_applications.map {| oa | [oa.name, oa.id] }, { include_blank: t(:all) }, multiple: true, description: t( "views.announcements.observation_oauth_application_ids_desc" ), description_tip: true
           %h4
             %i.icon-identification
             =t :identifications
@@ -97,8 +101,13 @@
             =t :users
           %p.text-muted=t "views.announcements.target_users_by_other_attributes"
           .row
-            .col-xs-2= f.text_field :user_created_start_date, type: "date"
-            .col-xs-2= f.text_field :user_created_end_date, type: "date"
+            .col-xs-4
+              .row
+                .col-xs-6= f.text_field :user_created_start_date, type: "date"
+                .col-xs-6= f.text_field :user_created_end_date, type: "date"
+              .row
+                .col-xs-12
+                  = f.select :clients, clients, { include_blank: t( :all ) }, { multiple: true, description: t( "views.announcements.clients_desc" ),description_tip: true, size: [clients.length + 1, 5].min, wrapper: { style: "display: none;" } }
             .col-xs-4
               = f.check_box :prefers_target_staff, label_after: true
               = f.check_box :prefers_target_unconfirmed_users, label_after: true
@@ -112,6 +121,7 @@
               = f.select :target_group_partition, target_group_partitions,              |
                 { include_blank: target_group_partitions.empty? ? t( :none ) : false }, |
                 { disabled: target_group_partitions.empty? }                            |
+
   .actions.buttons
     = f.submit f.object.new_record? ? t(:create) : t(:update), :class => "default button"
     = link_to t(:cancel), announcements_path, :class => "button"

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -108,17 +108,23 @@
               .row
                 .col-xs-12
                   = f.select :clients, clients, { include_blank: t( :all ) }, { multiple: true, description: t( "views.announcements.clients_desc" ),description_tip: true, size: [clients.length + 1, 5].min, wrapper: { style: "display: none;" } }
+              .row
+                .col-xs-12
+                  = f.check_box :prefers_target_staff, label_after: true
+                  = f.check_box :prefers_target_unconfirmed_users, label_after: true
             .col-xs-4
-              = f.check_box :prefers_target_staff, label_after: true
-              = f.check_box :prefers_target_unconfirmed_users, label_after: true
               = f.form_field :target_logged_in, builder: BootstrapFormBuilder do
                 = f.radio_button :target_logged_in, Announcement::ANY, label: t( :any_ ), inline: true
-                = f.radio_button :target_logged_in, Announcement::YES, label: t( :yes ), inline: true
-                = f.radio_button :target_logged_in, Announcement::NO, label: t( :no ), inline: true
+                = f.radio_button :target_logged_in, Announcement::YES, label: t( :logged_in ), inline: true
+                = f.radio_button :target_logged_in, Announcement::NO, label: t( :logged_out ), inline: true
               = f.form_field :target_curators, builder: BootstrapFormBuilder do
                 = f.radio_button :target_curators, Announcement::ANY, label: t( :any_ ), inline: true
-                = f.radio_button :target_curators, Announcement::YES, label: t( :yes ), inline: true
-                = f.radio_button :target_curators, Announcement::NO, label: t( :no ), inline: true
+                = f.radio_button :target_curators, Announcement::YES, label: t( :curator ), inline: true
+                = f.radio_button :target_curators, Announcement::NO, label: t( :non_curator ), inline: true
+              = f.form_field :target_project_admins, builder: BootstrapFormBuilder do
+                = f.radio_button :target_project_admins, Announcement::ANY, label: t( :any_ ), inline: true
+                = f.radio_button :target_project_admins, Announcement::YES, label: t( :project_admin ), inline: true
+                = f.radio_button :target_project_admins, Announcement::NO, label: t( :non_project_admin ), inline: true
             .col-xs-4
               = f.select :target_group_type, Announcement::TARGET_GROUPS.keys, include_blank: t( :none )
               - target_group_partitions = Announcement::TARGET_GROUPS[@announcement.target_group_type] || []

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3005,6 +3005,10 @@ en:
   # Application is a mobile app the user has authorized to access their iNat account
   log_out_of_application: "Log out of %{site_name}?"
   log_scale_label: Log
+  # Adjectival phrase describing state of being logged in
+  logged_in: Logged in
+  # Adjectival phrase describing state of being logged out
+  logged_in: Logged out
   # Status message shown while logging in
   logging_in: Logging in...
   logo:
@@ -3473,6 +3477,10 @@ en:
   no_users_found_with_those_filters: No users found with those filters
   no_wikipedia_page_for_taxon: No Wikipedia page for this taxon.
   noble_curators: "%{site}'s Noble Curators"
+  # A user who is not a curator
+  non_curator: Non-curator
+  # A user who does not admin any projects
+  non_project_admin: Non-project admin
   non_human?: Non-human?
   none: None
   none_found: None found
@@ -4573,6 +4581,8 @@ en:
     publicly visible after a user has contributed several Research Grade
     observations.
   project: Project
+  # A user who admin's a project
+  project_admin: Project admin
   project_admins:
     one: Project admin
     other: Project admins

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6757,6 +6757,10 @@ en:
         Note that the creation date of the user's most recently-created
         observation is cached, so it might take a few hours for targeting to
         take effect
+      observation_oauth_application_ids_desc: |
+        CMD- or SHIFT-click to select multiple. Selecting "All" or not making
+        a selection will show the announcement to all users regardless of
+        app.
       site_ids_desc: |
         CMD- or SHIFT-click to select multiple. Selecting "All" or not making
         a selection will show the announcement to all users regardless of
@@ -9847,10 +9851,16 @@ en:
         exclude_donor_start_date: Exclude donor start date
         # End of a date range that the viewer must not have donated in to see the announcement
         exclude_donor_end_date: Exclude donor end date
+        # iNat client applications that the user must not have made an observation
+        # with to see the announcement
+        exclude_observation_oauth_application_ids: Exclude observers from apps
         # start of a date range that the viewer must have donated in to see the announcement
         include_donor_start_date: Include donor start date
         # End of a date range that the viewer must have donated in to see the announcement
         include_donor_end_date: Include donor end date
+        # iNat client applications that the user must have made an observation
+        # with to see the announcement
+        include_observation_oauth_application_ids: Include observers from apps
         # List of countries that the viewer's IP address can come from to see the announcement
         ip_countries: IP Countries
         # Start of a date range that includes the viewer's most recent observation

--- a/db/migrate/20250326170449_add_observation_oauth_app_ids_to_announcements.rb
+++ b/db/migrate/20250326170449_add_observation_oauth_app_ids_to_announcements.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddObservationOauthAppIdsToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :include_observation_oauth_application_ids, :integer, array: true, default: []
+    add_column :announcements, :exclude_observation_oauth_application_ids, :integer, array: true, default: []
+  end
+end

--- a/db/migrate/20250326190722_add_target_curators_to_announcements.rb
+++ b/db/migrate/20250326190722_add_target_curators_to_announcements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTargetCuratorsToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :target_curators, :string, default: "any"
+  end
+end

--- a/db/migrate/20250326213516_add_target_project_admins_to_announcements.rb
+++ b/db/migrate/20250326213516_add_target_project_admins_to_announcements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTargetProjectAdminsToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :target_project_admins, :string, default: "any"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -409,7 +409,8 @@ CREATE TABLE public.announcements (
     ip_countries text[] DEFAULT '{}'::text[],
     include_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[],
     exclude_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[],
-    target_curators character varying DEFAULT 'any'::character varying
+    target_curators character varying DEFAULT 'any'::character varying,
+    target_project_admins character varying DEFAULT 'any'::character varying
 );
 
 
@@ -11500,6 +11501,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250311212144'),
 ('20250311225953'),
 ('20250326170449'),
-('20250326190722');
+('20250326190722'),
+('20250326213516');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -408,7 +408,8 @@ CREATE TABLE public.announcements (
     last_observation_end_date date,
     ip_countries text[] DEFAULT '{}'::text[],
     include_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[],
-    exclude_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[]
+    exclude_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[],
+    target_curators character varying DEFAULT 'any'::character varying
 );
 
 
@@ -11498,6 +11499,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250311191217'),
 ('20250311212144'),
 ('20250311225953'),
-('20250326170449');
+('20250326170449'),
+('20250326190722');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -406,7 +406,9 @@ CREATE TABLE public.announcements (
     user_created_end_date date,
     last_observation_start_date date,
     last_observation_end_date date,
-    ip_countries text[] DEFAULT '{}'::text[]
+    ip_countries text[] DEFAULT '{}'::text[],
+    include_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[],
+    exclude_observation_oauth_application_ids integer[] DEFAULT '{}'::integer[]
 );
 
 
@@ -2884,7 +2886,7 @@ CREATE TABLE public.observation_accuracy_validators (
     email_date timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    validation_count integer
+    validation_count integer DEFAULT 0
 );
 
 
@@ -5513,9 +5515,9 @@ ALTER SEQUENCE public.user_donations_id_seq OWNED BY public.user_donations.id;
 
 CREATE TABLE public.user_installations (
     id bigint NOT NULL,
-    installation_id character varying(255),
+    installation_id character varying,
     oauth_application_id integer,
-    platform_id character varying(255),
+    platform_id character varying,
     user_id integer,
     created_at date,
     first_logged_in_at date
@@ -11495,6 +11497,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250307004743'),
 ('20250311191217'),
 ('20250311212144'),
-('20250311225953');
+('20250311225953'),
+('20250326170449');
 
 

--- a/spec/controllers/announcements_controller_api_spec.rb
+++ b/spec/controllers/announcements_controller_api_spec.rb
@@ -250,6 +250,30 @@ describe AnnouncementsController do
         annc_ids = response.parsed_body.map {| a | a["id"] }
         expect( annc_ids ).not_to include( unconfirmed_announcement.id )
       end
+
+      it "includes users by observation oauth application ids" do
+        app = create :oauth_application, official: true
+        app_obs = create :observation, oauth_application: app
+        app_annc = create :announcement, include_observation_oauth_application_ids: [app.id]
+        oth_annc = create :announcement, include_observation_oauth_application_ids: [OauthApplication::WEB_APP_ID]
+        sign_in app_obs.user
+        get :active, format: :json
+        annc_ids = response.parsed_body.map {| a | a["id"] }
+        expect( annc_ids ).to include( app_annc.id )
+        expect( annc_ids ).not_to include( oth_annc.id )
+      end
+
+      it "excludes users by observation oauth application ids" do
+        app = create :oauth_application, official: true
+        app_obs = create :observation, oauth_application: app
+        app_annc = create :announcement, exclude_observation_oauth_application_ids: [app.id]
+        oth_annc = create :announcement, exclude_observation_oauth_application_ids: [OauthApplication::WEB_APP_ID]
+        sign_in app_obs.user
+        get :active, format: :json
+        annc_ids = response.parsed_body.map {| a | a["id"] }
+        expect( annc_ids ).not_to include( app_annc.id )
+        expect( annc_ids ).to include( oth_annc.id )
+      end
     end
 
     it "creates announcement impressions" do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -345,6 +345,23 @@ describe Announcement do
         expect( annc.targeted_to_user?( obs.user ) ).to be false
       end
     end
+
+    it "includes and excludes users by observation oauth application ids" do
+      app_to_include = create :oauth_application, official: true
+      app_to_exclude = create :oauth_application, official: true
+      annc = create :announcement,
+        include_observation_oauth_application_ids: [app_to_include.id],
+        exclude_observation_oauth_application_ids: [app_to_exclude.id]
+      include_user = create( :observation, oauth_application: app_to_include ).user
+      exclude_user = create( :observation, oauth_application: app_to_exclude ).user
+      both_user = create :user
+      create :observation, oauth_application: app_to_include, user: both_user
+      create :observation, oauth_application: app_to_exclude, user: both_user
+      expect( annc.targeted_to_user?( include_user ) ).to be true
+      expect( annc.targeted_to_user?( exclude_user ) ).to be false
+      puts "testing both user"
+      expect( annc.targeted_to_user?( both_user ) ).to be false
+    end
   end
 
   describe "dismissals" do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -184,6 +184,29 @@ describe Announcement do
       end
     end
 
+    describe "target_curators" do
+      it "defaults to targeting all" do
+        annc = create :announcement
+        expect( annc.target_curators ).to eq Announcement::ANY
+        expect( annc.targeted_to_user?( nil ) ).to be true
+        expect( annc.targeted_to_user?( create( :user ) ) ).to be true
+      end
+
+      it "can target curators" do
+        annc = create :announcement, target_curators: Announcement::YES
+        expect( annc.targeted_to_user?( nil ) ).to be false
+        expect( annc.targeted_to_user?( create( :user, :as_curator ) ) ).to be true
+        expect( annc.targeted_to_user?( create( :user ) ) ).to be false
+      end
+
+      it "can target non-curators" do
+        annc = create :announcement, target_curators: Announcement::NO
+        expect( annc.targeted_to_user?( nil ) ).to be true
+        expect( annc.targeted_to_user?( create( :user, :as_curator ) ) ).to be false
+        expect( annc.targeted_to_user?( create( :user ) ) ).to be true
+      end
+    end
+
     describe "min_identifications" do
       it "defaults to targeting all" do
         annc = create :announcement

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -207,6 +207,29 @@ describe Announcement do
       end
     end
 
+    describe "target_project_admins" do
+      it "defaults to targeting all" do
+        annc = create :announcement
+        expect( annc.target_project_admins ).to eq Announcement::ANY
+        expect( annc.targeted_to_user?( nil ) ).to be true
+        expect( annc.targeted_to_user?( create( :user ) ) ).to be true
+      end
+
+      it "can target project admins" do
+        annc = create :announcement, target_project_admins: Announcement::YES
+        expect( annc.targeted_to_user?( nil ) ).to be false
+        expect( annc.targeted_to_user?( create( :project ).user ) ).to be true
+        expect( annc.targeted_to_user?( create( :user ) ) ).to be false
+      end
+
+      it "can target non-project admins" do
+        annc = create :announcement, target_project_admins: Announcement::NO
+        expect( annc.targeted_to_user?( nil ) ).to be true
+        expect( annc.targeted_to_user?( create( :project ).user ) ).to be false
+        expect( annc.targeted_to_user?( create( :user ) ) ).to be true
+      end
+    end
+
     describe "min_identifications" do
       it "defaults to targeting all" do
         annc = create :announcement


### PR DESCRIPTION
Adds to announcement targeting to

* target/exclude project admins (i.e. people who admin projects, not people
  who admin a specific project)
* target/exclude curators
* target/exclude people who have posted observations from iNat Next (might be
  more useful to target people who have posted from a specific OAuth
  application)

Closes WEB-623