### PR TITLE
fix: prevent places w/ slugs w/ leading numbers from being suggested

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -85,6 +85,9 @@ class Place < ApplicationRecord
     if Place.where( slug: candidate ).exists? && !display_name.blank?
       candidate = display_name.parameterize
     end
+    if candidate.to_i.positive?
+      candidate = string.gsub( /^[0-9]+/, "" ).downcase
+    end
     candidate
   end
 

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -566,3 +566,11 @@ describe Place, "localized_name" do
     end
   end
 end
+
+describe Place, "normalize_friendly_id" do
+  it "does not suggest a number as a slug from a number w/ chars that get removed by parameterize" do
+    place = build :place, name: "賞蝶識花山行健", display_name: "2021 賞蝶識花山行健"
+    expect( place.normalize_friendly_id( place.name ).to_i ).to eq 0
+    expect( place.normalize_friendly_id( place.display_name ).to_i ).to eq 0
+  end
+end


### PR DESCRIPTION
Affected places will need to have their slugs updated after this is merged.

WEB-679