### PR TITLE
feat: index attribution_name for taxon photos

### DIFF
--- a/app/es_indices/taxon_index.rb
+++ b/app/es_indices/taxon_index.rb
@@ -38,6 +38,7 @@ class Taxon < ApplicationRecord
       indexes :current_synonymous_taxon_ids, type: "integer"
       indexes :default_photo do
         indexes :attribution, type: "keyword", index: false
+        indexes :attribution_name, type: "keyword", index: false
         indexes :flags do
           indexes :comment, type: "keyword", index: false
           indexes :created_at, type: "date", index: false
@@ -124,6 +125,7 @@ class Taxon < ApplicationRecord
         indexes :license_code, type: "keyword", index: false
         indexes :photo do
           indexes :attribution, type: "keyword", index: false
+          indexes :attribution_name, type: "keyword", index: false
           indexes :flags do
             indexes :comment, type: "keyword", index: false
             indexes :created_at, type: "date", index: false
@@ -209,7 +211,10 @@ class Taxon < ApplicationRecord
       json.merge!({
         created_at: created_at,
         default_photo: default_photo ?
-          default_photo.as_indexed_json(for_taxon: true, sizes: [ :square, :medium ]) : nil,
+          default_photo.as_indexed_json(
+            sizes: [:square, :medium],
+            attribution_name: true
+          ) : nil,
         colors: colors.map(&:as_indexed_json),
         ancestry: ancestry,
         taxon_changes_count: taxon_changes_count,

--- a/app/es_indices/taxon_photo_index.rb
+++ b/app/es_indices/taxon_photo_index.rb
@@ -56,7 +56,8 @@ class TaxonPhoto < ApplicationRecord
           sizes: [:square, :small, :medium, :large, :original],
           native_page_url: true,
           native_photo_id: true,
-          type: true
+          type: true,
+          attribution_name: true
         )
       }
     end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -536,6 +536,7 @@ class Photo < ApplicationRecord
     json[:native_page_url] = native_page_url if options[:native_page_url]
     json[:native_photo_id] = native_photo_id if options[:native_photo_id]
     json[:type] = type if options[:type]
+    json[:attribution_name] = attribution_name( allow_nil: true ) if options[:attribution_name]
     options[:sizes] ||= [ ]
     options[:sizes].each do |size|
       json["#{ size }_url"] = best_url(size)

--- a/app/models/shared/license_module.rb
+++ b/app/models/shared/license_module.rb
@@ -59,15 +59,15 @@ module Shared::LicenseModule
     end
   end
 
-  def attribution_name
+  def attribution_name( options = {} )
     if !native_realname.blank?
       native_realname
     elsif !native_username.blank?
       native_username
     elsif user
       user.name.blank? ? user.login : user.name
-    else
-      I18n.t('copyright.anonymous')
+    elsif !options[:allow_nil]
+      I18n.t( "copyright.anonymous" )
     end
   end
 

--- a/app/webpack/taxa/shared/ducks/taxon.js
+++ b/app/webpack/taxa/shared/ducks/taxon.js
@@ -396,6 +396,7 @@ export function fetchTaxon( taxon, options = { params: { } } ) {
         taxon_photos: {
           photo: {
             attribution: true,
+            attribution_name: true,
             id: true,
             license_code: true,
             small_url: true,

--- a/app/webpack/taxa/shared/util.js
+++ b/app/webpack/taxa/shared/util.js
@@ -43,6 +43,9 @@ const localizedPhotoAttribution = ( photo, options = { } ) => {
   if ( user && userName.length === 0 ) {
     userName = user.name || user.login || userName;
   }
+  if ( userName.length === 0 && photo.attribution_name ) {
+    userName = photo.attribution_name;
+  }
   if ( userName.length === 0 && photo.attribution ) {
     const matches = photo.attribution.match( /\(.+\) (.+?),/ );
     if ( matches ) {

--- a/spec/lib/elastic_model/indices/taxon_index_spec.rb
+++ b/spec/lib/elastic_model/indices/taxon_index_spec.rb
@@ -26,6 +26,36 @@ describe "Taxon Index" do
     expect( taxon.as_indexed_json[:taxon_photos] ).to be_empty
   end
 
+  it "includes photo attribution names" do
+    taxon = Taxon.make!
+    user = User.make!( name: "photographer" )
+    photo = LocalPhoto.make!( user: user )
+    TaxonPhoto.make!( taxon: taxon, photo: photo )
+    taxon.reload
+    expect( taxon.as_indexed_json[:default_photo][:id] ).to eq photo.id
+    expect( taxon.as_indexed_json[:default_photo][:attribution_name] ).to eq user.name
+
+    expect( taxon.as_indexed_json[:taxon_photos].first[:photo][:id] ).to eq photo.id
+    expect( taxon.as_indexed_json[:taxon_photos].first[:photo][:attribution_name] ).to eq user.name
+  end
+
+  it "allows photo attribution names to be nil" do
+    taxon = Taxon.make!
+    photo = FlickrPhoto.make!(
+      user: nil,
+      native_realname: nil,
+      native_username: nil,
+      license: Photo::CC0
+    )
+    TaxonPhoto.make!( taxon: taxon, photo: photo )
+    taxon.reload
+    expect( taxon.as_indexed_json[:default_photo][:id] ).to eq photo.id
+    expect( taxon.as_indexed_json[:default_photo][:attribution_name] ).to be_nil
+
+    expect( taxon.as_indexed_json[:taxon_photos].first[:photo][:id] ).to eq photo.id
+    expect( taxon.as_indexed_json[:taxon_photos].first[:photo][:attribution_name] ).to be_nil
+  end
+
   describe "prepare_batch_for_index" do
     it "caches project_ids" do
       t = Taxon.make!


### PR DESCRIPTION
related to WEB-551. Adds an attribute `attribution_name` to taxon photos in the taxon index that can be used for better attribution of photos, particularly those not associated with iNaturalist users or those with a CC0 license