### PR TITLE
fix: prevent stale updates to current obs in Identify

### DIFF
--- a/app/webpack/observations/identify/actions/current_observation_actions.js
+++ b/app/webpack/observations/identify/actions/current_observation_actions.js
@@ -294,10 +294,11 @@ function receiveCurrentObservation( observation, others ) {
   } );
 }
 
-function updateCurrentObservation( updates ) {
+function updateCurrentObservation( updates, options = { } ) {
   return Object.assign( { }, {
     type: UPDATE_CURRENT_OBSERVATION,
-    updates
+    updates,
+    observation_id: options.observation_id
   } );
 }
 
@@ -637,7 +638,7 @@ function stopLoadingDiscussionItem( item ) {
   return { type: STOP_LOADING_DISCUSSION_ITEM, item };
 }
 
-export function addAnnotation( controlledAttribute, controlledValue ) {
+export function addAnnotation( controlledAttribute, controlledValue, options = {} ) {
   return ( dispatch, getState ) => {
     const state = getState( );
     const newAnnotations = ( state.currentObservation.observation.annotations || [] ).concat( [{
@@ -649,7 +650,10 @@ export function addAnnotation( controlledAttribute, controlledValue ) {
     dispatch( updateSession( {
       prefers_hide_identify_annotations: false
     } ) );
-    dispatch( updateCurrentObservation( { annotations: newAnnotations } ) );
+    dispatch( updateCurrentObservation(
+      { annotations: newAnnotations },
+      { observation_id: state.currentObservation.observation.id }
+    ) );
 
     const payload = {
       resource_type: "Observation",

--- a/app/webpack/observations/identify/reducers/current_observation_reducer.js
+++ b/app/webpack/observations/identify/reducers/current_observation_reducer.js
@@ -63,6 +63,14 @@ const currentObservationReducer = ( state = { tab: "info" }, action ) => {
       } );
     }
     case UPDATE_CURRENT_OBSERVATION:
+      // If for some reason we're reducing an attempt to update the current
+      // observation but the request was made when the current observation
+      // was *different*, just bail. Potential workaround for
+      // https://github.com/inaturalist/inaturalist/issues/4478 which I can't
+      // replicate. ~~~~kueda 20250304
+      if ( action.observation_id && action.observation_id !== state.observation.id ) {
+        return state;
+      }
       return Object.assign( {}, state, {
         observation: Object.assign( {}, state.observation, action.updates )
       }, action.updates );


### PR DESCRIPTION
Potentially fixes WEB-688 / #4478 in which annotations for previously viewed observations appear in Identify, particularly under slow network conditions.

I can't replicate that bug, so I'm just working on the theory that there are attempts to update the current observation that happen after very slow network requests.