### PR TITLE
fix: update hardcoded iNat Next oauth name

### DIFF
--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -26,7 +26,7 @@ class OauthApplication < Doorkeeper::Application
   ANDROID_APP_NAME = "iNaturalist Android App"
   IPHONE_APP_NAME = "iNaturalist iPhone App"
   SEEK_APP_NAME = "Seek"
-  INAT_NEXT_APP_NAME = "iNat Next"
+  INAT_NEXT_APP_NAME = "iNaturalist (iNat Next)"
 
   def redirect_uri_has_no_params
     if redirect_uri.to_s.split( "?" ).size > 1


### PR DESCRIPTION
Apparently, the stats page is using the name of the oauth application as label and category. The name of the oauth application for iNatNext was changed yesterday in line with the app rename. So, this needs an update.
Maybe a better approach would be to use the oauth application id instead of the name but I am not comfortable enough in this codebase to do that.