### PR TITLE
fix: prevent user settings from going blank after deleting email & username

### DIFF
--- a/app/webpack/users/edit/components/profile.jsx
+++ b/app/webpack/users/edit/components/profile.jsx
@@ -44,7 +44,7 @@ const Profile = ( {
 
   // this gets rid of the React warning about inputs being controlled vs. uncontrolled
   // by ensuring user data is fetched before the Profile & User page loads
-  if ( !profile.login && !profile.email ) {
+  if ( _.isEmpty( profile ) ) {
     return null;
   }
 


### PR DESCRIPTION
fix: #4540
![image](https://github.com/user-attachments/assets/98424342-fc00-41f1-9b53-363763f8e956)