### PR TITLE
refactor: more actions and DJs use replica and more association loading

### DIFF
--- a/app/controllers/identifications_controller.rb
+++ b/app/controllers/identifications_controller.rb
@@ -52,7 +52,7 @@ class IdentificationsController < ApplicationController
         :user,
         { taxon: [
           { taxon_names: :place_taxon_names },
-          { photos: [:flags, :file_prefix,] }
+          { photos: [:flags, :file_prefix] }
         ] }
       ).order(id: :desc)
     Observation.preload_for_component(ids.map(&:observation), logged_in: logged_in?)

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -15,7 +15,7 @@ class ListsController < ApplicationController
   before_action :load_user_by_login, :only => :by_login
   before_action :admin_required, :only => [:add_from_observations_now, :refresh_now]
   before_action :set_iconic_taxa, :only => [:show]
-  prepend_around_action :enable_replica, only: [:by_login]
+  prepend_around_action :enable_replica, only: [:show, :by_login]
 
   caches_page :show, :if => Proc.new {|c| c.request.format == :csv}
 

--- a/app/controllers/shared/lists_module.rb
+++ b/app/controllers/shared/lists_module.rb
@@ -156,7 +156,7 @@ module Shared::ListsModule
         ListedTaxon.preload_associations(@listed_taxa, [
           { taxon: [
             { taxon_names: :place_taxon_names },
-            { photos: [:user, :flags, :file_prefix, :file_extension] },
+            { photos: [:user, :flags, :file_prefix, :file_extension, :moderator_actions] },
             :taxon_descriptions
           ]}
         ])
@@ -455,7 +455,7 @@ private
         :list, :user, :first_observation, :last_observation,
         { taxon: [
           :iconic_taxon,
-          { photos: [:flags, :file_prefix, :file_extension] },
+          { photos: [:flags, :file_prefix, :file_extension, :moderator_actions] },
           { taxon_names: :place_taxon_names }
         ] }
       ]

--- a/lib/dj_makara_plugin.rb
+++ b/lib/dj_makara_plugin.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 # only allow certain jobs to query replicas
 def job_can_use_replica( job )
   return true if job.handler_yaml.is_a?( ObservationsExportFlowTask )
-  unless job.handler_yaml.respond_to?(:object) && job.handler_yaml.respond_to?(:method_name)
+  unless job.handler_yaml.respond_to?( :object ) && job.handler_yaml.respond_to?( :method_name )
     return false
   end
+
   class_name = ( job.handler_yaml.object.kind_of?( ActiveRecord::Base ) ?
     job.handler_yaml.object.class.name : job.handler_yaml.object.name ) rescue nil
   object_method = "#{class_name}::#{job.handler_yaml.method_name}"
@@ -13,38 +16,38 @@ def job_can_use_replica( job )
   return true if object_method == "Identification::notify_subscribers_of"
   return true if object_method == "Identification::run_update_curator_identification"
   return true if object_method == "Identification::update_categories_for_observation"
+  return true if object_method == "Observation::elastic_index!"
   return true if object_method == "Observation::notify_subscribers_of"
   return true if object_method == "Observation::update_stats_for_observations_of"
+  return true if object_method == "Observation::user_viewed_updates"
   return true if object_method == "ProjectUser::update_taxa_obs_and_observed_taxa_count_after_update_observation"
   return true if object_method == "Taxon::elastic_index!"
   return true if object_method == "Taxon::update_observation_counts"
   return true if object_method == "UpdateAction::email_updates_to_user"
+  return true if object_method == "UserPrivilege::check"
+
   false
 end
 
 class DJMakaraPlugin < Delayed::Plugin
-
-  callbacks do |lifecycle|
-
-    lifecycle.around(:invoke_job) do |job, *args, &block|
-      using_replica = job_can_use_replica(job)
+  callbacks do | lifecycle |
+    lifecycle.around( :invoke_job ) do | job, *args, &block |
+      using_replica = job_can_use_replica( job )
       begin
-        if using_replica && ActiveRecord::Base.connection.respond_to?(:enable_context_refresh)
+        if using_replica && ActiveRecord::Base.connection.respond_to?( :enable_context_refresh )
           # enable use of replica DBs
           ActiveRecord::Base.connection.enable_replica
           ActiveRecord::Base.connection.enable_context_refresh
           Makara::Context.release_all
         end
-        block.call(job, *args)
+        block.call( job, *args )
       ensure
-        if using_replica && ActiveRecord::Base.connection.respond_to?(:enable_context_refresh)
+        if using_replica && ActiveRecord::Base.connection.respond_to?( :enable_context_refresh )
           ActiveRecord::Base.connection.disable_replica
           ActiveRecord::Base.connection.disable_context_refresh
           Makara::Context.release_all
         end
       end
     end
-
   end
-
 end


### PR DESCRIPTION
* allow more endpoint to query replica DB
* allow more DJ to start off by querying replica DB
* preload more associations for some endpoints that were generating a lot of queries