### PR TITLE
new admin tool to replace an account name

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -68,6 +68,38 @@ class UsersController < ApplicationController
     }
   cache_sweeper :user_sweeper, :only => [:update]
 
+  def replace_username
+    @user = User.find(params[:id])
+    new_username = nil
+    i = 1
+    loop do
+      candidate = "naturalist#{i.to_s.rjust(4, '0')}"
+      unless User.exists?(login: candidate)
+        new_username = candidate
+        break
+      end
+      i += 1
+    end
+    if new_username
+      old_username = @user.login
+      begin
+        ModeratorAction.create!(
+          user: current_user,
+          resource: @user,
+          action: ModeratorAction::REPLACEUSERNAME,
+          reason: "Username changed from #{old_username} to #{new_username}",
+          resource_content: new_username
+        )
+
+        flash[:notice] = "Username successfully replaced with #{new_username}"
+      rescue ActiveRecord::RecordInvalid => e
+        flash[:alert] = flash[:alert] =  e.message
+      end
+    else
+      flash[:error] = "Failed to generate a unique username"
+    end
+    redirect_to user_detail_admin_path(id: params[:id])
+  end
   def suspend
     if @user.suspended?
       flash[:error] = "You cannot suspend someone who is already suspended"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   acts_as_voter
   acts_as_spammable fields: [:description],
     comment_type: "signup"
-  has_moderator_actions %w(suspend unsuspend)
+  has_moderator_actions %w(suspend unsuspend replaceUsername)
 
   # If the user has this role, has_role? will always return true
   JEDI_MASTER_ROLE = "admin"
@@ -1590,6 +1590,11 @@ class User < ApplicationRecord
       self.spammer = false
       self.suspended_by_user = nil
       unsuspend!
+    elsif moderator_action.action == ModeratorAction::REPLACEUSERNAME
+      new_login = moderator_action.resource_content.to_s.strip
+      return if new_login.blank? || User.exists?(login: new_login)
+      self.login = new_login
+      save!
     end
   end
 

--- a/app/views/admin/user_detail.html.haml
+++ b/app/views/admin/user_detail.html.haml
@@ -37,10 +37,15 @@
       } );
     } );
 = content_for :extracss do
+  :javascript
+    $('#replaceusername').on('shown.bs.modal', function () {
+      $('.modal-footer .btn-danger', this).focus()
+    })
   :css
     .dropdown-menu.site-admins li {
       padding: 3px 10px;
     }
+
 .container
   .row
     .col-xs-12
@@ -295,6 +300,8 @@
         = link_to t(:flag_as_non_spammer), set_spammer_path(@display_user, spammer: false), |
           method: :post, data: { confirm: t(:are_you_sure_you_want_to_remove_spammer) },  |
           class: "btn btn-block btn-success"
+      = link_to "#replaceusername", "data-toggle" => "modal", class: "btn btn-block btn-warning" do
+        = t(:moderator_actions_replaceUsername)
       %hr
       - if !@display_user.confirmed? || @display_user.unconfirmed_email?
         = link_to "Confirm user email", admin_update_user_path( @display_user.id, confirm: true ), method: :put,
@@ -379,3 +386,17 @@
             = text_field_tag :reject_user_name, "", class: "form-control", placeholder: "User to delete", data: { "1p_ignore" =>  true }
             = hidden_field_tag :reject_user_id
           = submit_tag "Merge Into #{@display_user.login}", class: "btn btn-danger", data: { confirm: "This will delete the user you just chose and move all their content over to #{@display_user.login}. This can't be undone. Proceed?" }
+#replaceusername.modal.fade
+  .modal-dialog{ role: "document" }
+    .modal-content
+      = form_tag replace_username_admin_user_path(@display_user), method: :put do
+        .modal-header
+          %button.close{ type: "button", "data-dismiss" => "modal" } ×
+          %h4.modal-title= t(:moderator_actions_replaceUsername)
+        .modal-body
+          %p
+            = t(:replace_user_name_admin_explanation)
+            %code naturalistXXXX
+        .modal-footer
+          %button.btn.btn-default{ type: "button", "data-dismiss" => "modal" }= t(:cancel)
+          %button.btn.btn-danger{ type: "submit" }= "Yes, replace"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3180,6 +3180,8 @@ en:
     to that person.
   # Action a moderator can take to hide content; verb
   moderator_actions_hide: Hide
