### PR TITLE
fix: prevent creation of polygons without bounding boxes

### DIFF
--- a/app/models/place_geometry.rb
+++ b/app/models/place_geometry.rb
@@ -52,6 +52,11 @@ class PlaceGeometry < ApplicationRecord
     if geom.detect {| g | g.num_points < 4 }
       errors.add( :geom, :polygon_with_less_than_four_points )
     end
+    # Somehow rgeo allows polygons with identical points to exist, and when
+    # that happens, the envelope is itself a point
+    if geom.detect {| g | g.envelope.is_a?( RGeo::Geos::CAPIPointImpl ) }
+      errors.add( :geom, :polygon_with_no_area )
+    end
     unless geom.detect {| g | g.points.detect {| pt | pt.x < -180 || pt.x > 180 || pt.y < -90 || pt.y > 90 } }
       return
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10339,6 +10339,7 @@ en:
               invalid_point: has an invalid point, e.g. longitude greater than 180 or latitude less than -90
               must_have_more_than_three_points: must have more than 3 points
               polygon_with_less_than_four_points: has a polygon with fewer than 4 points
+              polygon_with_no_area: has a polygon with no area (all points are the same)
         place_geometry:
           attributes:
             geom:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10339,6 +10339,8 @@ en:
               invalid_point: has an invalid point, e.g. longitude greater than 180 or latitude less than -90
               must_have_more_than_three_points: must have more than 3 points
               polygon_with_less_than_four_points: has a polygon with fewer than 4 points
+              # Error message when a user uploads a KML that has a polygon
+              # where all the points are the same.
               polygon_with_no_area: has a polygon with no area (all points are the same)
         place_geometry:
           attributes:

--- a/spec/models/place_geometry_spec.rb
+++ b/spec/models/place_geometry_spec.rb
@@ -45,6 +45,14 @@ describe PlaceGeometry do
       expect( pg ).not_to be_valid
       expect( pg.errors.size ).to eq 1
     end
+
+    it "should be invalid with a polygon that has 4 identical points" do
+      pg = PlaceGeometry.new( place: @place )
+      impossible_polygon = "MULTIPOLYGON(((1 1,1 1,1 1,1 1)))"
+      pg.geom = impossible_polygon
+      expect( pg ).not_to be_valid
+      expect( pg.errors.size ).to eq 1
+    end
   end
 
   describe "observations_places" do


### PR DESCRIPTION
RGeo allows polygons that have multiple points that are identical, and when that happens their bounding boxes are points, which causes problems for us. This should prevent it.

Closes WEB-663