### PR TITLE
fix: search tags using keyword instead of fuzzy matching

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -246,7 +246,9 @@ class Observation < ApplicationRecord
       indexes :sounds_count, type: "short"
       indexes :spam, type: "boolean"
       indexes :species_guess, type: "keyword"
-      indexes :tags, type: "text", analyzer: "ascii_snowball_analyzer"
+      indexes :tags, type: "text", analyzer: "ascii_snowball_analyzer" do
+        indexes :keyword, type: "keyword"
+      end
       indexes :taxon do
         indexes :ancestor_ids, type: "integer" do
           indexes :keyword, type: "keyword"
@@ -581,7 +583,7 @@ class Observation < ApplicationRecord
         search_taxa = true
         searched_taxa = matching_taxon_ids( q )
       elsif search_on === "tags"
-        fields = [ :tags ]
+        fields = [ "tags.keyword" ]
       elsif search_on === "description"
         fields = [ :description ]
       elsif search_on === "place"

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -282,10 +282,10 @@ describe "Observation Index" do
       expect( eq[:filters] ).to eq( [{ term: { id: -1 } }])
     end
 
-    it "queries tags" do
+    it "queries using exact keyword matching when explicitly searching on tags" do
       expect( Observation.params_to_elastic_query({ q: "s", search_on: "tags" }) ).to include(
         filters: [ { multi_match:
-          { query: "s", operator: "and", fields: [ :tags ] } } ] )
+          { query: "s", operator: "and", fields: [ "tags.keyword" ] } } ] )
     end
 
     it "queries descriptions" do


### PR DESCRIPTION
Adds an additional index subfield for tags, which is used only when the search_on query parameter is set to tags. Fuzzy matching will still be used when searching generally. Updates one spec to verify the new behavior. Unchanged behaviors are still covered well by other specs.

Closes WEB-616