### PR TITLE
Notification delay and priority updates

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -10,8 +10,10 @@ class Observation < ApplicationRecord
     :comments => {:notification => "activity", :include_owner => true},
     :identifications => {:notification => "activity", :include_owner => true}
   }
-  notifies_subscribers_of :user, :notification => "created_observations",
-    unless: lambda {| observation | observation.bulk_import }
+  notifies_subscribers_of :user,
+    delay: false,
+    notification: "created_observations",
+    unless: lambda( &:bulk_import )
 
   earns_privilege UserPrivilege::SPEECH
   earns_privilege UserPrivilege::ORGANIZER
@@ -25,6 +27,7 @@ class Observation < ApplicationRecord
   notifies_subscribers_of :public_places,
     notification: "new_observations",
     on: :create,
+    priority: USER_INTEGRITY_PRIORITY,
     unless: lambda {| observation |
       !observation.georeferenced? || observation.bulk_import
     },
@@ -45,6 +48,7 @@ class Observation < ApplicationRecord
     }
   notifies_subscribers_of :taxon_and_ancestors,
     notification: "new_observations",
+    priority: USER_INTEGRITY_PRIORITY,
     unless: lambda {| observation |
       observation.taxon_id.blank? || observation.bulk_import
     },
@@ -57,13 +61,14 @@ class Observation < ApplicationRecord
   notifies_users :mentioned_users,
     on: :save,
     notification: "mention",
-    delay: true,
-    if: lambda {|u| u.prefers_receive_mentions? },
-    unless: lambda { |observation|
+    delay: false,
+    if: lambda( &:prefers_receive_mentions? ),
+    unless: lambda {| observation |
       # description hasn't changed, so mentions haven't changed
       return true unless observation.previous_changes[:description]
+
       # description has changed, but neither version mentioned users
-      observation.previous_changes[:description].map do |d|
+      observation.previous_changes[:description].map do | d |
         d ? d.mentioned_users.any? : false
       end.none?
     }
@@ -1274,32 +1279,35 @@ class Observation < ApplicationRecord
     end
     assign_nested_attributes_for_collection_association(:observation_field_values, attr_array)
   end
-  
+
   def refresh_check_lists
     return true if skip_refresh_check_lists
+
     changing_quality_grade = will_save_change_to_quality_grade? || saved_change_to_quality_grade?
     changing_taxon_id = will_save_change_to_taxon_id? || saved_change_to_taxon_id?
     changing_latitude = will_save_change_to_latitude? || saved_change_to_latitude?
     changing_longitude = will_save_change_to_longitude? || saved_change_to_longitude?
     changing_observed_on = will_save_change_to_observed_on? || saved_change_to_observed_on?
-    refresh_needed = (georeferenced? || was_georeferenced?) && 
-      ( taxon_id || taxon_id_before_last_save) &&
+    refresh_needed = ( georeferenced? || was_georeferenced? ) &&
+      ( taxon_id || taxon_id_before_last_save ) &&
       ( changing_quality_grade ||
         changing_taxon_id ||
         changing_latitude ||
         changing_longitude ||
         changing_observed_on )
     return true unless refresh_needed
-    CheckList.delay(priority: INTEGRITY_PRIORITY, queue: "slow",
-      unique_hash: { "CheckList::refresh_with_observation": id }).
-      refresh_with_observation(id, :taxon_id => taxon_id,
-        :taxon_id_was  => saved_change_to_taxon_id? ? taxon_id_before_last_save : nil,
-        :latitude_was  => saved_change_to_latitude? ? latitude_before_last_save : nil,
-        :longitude_was => saved_change_to_longitude? ? longitude_before_last_save : nil,
-        :new => saved_change_to_id? )
+
+    CheckList.refresh_with_observation(
+      self,
+      taxon_id: taxon_id,
+      taxon_id_was: saved_change_to_taxon_id? ? taxon_id_before_last_save : nil,
+      latitude_was: saved_change_to_latitude? ? latitude_before_last_save : nil,
+      longitude_was: saved_change_to_longitude? ? longitude_before_last_save : nil,
+      new: saved_change_to_id?
+    )
     true
   end
-  
+
   #
   # Preserve the old taxon id if the taxon has changed so we know to update
   # that taxon in the user's lists after_save

--- a/spec/models/listed_taxon_spec.rb
+++ b/spec/models/listed_taxon_spec.rb
@@ -112,12 +112,14 @@ describe ListedTaxon do
           expect(@last_observation.places).to include @place
         end
         it "should set first observation to the first research grade observation added" do
-          lt = without_delay { ListedTaxon.make!(:list => @check_list, :place => @place, :taxon => @taxon) }
-          expect(lt.first_observation).to eq @first_observation
+          Delayed::Worker.new.work_off
+          lt = ListedTaxon.where( list: @check_list, place: @place, taxon: @taxon ).first
+          expect( lt.first_observation ).to eq @first_observation
         end
         it "should set last observation to the last research grade observation observed" do
-          lt = without_delay { ListedTaxon.make!(:list => @check_list, :place => @place, :taxon => @taxon) }
-          expect(lt.last_observation).to eq @last_observation
+          Delayed::Worker.new.work_off
+          lt = ListedTaxon.where( list: @check_list, place: @place, taxon: @taxon ).first
+          expect( lt.last_observation ).to eq @last_observation
         end
       end
 
@@ -377,12 +379,9 @@ describe ListedTaxon do
     it "should set first observation to obs of desc taxa" do
       subspecies = Taxon.make!(:rank => Taxon::SUBSPECIES, :parent => @taxon)
       o = make_research_grade_observation(:taxon => subspecies, :latitude => @place.latitude, :longitude => @place.longitude)
-      lt = ListedTaxon.make!(:list => @check_list, :place => @place, :taxon => @taxon)
-      without_delay do
-        ListedTaxon.update_cache_columns_for(lt)
-      end
-      lt.reload
-      expect(lt.first_observation_id).to eq o.id
+      Delayed::Worker.new.work_off
+      lt = ListedTaxon.where( list: @check_list, place: @place, taxon: @taxon ).first
+      expect( lt.first_observation_id ).to eq o.id
     end
   end
 


### PR DESCRIPTION
* Observation notify subscribers of user and notify mentioned users are not longer delayed as they are fast tasks and using delayed jobs can add an unnecessary amount of overhead
* Observation triggering of CheckList.refresh_with_observation is also no longer delayed. This is a job that queues other jobs and is generally quite fast
* Decrease priority of Observation notify subscribers of places and taxa. These jobs are not as important as say notifying users of identification updates, so they can have a lower priority
* In has_subscribers, change order of operations to lookup existing update actions only when there may be users to notify. This can save time for tasks like notify subscribers of user when there are no subscribers to the given user