### PR TITLE
feat: allow announcement to target only the user who made it

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -66,6 +66,7 @@ class AnnouncementsController < ApplicationController
         ( @site_admin = @site.site_admins.detect {| sa | sa.user_id == current_user.id } )
       @announcement.sites = [@site]
     end
+    @announcement.user = current_user
     respond_to do | format |
       if @announcement.save
         format.html { redirect_to( @announcement, notice: t( :announcement_was_successfully_created ) ) }

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -133,6 +133,7 @@ class Announcement < ApplicationRecord
 
   def targeted_to_user?( user )
     return false if prefers_target_staff && ( user.blank? || !user.is_admin? )
+    return false if target_creator && ( user.blank? || user.id != user_id )
     return false if user&.monthly_donor? && prefers_exclude_monthly_supporters
     return false if target_group_type && user.blank?
     return false if target_logged_in == YES && user.blank?

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -47,6 +47,7 @@ class Announcement < ApplicationRecord
   ANY = "any"
   YES_NO_ANY = [YES, NO, ANY].freeze
 
+  belongs_to :user
   has_and_belongs_to_many :sites
   has_many :announcement_impressions, dependent: :delete_all
   validates_presence_of :placement, :start, :end, :body

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -131,6 +131,9 @@ class Announcement < ApplicationRecord
     dismiss_user_ids.count
   end
 
+  # This works by excluding users from filters, so it should only return false
+  # until the very end, otherwise you'll block subsequent filters from being
+  # checked
   def targeted_to_user?( user )
     return false if prefers_target_staff && ( user.blank? || !user.is_admin? )
     return false if target_creator && ( user.blank? || user.id != user_id )
@@ -193,9 +196,7 @@ class Announcement < ApplicationRecord
     return false if user_created_start_date && user.created_at < user_created_start_date
     return false if user_created_end_date && user.created_at > user_created_end_date
 
-    if prefers_target_unconfirmed_users
-      return user && !user.confirmed?
-    end
+    return false if prefers_target_unconfirmed_users && user&.confirmed?
 
     if user && ( last_observation_start_date || last_observation_end_date )
       last_observation_created_at = user.last_observation_created_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,6 +220,7 @@ class User < ApplicationRecord
   has_many :taxon_name_priorities, dependent: :destroy
   has_many :user_donations, dependent: :delete_all
   has_many :redirect_links, dependent: :nullify
+  has_many :announcements, dependent: :nullify
 
   file_options = {
     processors: [:deanimator],

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -101,6 +101,7 @@
             .col-xs-2= f.text_field :user_created_end_date, type: "date"
             .col-xs-4
               = f.check_box :prefers_target_staff, label_after: true
+              = f.check_box :target_creator, label_after: true
               = f.check_box :prefers_target_unconfirmed_users, label_after: true
               = f.form_field :target_logged_in, builder: BootstrapFormBuilder do
                 = f.radio_button :target_logged_in, Announcement::ANY, label: t( :any_ ), inline: true

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -9,6 +9,7 @@
     }
     .sidebar-body { max-width: 360px; }
     .sidebar-body img, .general-body img { max-width: 100%; }