+  #Label for a button to replace username of an user from the admin page
+  moderator_actions_replaceUsername: Replace Username
   # Action a moderator can take to unhide content, i.e. undo hiding; verb
   moderator_actions_unhide2: Unhide
   # Action a moderator can take to suspend a user; verb
@@ -4956,6 +4958,10 @@ en:
   repair_external_photos: Repair External Photos
   replace_boundary_with_kml: Replace boundary with KML
   replace_parentesis: (replace)
+  # Label for a button that confirms the replacement of the userName
+  replace_user_name_admin_confirmation: Yes, replace
+  # Message displayed in the modal of replacement of the userName as explanation of the action
+  replace_user_name_admin_explanation: Are you sure you want to replace this user's username with an anonymized one? This cannot be undone. The new username will look like
   reply: Reply
   reptiles: reptiles
   request_failed: "Request Failed"
@@ -10280,6 +10286,8 @@ en:
               # a ModeratorAction with action Hide
               only_staff_and_curators_can_hide: Only staff and curators can hide content
               only_staff_and_hiding_curators_can_unhide: Only staff and curators who hide content can unhide it
+              # Error saying that only staff can replace userName
+              only_staff_can_replace_username: Only staff can replace userName
               # Error saying that only staff can set resources as private
               only_staff_can_make_private: Only staff can set content as private
               staff_cannot_be_suspended: Staff cannot be suspended

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,6 +230,7 @@ Rails.application.routes.draw do
   get "/users/:id/suspend" => "users#suspend", :as => :suspend_user, :constraints => { id: /\d+/ }
   get "/users/:id/unsuspend" => "users#unsuspend", :as => :unsuspend_user, :constraints => { id: /\d+/ }
   post "users/:id/add_role" => "users#add_role", :as => :add_role, :constraints => { id: /\d+/ }
+  put "users/:id/replace_username" => "users#replace_username", :as => :replace_username_admin_user, :constraints => { id: /\d+/ }
   post "users/set_spammer" => "users#set_spammer"
   post "users/:id/set_spammer" => "users#set_spammer", :as => :set_spammer, :constraints => { id: /\d+/ }
   delete "users/:id/remove_role" => "users#remove_role", :as => :remove_role, :constraints => { id: /\d+/ }

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -262,7 +262,30 @@ describe ModeratorAction do
         expect( u ).not_to be_suspended
       end
     end
+    describe "REPLACENAME" do
+      let( :user ) { create( :user, login: "old_login" ) }
+      let( :new_login ) { "new_login" }
+      let( :action ) do
+        create( :moderator_action, action: ModeratorAction::REPLACEUSERNAME, resource: user, user: admin,
+          reason: generic_reason )
+      end
 
+      it "should replace the login for a user and persist the action when admin performs it" do
+        user.update!( login: new_login )
+        action
+        user.reload
+        expect( user.login ).to eq( new_login )
+        expect( action ).to be_persisted
+        expect( action.action ).to eq( ModeratorAction::REPLACEUSERNAME )
+        expect( action.reason ).to eq( generic_reason )
+      end
+
+      it "should not allow a non-admin user to replace the login" do
+        action = build( :moderator_action, action: ModeratorAction::REPLACEUSERNAME, resource: user, user: User.make!,
+          reason: generic_reason )
+        expect( action ).not_to be_valid
+      end
+    end
     describe "set_resource_user_id" do
       it "is set properly for Comments" do
         comment = Comment.make!


### PR DESCRIPTION
This is my largest PR so far, so feel free to request any changes or improvements you think are necessary.

I've opted to add this change to the moderation history as I believe such a modification should be traceable. If you have any suggestions or alternative ideas on how this could be implemented better, I'm more than happy to hear them!

![image](https://github.com/user-attachments/assets/079c64c5-a4a5-4532-9a0e-41f680a25658)
![image](https://github.com/user-attachments/assets/6cc8a868-542f-460f-aeda-a1644f024a64)
![image](https://github.com/user-attachments/assets/8e44876f-a6da-434b-86d1-f9b56a0e12af)
