### PR TITLE
refactor: reduce number of ES queries needed for notify_subscribers_with

### DIFF
--- a/app/models/update_action.rb
+++ b/app/models/update_action.rb
@@ -269,12 +269,43 @@ class UpdateAction < ApplicationRecord
     UpdateAction.where(*args).delete_all
   end
 
-  def self.first_with_attributes( attrs, options = { } )
+  def self.for_notifier( notifier )
+    update_actions = UpdateAction.elastic_paginate(
+      page: 1,
+      per_page: 100,
+      filters: [
+        { term: { notifier_type: notifier.class.to_s } },
+        { term: { notifier_id: notifier.id } }
+      ],
+      sort: { id: :desc },
+      keep_es_source: true
+    )
+    UpdateAction.preload_associations( update_actions, :notifier )
+    update_actions
+  end
+
+  def self.first_with_attributes( attrs, options = {} )
     return if CONFIG.has_subscribers == :disabled
     skip_validations = options.delete( :skip_validations )
+
+    options[:candidate_update_actions]&.each do | candidate |
+      is_match = attrs.all? do | k, v |
+        if k.to_sym == :resource
+          candidate.resource_id == v.id &&
+            candidate.resource_type == v.class.base_class.name
+        elsif k.to_sym == :notifier
+          candidate.notifier_id == v.id &&
+            candidate.notifier_type == v.class.base_class.name
+        else
+          candidate[k] == v.try( :id ) || v
+        end
+      end
+      return candidate if is_match
+    end
+
     filters = UpdateAction.arel_attributes_to_es_filters( attrs )
     # first search for a doc in Elasticsearch with these attributes
-    if es_action = UpdateAction.elastic_paginate( filters: filters, keep_es_source: true ).first
+    if ( es_action = UpdateAction.elastic_paginate( filters: filters, keep_es_source: true ).first )
       return es_action
     end
     # if none are found, see if one exists in the DB
@@ -288,7 +319,8 @@ class UpdateAction < ApplicationRecord
     end
     # no match was found in Elasticsearch or the DB, so attempt to create it
     begin
-      action = UpdateAction.new( attrs.merge(created_at: Time.now, skip_indexing: true ).merge( options ) )
+      action = UpdateAction.new( attrs.merge( created_at: Time.now, skip_indexing: true ).
+        merge( options.except( :candidate_update_actions ) ) )
       if !action.save( validate: !skip_validations )
         return
       end


### PR DESCRIPTION
This modifies `HasSubscribers::notify_subscribers_with` which is the HasSubscribers method we spend the most processing time on. We were already fetching all UpdateActions for a notifier, then making subsequent more specific requests with more filters for each subscribable, when we might have the information on hand from the earlier call. The change made is to leverage already fetched Elasticsearch records when possible, saving an ES query each subscribable, otherwise the original logic will be used 