### PR TITLE
fix: ensure license changes happen in a delayed job

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -675,15 +675,12 @@ class User < ApplicationRecord
   end
 
   def update_photo_licenses
-    puts "update_photo_licenses, preferred_photo_license: #{preferred_photo_license}"
     license_number = Photo.license_number_for_code( preferred_photo_license )
-    puts "update_photo_licenses, license_number: #{license_number}"
     return true unless license_number
 
     Photo.where( "user_id = ? AND type != 'GoogleStreetViewPhoto'", id ).
       update_all( license: license_number, updated_at: Time.now )
     index_observations
-    puts "update_photo_licenses, enqueing photo bucket moving jobs"
     User.enqueue_photo_bucket_moving_jobs( id )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,9 +288,9 @@ class User < ApplicationRecord
   before_save :set_pi_consent_at
   before_save :set_data_transfer_consent_at
   before_save :set_locale
-  after_save :update_observation_licenses
-  after_save :update_photo_licenses
-  after_save :update_sound_licenses
+  after_save :update_observation_licenses_later
+  after_save :update_photo_licenses_later
+  after_save :update_sound_licenses_later
   after_save :update_observation_sites_later
   after_save :destroy_messages_by_suspended_user
   after_save :send_messages_by_unsuspended_user
@@ -649,35 +649,60 @@ class User < ApplicationRecord
       detect{ |pa| pa.provider_name == "orcid" }.try( :provider_uid )
   end
 
-  def update_observation_licenses
-    return true unless [true, "1", "true"].include?(@make_observation_licenses_same)
-    Observation.where( user_id: id ).
-      update_all( license: preferred_observation_license, updated_at: Time.now )
-    index_observations_later
-    true
+  def update_observation_licenses_later
+    return true unless [true, "1", "true"].include?( @make_observation_licenses_same )
+
+    delay(
+      priority: USER_INTEGRITY_PRIORITY,
+      unique_hash: { "User::update_observation_licenses_later": id },
+      queue: "throttled"
+    ).update_observation_licenses
   end
-  
-  def update_photo_licenses
+
+  def update_observation_licenses
+    Observation.where( user_id: id ).update_all( license: preferred_observation_license, updated_at: Time.now )
+    index_observations
+  end
+
+  def update_photo_licenses_later
     return true unless [true, "1", "true"].include?( @make_photo_licenses_same )
-    number = Photo.license_number_for_code( preferred_photo_license )
-    return true unless number
+
+    delay(
+      priority: USER_INTEGRITY_PRIORITY,
+      unique_hash: { "User::update_photo_licenses": id },
+      queue: "throttled"
+    ).update_photo_licenses
+  end
+
+  def update_photo_licenses
+    puts "update_photo_licenses, preferred_photo_license: #{preferred_photo_license}"
+    license_number = Photo.license_number_for_code( preferred_photo_license )
+    puts "update_photo_licenses, license_number: #{license_number}"
+    return true unless license_number
+
     Photo.where( "user_id = ? AND type != 'GoogleStreetViewPhoto'", id ).
-      update_all( license: number, updated_at: Time.now )
-    index_observations_later
-    User.delay(
-      queue: "photos",
-      unique_hash: { "User::enqueue_photo_bucket_moving_jobs": id }
-    ).enqueue_photo_bucket_moving_jobs( id )
-    true
+      update_all( license: license_number, updated_at: Time.now )
+    index_observations
+    puts "update_photo_licenses, enqueing photo bucket moving jobs"
+    User.enqueue_photo_bucket_moving_jobs( id )
+  end
+
+  def update_sound_licenses_later
+    return true unless [true, "1", "true"].include?( @make_sound_licenses_same )
+
+    delay(
+      priority: USER_INTEGRITY_PRIORITY,
+      unique_hash: { "User::update_sound_licenses": id },
+      queue: "throttled"
+    ).update_sound_licenses
   end
 
   def update_sound_licenses
-    return true unless [true, "1", "true"].include?(@make_sound_licenses_same)
-    number = Photo.license_number_for_code(preferred_sound_license)
-    return true unless number
-    Sound.where( user_id: id ).update_all( license: number, updated_at: Time.now )
-    index_observations_later
-    true
+    license_number = Photo.license_number_for_code( preferred_sound_license )
+    return true unless license_number
+
+    Sound.where( user_id: id ).update_all( license: license_number, updated_at: Time.now )
+    index_observations
   end
 
   def update_observation_sites_later

--- a/app/webpack/users/edit/components/checkbox_row.jsx
+++ b/app/webpack/users/edit/components/checkbox_row.jsx
@@ -56,7 +56,7 @@ const CheckboxRow = ( {
             </button>
           </div>
         ) }
