### PR TITLE
fix: restrict 410 responses for obs to GET requests

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -2964,8 +2964,11 @@ class ObservationsController < ApplicationController
       unless Observation.where( id: deleted_observation.observation_id ).exists?
         Observation.elastic_delete_by_ids!( [deleted_observation.observation_id] )
       end
-      render_410
-      return
+      # Temporary workaround for clients that are hard-coded to expect a 404
+      if request.get?
+        render_410
+        return
+      end
     end
     render_404
   end


### PR DESCRIPTION
Unforuntately the iNat iOS app is hard-coded to expect 404 responses when DELETEing obs that no longer exist, so until we can update that we should continue to respond with 404.

WEB-562