### PR TITLE
refactor: simplify identifications index on observation_id

### DIFF
--- a/db/migrate/20250409212827_alter_identifications_indices.rb
+++ b/db/migrate/20250409212827_alter_identifications_indices.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AlterIdentificationsIndices < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :identifications, [:observation_id, :created_at]
+    add_index :identifications, :observation_id
+  end
+
+  def down
+    remove_index :identifications, :observation_id
+    add_index :identifications, [:observation_id, :created_at]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -8964,10 +8964,10 @@ CREATE INDEX index_identifications_on_created_at ON public.identifications USING
 
 
 --
--- Name: index_identifications_on_observation_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_identifications_on_observation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_identifications_on_observation_id_and_created_at ON public.identifications USING btree (observation_id, created_at);
+CREATE INDEX index_identifications_on_observation_id ON public.identifications USING btree (observation_id);
 
 
 --
@@ -11530,6 +11530,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250326223846'),
 ('20250327191619'),
 ('20250328144900'),
-('20250404192042');
+('20250404192042'),
+('20250409212827');
 
 


### PR DESCRIPTION
Replace an index on both `observation_id` and `created_at` with an index on only `observation_id`