-        { description && typeof ( description ) === "string" && (
+        { typeof ( description ) === "string" && (
           <div className="checkbox-description-margin">
             <p
               className="text-muted"
@@ -65,7 +65,7 @@ const CheckboxRow = ( {
             />
           </div>
         ) }
-        { description && typeof ( description ) === "object" && (
+        { typeof ( description ) === "object" && (
           <div className="checkbox-description-margin">
             { description }
           </div>

--- a/app/webpack/users/edit/components/content.jsx
+++ b/app/webpack/users/edit/components/content.jsx
@@ -157,6 +157,8 @@ const Content = ( {
               <CheckboxRowContainer
                 name="make_observation_licenses_same"
                 label={I18n.t( "update_existing_observations_with_new_license" )}
+                modalDescriptionTitle={I18n.t( "update_existing_observations_with_new_license" )}
+                modalDescription={I18n.t( "update_existing_observations_with_new_license_desc" )}
               />
             </div>
             <label htmlFor="preferred_photo_license">{I18n.t( "default_photo_license" )}</label>
@@ -174,6 +176,8 @@ const Content = ( {
               <CheckboxRowContainer
                 name="make_photo_licenses_same"
                 label={I18n.t( "update_existing_photos_with_new_license" )}
+                modalDescriptionTitle={I18n.t( "update_existing_photos_with_new_license" )}
+                modalDescription={I18n.t( "update_existing_photos_with_new_license_desc" )}
               />
             </div>
             <label htmlFor="preferred_sound_license">{I18n.t( "default_sound_license" )}</label>
@@ -191,6 +195,8 @@ const Content = ( {
           <CheckboxRowContainer
             name="make_sound_licenses_same"
             label={I18n.t( "update_existing_sounds_with_new_license" )}
+            modalDescriptionTitle={I18n.t( "update_existing_sounds_with_new_license" )}
+            modalDescription={I18n.t( "update_existing_sounds_with_new_license_desc" )}
           />
         </SettingsItem>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6091,8 +6091,20 @@ en:
   upcoming_bioblitzes: Upcoming bioblitzes
   update: Update
   update_existing_observations_with_new_license: Update existing observations with new license choices
+  update_existing_observations_with_new_license_desc: |
+    Selecting this option will apply your new license choice to all your
+    existing observations. This can take a few hours if you have a lot of
+    observations.
   update_existing_photos_with_new_license: Update existing photos with new license choices
+  update_existing_photos_with_new_license_desc: |
+    Selecting this option will apply your new license choice to all your
+    existing photos. This can take a few hours if you have a lot of
+    photos.
   update_existing_sounds_with_new_license: Update existing sounds with new license choices
+  update_existing_sounds_with_new_license_desc: |
+    Selecting this option will apply your new license choice to all your
+    existing sounds. This can take a few hours if you have a lot of
+    sounds.
   update_observations: Update Observations
   update_past: "Update Past %{type}"
   update_photos: Update Photos

--- a/spec/controllers/users_controller_api_spec.rb
+++ b/spec/controllers/users_controller_api_spec.rb
@@ -45,9 +45,11 @@ shared_examples_for "a signed in UsersController" do
         user.update( preferred_observation_license: Observation::CC_BY )
         o = Observation.make!( user: user )
         expect( o.license ).to eq Observation::CC_BY
-        put :update, format: :json, params: {
-          id: user.id, user: { preferred_observation_license: Observation::CC0, make_observation_licenses_same: "1" }
-        }
+        after_delayed_job_finishes( ignore_run_at: true ) do
+          put :update, format: :json, params: {
+            id: user.id, user: { preferred_observation_license: Observation::CC0, make_observation_licenses_same: "1" }
+          }
+        end
         o.reload
         expect( o.license ).to eq Observation::CC0
       end
@@ -66,14 +68,16 @@ shared_examples_for "a signed in UsersController" do
       end
     end
     describe "photo license preference" do
-      it "should update past observations if requested" do
+      it "should update past photos if requested" do
         user.update( preferred_photo_license: Observation::CC_BY )
         p = LocalPhoto.make!( user: user )
         expect( p.license_code ).to eq Observation::CC_BY
-        put :update, format: :json, params: { id: user.id, user: {
-          preferred_photo_license: Observation::CC0,
-          make_photo_licenses_same: "1"
-        } }
+        after_delayed_job_finishes( ignore_run_at: true ) do
+          put :update, format: :json, params: { id: user.id, user: {
+            preferred_photo_license: Observation::CC0,
+            make_photo_licenses_same: "1"
+          } }
+        end
         p.reload
         expect( p.license_code ).to eq Observation::CC0
       end


### PR DESCRIPTION
Previously if a user changed their license preference and requested that it be retroactive, the task was happening in the request, which caused it to time out if the user had a lot of observations.

Closes WEB-682