+    th.user, td.user { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .container
   .row
     .col-xs-12
@@ -38,6 +39,7 @@
             %th= t :start
             %th= t :end
             %th= t :body
+            %th.user= t :created_by
         %tbody
           - @announcements.each do |announcement|
             %tr
@@ -48,9 +50,9 @@
                   .clients
                     = announcement.clients.join( ", " )
               %td= announcement.site_ids.empty? ? t(:all)  : announcement.sites.map(&:name).join(", ")
-              %td=l announcement.start
+              %td=l announcement.start, format: :short
               %td
-                =l announcement.end
+                =l announcement.end, format: :short
                 - if announcement.end > Time.now
                   %span.label.label-success=t :active
               %td.announcement-body
@@ -58,6 +60,9 @@
                   %div.sidebar-body=raw announcement.body
                 - else
                   %div.general-body=raw announcement.body
+              %td.user
+                = link_to( user_image( announcement.user), announcement.user ) if announcement.user
+                = link_to_user announcement.user, missing: t( :unknown )
               %td
                 = link_to announcement, class: "btn btn-default btn-sm" do
                   %i.fa.fa-eye
@@ -66,10 +71,5 @@
                 = link_to edit_announcement_path(announcement), class: "btn btn-default btn-sm" do
                   %i.fa.fa-pencil
                   = t(:edit)
-
-              %td
-                = link_to announcement, :data => {:confirm => t(:are_you_sure?)}, :method => :delete, class: "btn btn-danger btn-sm" do
-                  %i.fa.fa-trash
-                  = t(:destroy)
       = will_paginate @announcements
       = link_to t(:new_announcement), new_announcement_path, class: "btn btn-primary"

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -2,6 +2,7 @@
   meta_attributes = %w(
     created_at
     updated_at
+    user
     placement
     clients
     target_group_type
@@ -71,6 +72,9 @@
                       = val.map { | code | Place::COUNTRIES_BY_NAME.values.detect { | country | country[:code] == code }.try(:[], :name) }.sort.join( ", " )
                     - elsif a == "locales"
                       = val.map { | locale | I18n.t( "locales.#{locale}" ) }.sort.join( ", " )
+                    - elsif a == "user"
+                      = link_to( user_image( @announcement.user), @announcement.user ) if @announcement.user
+                      = link_to_user @announcement.user, missing: t( :unknown )
                     - elsif val.is_a?( Array)
                       = val.sort.join( ", " )
                     - elsif val.is_a?( String ) || [true, false].include?( val )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9867,6 +9867,8 @@ en:
         min_observations: Min observations
         # Place in iNat where this announcement will be shown, e.g. web dashboard, mobile home, etc
         placement: Placement
+        # Preference for an announcement that is only shown to the user who created the announcement
+        target_creator: Target creator (for testing)
         # Whether or not the announcement is shown to logged in users
         target_logged_in: Target logged in
         # Earliest date the viewer can have signed up to see the announcement

--- a/db/migrate/20250326223846_add_user_to_announcements.rb
+++ b/db/migrate/20250326223846_add_user_to_announcements.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUserToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :user_id, :integer
+    add_index :announcements, :user_id
+  end
+end

--- a/db/migrate/20250327191619_add_target_creator_to_announcements.rb
+++ b/db/migrate/20250327191619_add_target_creator_to_announcements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTargetCreatorToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :target_creator, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -407,7 +407,8 @@ CREATE TABLE public.announcements (
     last_observation_start_date date,
     last_observation_end_date date,
     ip_countries text[] DEFAULT '{}'::text[],
-    user_id integer
+    user_id integer,
+    target_creator boolean DEFAULT false
 );
 
 
@@ -11504,6 +11505,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250311191217'),
 ('20250311212144'),
 ('20250311225953'),
-('20250326223846');
+('20250326223846'),
+('20250327191619');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -406,7 +406,8 @@ CREATE TABLE public.announcements (
     user_created_end_date date,
     last_observation_start_date date,
     last_observation_end_date date,
-    ip_countries text[] DEFAULT '{}'::text[]
+    ip_countries text[] DEFAULT '{}'::text[],
+    user_id integer
 );
 
 
@@ -2884,7 +2885,7 @@ CREATE TABLE public.observation_accuracy_validators (
     email_date timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    validation_count integer
+    validation_count integer DEFAULT 0
 );
 
 
@@ -5513,9 +5514,9 @@ ALTER SEQUENCE public.user_donations_id_seq OWNED BY public.user_donations.id;
 
 CREATE TABLE public.user_installations (
     id bigint NOT NULL,
-    installation_id character varying(255),
+    installation_id character varying,
     oauth_application_id integer,
-    platform_id character varying(255),
+    platform_id character varying,
     user_id integer,
     created_at date,
     first_logged_in_at date
@@ -8289,6 +8290,13 @@ CREATE INDEX index_announcement_impressions_on_user_id ON public.announcement_im
 --
 
 CREATE INDEX index_announcements_on_start_and_end ON public.announcements USING btree (start, "end");
+
+
+--
+-- Name: index_announcements_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_announcements_on_user_id ON public.announcements USING btree (user_id);
 
 
 --
@@ -11495,6 +11503,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250307004743'),
 ('20250311191217'),
 ('20250311212144'),
-('20250311225953');
+('20250311225953'),
+('20250326223846');
 
 

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     send( :end ) { 1.day.from_now }
     body { Faker::Lorem.sentence }
     placement { "users/dashboard#sidebar" }
+    user
   end
 end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -65,6 +65,14 @@ describe Announcement do
       expect( a.targeted_to_user?( User.make! ) ).to be false
     end
 
+    it "targets creator" do
+      a = create :announcement, target_creator: true
+      expect( a.targeted_to_user?( make_admin ) ).to be false
+      expect( a.targeted_to_user?( make_curator ) ).to be false
+      expect( a.targeted_to_user?( User.make! ) ).to be false
+      expect( a.targeted_to_user?( a.user ) ).to be true
+    end
+
     it "targets unconfirmed users" do
       a = Announcement.make!( prefers_target_unconfirmed_users: true )
       expect( a.targeted_to_user?( User.make!( confirmed_at: Time.now ) ) ).to be false

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -79,6 +79,22 @@ describe Announcement do
       expect( a.targeted_to_user?( User.make!( confirmed_at: nil ) ) ).to be true
     end
 
+    it "targets unconfirmed users and last observation date" do
+      annc = create :announcement,
+        prefers_target_unconfirmed_users: true,
+        last_observation_start_date: 2.days.ago
+      confirmed_user = create :user
+      expect( confirmed_user ).to be_confirmed
+      unconfirmed_user = create :user, :as_unconfirmed
+      unconfirmed_user_no_obs = create :user, :as_unconfirmed
+      expect( unconfirmed_user ).not_to be_confirmed
+      create :observation, created_at: 1.day.ago, user: confirmed_user
+      create :observation, created_at: 1.day.ago, user: unconfirmed_user
+      expect( annc.targeted_to_user?( unconfirmed_user ) ).to be true
+      expect( annc.targeted_to_user?( confirmed_user ) ).to be false
+      expect( annc.targeted_to_user?( unconfirmed_user_no_obs ) ).to be false
+    end
+
     it "can exclude monthly supporters" do
       monthly_supporter = User.make!(
         donorbox_donor_id: 1,

--- a/tools/donorbox-plans.rb
+++ b/tools/donorbox-plans.rb
@@ -48,10 +48,12 @@ puts
 loop do
   url = "https://donorbox.org/api/v1/plans?page=#{page}&per_page=#{per_page}"
   puts url if opts.debug
-  response = RestClient.get( url, {
-    "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
-    "User-Agent" => "iNaturalist/Donorbox"
-  } )
+  response = try_and_try_again( RestClient::TooManyRequests, exponential_backoff: true, sleep: 3 ) do
+    RestClient.get( url, {
+      "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
+      "User-Agent" => "iNaturalist/Donorbox"
+    } )
+  end
   json = JSON.parse( response )
   break if json.size.zero?
 

--- a/tools/donorbox.rb
+++ b/tools/donorbox.rb
@@ -45,10 +45,12 @@ donors = {}
 loop do
   url = "https://donorbox.org/api/v1/donors?page=#{page}&per_page=#{per_page}"
   puts url if opts.debug
-  response = RestClient.get( url, {
-    "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
-    "User-Agent" => "iNaturalist/Donorbox"
-  } )
+  response = try_and_try_again( RestClient::TooManyRequests, exponential_backoff: true, sleep: 3 ) do
+    RestClient.get( url, {
+      "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
+      "User-Agent" => "iNaturalist/Donorbox"
+    } )
+  end
   json = JSON.parse( response )
   break if json.size.zero?
 

--- a/tools/donorbox_user_donations.rb
+++ b/tools/donorbox_user_donations.rb
@@ -35,10 +35,12 @@ per_page = 100
 loop do
   url = "https://donorbox.org/api/v1/donations?page=#{page}&per_page=#{per_page}&date_from=#{donation_lookup_start_time}"
   puts url if opts.debug
-  response = RestClient.get( url, {
-    "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
-    "User-Agent" => "iNaturalist/Donorbox"
-  } )
+  response = try_and_try_again( RestClient::TooManyRequests, exponential_backoff: true, sleep: 3 ) do
+    RestClient.get( url, {
+      "Authorization" => "Basic #{Base64.strict_encode64( "#{donorbox_email}:#{donorbox_key}" ).strip}",
+      "User-Agent" => "iNaturalist/Donorbox"
+    } )
+  end
   json = JSON.parse( response )
   break if json.size.zero?
 


### PR DESCRIPTION
Closes WEB-638

Also

* backoff behavior for donorbox scripts; they may not have been working
  reliably without this
* fixed bug where targeting unconfirmed users was blocking last obs date
  filters from working