### PR TITLE
fix: use Com Taxon presence to mark DQA as has ID supported by 2 or more

### DIFF
--- a/app/webpack/observations/show/components/quality_metrics.jsx
+++ b/app/webpack/observations/show/components/quality_metrics.jsx
@@ -281,7 +281,6 @@ class QualityMetrics extends React.Component {
       observation.taxon
       && observation.taxon.rank_level < 30
     );
-    const mostAgree = observation.identifications_most_agree;
     let locationSpecified = false;
     if ( observation.geojson ) {
       locationSpecified = true;
@@ -372,8 +371,8 @@ class QualityMetrics extends React.Component {
                 <i className="fa icon-identification" />
                 { I18n.t( "has_id_supported_by_two_or_more" ) }
               </td>
-              <td className="agree">{ mostAgree ? checkIcon : null }</td>
-              <td className="disagree">{ mostAgree ? null : xIcon }</td>
+              <td className="agree">{ observation.communityTaxon ? checkIcon : null }</td>
+              <td className="disagree">{ observation.communityTaxon ? null : xIcon }</td>
             </tr>
             <tr className={( dateCells.loading || dateVoteDisabled ) ? "disabled" : ""}>
               <td className="metric_title">


### PR DESCRIPTION
I thought #4473 would fix [WEB-612](https://linear.app/inaturalist/issue/WEB-612), but as I was trying to update the data, I realized that while we were using `num_identification_agreements` to control the offending part of the DQA, we don't actually use that to set the quality grade, b/c the quality grade concerns the Community Taxon, and `num_identification_agreements` concerns the Observation Taxon. So an obs might have an Observation Taxon of _Abra cadabra dubius_ b/c of an ID sequence like this:

Observation: _Abra cadabra dubius_
User A: _Abra cadabra_
User B: _Abra cadabra_

but the Community Taxon is _Abra cadabra_. Since `num_identification_agreements` is relative to the Observation Taxon its value is 0 (no one agrees with the observer), but the obs is Research Grade b/c it has a Community Taxon at species-level.

This PR changes the display of the DQA to match what actually goes into determining Research Grade status: the presence of a Community Taxon.