### PR TITLE
Remove orphan deleted observations from index

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -378,12 +378,25 @@ class ApplicationController < ActionController::Base
     unless request.format.json?
       request.format = "html"
     end
-    respond_to do |format|
-      format.json { render json: { error: t(:not_found) }, status: 404 }
+    respond_to do | format |
+      format.json { render json: { error: t( :not_found ) }, status: 404 }
       format.all { render template: "errors/error_404", status: 404, layout: "application" }
     end
   end
-  
+
+  #
+  # Return a 410 response with our default 404 page
+  #
+  def render_410
+    unless request.format.json?
+      request.format = "html"
+    end
+    respond_to do | format |
+      format.json { render json: { error: t( :not_found ) }, status: 410 }
+      format.all { render template: "errors/error_404", status: 410, layout: "application" }
+    end
+  end
+
   #
   # Redirect user to front page when they do something naughty.
   #

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2952,6 +2952,7 @@ class Observation < ApplicationRecord
   def create_deleted_observation
     DeletedObservation.create(
       observation_id: id,
+      observation_uuid: uuid,
       user_id: user_id,
       observation_created_at: created_at
     )

--- a/db/migrate/20250328144900_add_uuid_to_deleted_observations.rb
+++ b/db/migrate/20250328144900_add_uuid_to_deleted_observations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUuidToDeletedObservations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :deleted_observations, :observation_uuid, :uuid
+    add_index :deleted_observations, :observation_uuid
+    add_index :deleted_observations, :observation_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1304,7 +1304,8 @@ CREATE TABLE public.deleted_observations (
     observation_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    observation_created_at timestamp without time zone
+    observation_created_at timestamp without time zone,
+    observation_uuid uuid
 );
 
 
@@ -8623,6 +8624,20 @@ CREATE INDEX index_delayed_jobs_on_unique_hash ON public.delayed_jobs USING btre
 
 
 --
+-- Name: index_deleted_observations_on_observation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_deleted_observations_on_observation_id ON public.deleted_observations USING btree (observation_id);
+
+
+--
+-- Name: index_deleted_observations_on_observation_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_deleted_observations_on_observation_uuid ON public.deleted_observations USING btree (observation_uuid);
+
+
+--
 -- Name: index_deleted_observations_on_user_id_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11506,6 +11521,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250311212144'),
 ('20250311225953'),
 ('20250326223846'),
-('20250327191619');
+('20250327191619'),
+('20250328144900');
 
 


### PR DESCRIPTION
* When visiting observation details pages, using IDs or UUIDs, if the observations have been deleted from the database but are still in Elasticsearch for some reason, remove them from Elasticsearch
* Observation details pages return a 410 instead of a 404 when we know the observation once existed but has since been deleted
* Adds migration to add observation UUID to DeletedObservations, and indexes it as well as indexes the existing observation ID column for more efficient deleted observation lookups