### PR TITLE
fix: prevent anncs targeting user signup date and logged in

### DIFF
--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -62,7 +62,7 @@ $( function ( ) {
   // Enable / disable inputs that require a signed in user
   $( "[name='announcement[target_logged_in]']" ).change( function ( ) {
     var form = $( this ).parents( "form" ).get( 0 );
-    const val = $( "[name='announcement[target_logged_in]']:checked", form ).val( );
+    var val = $( "[name='announcement[target_logged_in]']:checked", form ).val( );
 
     // show / hide the options that concern users
     if ( val === "yes" ) {

--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -5,12 +5,15 @@
 /* global DISMISSIBLE_PLACEMENTS */
 
 $( function ( ) {
+  // show/hide inputs depending on placement selected
   $( "#announcement_placement" ).change( function ( ) {
     var placement = $( "#announcement_placement" ).val( );
     var clientsSelect = $( "#announcement_clients" );
     var valuesToSelect = clientsSelect.val( ) || clientsSelect.data( "originalValues" ) || [];
     clientsSelect.empty( );
     clientsSelect.append( $( "<option value>" + I18n.t( "all" ) + "</option>" ) );
+    // Some placements are only relevant to certain clients, so if the user
+    // chooses a placement we need to show/hide the relevant clients
     if ( PLACEMENT_CLIENTS[placement] ) {
       _.each( PLACEMENT_CLIENTS[placement], function ( placementClient ) {
         var option = $( "<option value='" + placementClient + "'>" + placementClient + "</option>" );
@@ -25,7 +28,7 @@ $( function ( ) {
       clientsSelect.attr( "size", 1 );
       $( ".clients_field" ).hide( );
     }
-
+    // Not all placements *can* be dismissed, so we hide that checkbox if the user chooses one
     if ( DISMISSIBLE_PLACEMENTS.indexOf( placement ) < 0 ) {
       $( ".dismissible_field" ).hide( );
     } else {
@@ -53,6 +56,42 @@ $( function ( ) {
       } );
     } else {
       partitionSelect.append( $( "<option value>" + I18n.t( "none" ) + "</option>" ) );
+    }
+  } );
+
+  // Enable / disable inputs that require a signed in user
+  $( "[name='announcement[target_logged_in]']" ).change( function ( ) {
+    var form = $( this ).parents( "form" ).get( 0 );
+    const val = $( "[name='announcement[target_logged_in]']:checked", form ).val( );
+    if ( val === "yes" ) {
+      // Disable created start and end date inputs
+      $( "[name='announcement[user_created_start_date]']", form ).prop( "disabled", true );
+      $( "[name='announcement[user_created_end_date]']", form ).prop( "disabled", true );
+    } else {
+      // Enable created start and end date inputs
+      $( "[name='announcement[user_created_start_date]']", form ).prop( "disabled", false );
+      $( "[name='announcement[user_created_end_date]']", form ).prop( "disabled", false );
+    }
+  } );
+
+  // Enable / disable logged_in input when inputs that require a signed in user change
+  var inputsRequiringLoggedIn = $( "[name='announcement[user_created_start_date]'], [name='announcement[user_created_end_date]']" );
+  inputsRequiringLoggedIn.change( function ( ) {
+    // if any of the inputsRequiringLoggedIn have a value
+    const inputsRequiringLoggedInSet = inputsRequiringLoggedIn
+      .toArray( )
+      .some( input => $( input ).val( ) );
+    var form = $( this ).parents( "form" ).get( 0 );
+    if ( inputsRequiringLoggedInSet ) {
+      // Disable logged_in input
+      $( "[name='announcement[target_logged_in]']", form ).prop( "disabled", true );
+      // Check the yes option
+      $( "[name='announcement[target_logged_in]'][value='yes']", form ).prop( "checked", true );
+    } else {
+      // Enable logged_in input
+      $( "[name='announcement[target_logged_in]']", form ).prop( "disabled", false );
+      // Check the any option
+      $( "[name='announcement[target_logged_in]'][value='any']", form ).prop( "checked", true );
     }
   } );
 } );

--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -63,35 +63,13 @@ $( function ( ) {
   $( "[name='announcement[target_logged_in]']" ).change( function ( ) {
     var form = $( this ).parents( "form" ).get( 0 );
     const val = $( "[name='announcement[target_logged_in]']:checked", form ).val( );
-    if ( val === "yes" ) {
-      // Disable created start and end date inputs
-      $( "[name='announcement[user_created_start_date]']", form ).prop( "disabled", true );
-      $( "[name='announcement[user_created_end_date]']", form ).prop( "disabled", true );
-    } else {
-      // Enable created start and end date inputs
-      $( "[name='announcement[user_created_start_date]']", form ).prop( "disabled", false );
-      $( "[name='announcement[user_created_end_date]']", form ).prop( "disabled", false );
-    }
-  } );
 
-  // Enable / disable logged_in input when inputs that require a signed in user change
-  var inputsRequiringLoggedIn = $( "[name='announcement[user_created_start_date]'], [name='announcement[user_created_end_date]']" );
-  inputsRequiringLoggedIn.change( function ( ) {
-    // if any of the inputsRequiringLoggedIn have a value
-    const inputsRequiringLoggedInSet = inputsRequiringLoggedIn
-      .toArray( )
-      .some( input => $( input ).val( ) );
-    var form = $( this ).parents( "form" ).get( 0 );
-    if ( inputsRequiringLoggedInSet ) {
-      // Disable logged_in input
-      $( "[name='announcement[target_logged_in]']", form ).prop( "disabled", true );
-      // Check the yes option
-      $( "[name='announcement[target_logged_in]'][value='yes']", form ).prop( "checked", true );
+    // show / hide the options that concern users
+    if ( val === "yes" ) {
+      $( "#logged-in-options" ).show( );
     } else {
-      // Enable logged_in input
-      $( "[name='announcement[target_logged_in]']", form ).prop( "disabled", false );
-      // Check the any option
-      $( "[name='announcement[target_logged_in]'][value='any']", form ).prop( "checked", true );
+      $( "#logged-in-options" ).hide( );
     }
   } );
+  $( "[name='announcement[target_logged_in]']" ).change();
 } );

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -56,6 +56,7 @@ class Announcement < ApplicationRecord
   belongs_to :user
   has_and_belongs_to_many :sites
   has_many :announcement_impressions, dependent: :delete_all
+
   validates_presence_of :placement, :start, :end, :body
   validate :valid_placement_clients
   validates_inclusion_of :target_group_type, in: TARGET_GROUPS.keys, if: :target_group_type?
@@ -90,6 +91,7 @@ class Announcement < ApplicationRecord
   }
 
   before_save :clean_target_group
+  before_save :reset_options_requiring_login
   before_validation :compact_array_attributes
 
   after_save :sync_announcement_dismissals
@@ -125,6 +127,33 @@ class Announcement < ApplicationRecord
   def clean_target_group
     self.target_group_type = nil if target_group_type.blank?
     self.target_group_partition = nil if target_group_type.nil?
+  end
+
+  def reset_options_requiring_login
+    return if target_logged_in == YES
+
+    self.user_created_start_date = nil
+    self.user_created_end_date = nil
+    self.include_donor_start_date = nil
+    self.include_donor_end_date = nil
+    self.exclude_donor_start_date = nil
+    self.exclude_donor_end_date = nil
+    self.prefers_exclude_monthly_supporters = false
+    self.min_observations = nil
+    self.max_observations = nil
+    self.last_observation_start_date = nil
+    self.last_observation_end_date = nil
+    self.include_observation_oauth_application_ids = []
+    self.exclude_observation_oauth_application_ids = []
+    self.min_identifications = nil
+    self.max_identifications = nil
+    self.user_created_start_date = nil
+    self.user_created_end_date = nil
+    self.prefers_target_unconfirmed_users = false
+    self.target_curators = ANY
+    self.target_project_admins = ANY
+    self.target_group_type = nil
+    self.target_group_partition = nil
   end
 
   def dismissed_by?( user )

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -211,8 +211,15 @@ class Announcement < ApplicationRecord
         where( "donated_at >= ?", exclude_donor_start_date || Date.new( 2018, 1, 1 ) ).
         where( "donated_at <= ?", exclude_donor_end_date || Time.now ).any?
 
-    return false if user && user_created_start_date && user.created_at < user_created_start_date
-    return false if user && user_created_end_date && user.created_at > user_created_end_date
+    if user_created_start_date
+      return false unless user
+      return false if user.created_at < user_created_start_date
+    end
+
+    if user_created_end_date
+      return false unless user
+      return false if user.created_at > user_created_end_date
+    end
 
     return false if prefers_target_unconfirmed_users && user&.confirmed?
 

--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -59,7 +59,11 @@
       = f.text_area :body
   .row.stacked.upstacked
     .col-xs-12
-      %details.panel.panel-default
+      = f.form_field :target_logged_in, builder: BootstrapFormBuilder do
+        = f.radio_button :target_logged_in, Announcement::ANY, label: t( :any_ ), inline: true
+        = f.radio_button :target_logged_in, Announcement::YES, label: t( :logged_in ), inline: true
+        = f.radio_button :target_logged_in, Announcement::NO, label: t( :logged_out ), inline: true
+      %details#logged-in-options.panel.panel-default
         %summary.panel-heading=t :more_options
         .panel-body
           %h4
@@ -112,10 +116,6 @@
                 .col-xs-12
                   = f.check_box :prefers_target_unconfirmed_users, label_after: true
             .col-xs-4
-              = f.form_field :target_logged_in, builder: BootstrapFormBuilder do
-                = f.radio_button :target_logged_in, Announcement::ANY, label: t( :any_ ), inline: true
-                = f.radio_button :target_logged_in, Announcement::YES, label: t( :logged_in ), inline: true
-                = f.radio_button :target_logged_in, Announcement::NO, label: t( :logged_out ), inline: true
               = f.form_field :target_curators, builder: BootstrapFormBuilder do
                 = f.radio_button :target_curators, Announcement::ANY, label: t( :any_ ), inline: true
                 = f.radio_button :target_curators, Announcement::YES, label: t( :curator ), inline: true

--- a/spec/controllers/announcements_controller_api_spec.rb
+++ b/spec/controllers/announcements_controller_api_spec.rb
@@ -244,7 +244,9 @@ describe AnnouncementsController do
       end
 
       it "does not target confirmed users if targeting unconfirmed users" do
-        unconfirmed_announcement = create :announcement, prefers_target_unconfirmed_users: true
+        unconfirmed_announcement = create :announcement,
+          target_logged_in: Announcement::YES,
+          prefers_target_unconfirmed_users: true
         sign_in create( :user )
         get :active, format: :json
         annc_ids = response.parsed_body.map {| a | a["id"] }
@@ -254,8 +256,12 @@ describe AnnouncementsController do
       it "includes users by observation oauth application ids" do
         app = create :oauth_application, official: true
         app_obs = create :observation, oauth_application: app
-        app_annc = create :announcement, include_observation_oauth_application_ids: [app.id]
-        oth_annc = create :announcement, include_observation_oauth_application_ids: [OauthApplication::WEB_APP_ID]
+        app_annc = create :announcement,
+          target_logged_in: Announcement::YES,
+          include_observation_oauth_application_ids: [app.id]
+        oth_annc = create :announcement,
+          target_logged_in: Announcement::YES,
+          include_observation_oauth_application_ids: [OauthApplication::WEB_APP_ID]
         sign_in app_obs.user
         get :active, format: :json
         annc_ids = response.parsed_body.map {| a | a["id"] }
@@ -266,8 +272,12 @@ describe AnnouncementsController do
       it "excludes users by observation oauth application ids" do
         app = create :oauth_application, official: true
         app_obs = create :observation, oauth_application: app
-        app_annc = create :announcement, exclude_observation_oauth_application_ids: [app.id]
-        oth_annc = create :announcement, exclude_observation_oauth_application_ids: [OauthApplication::WEB_APP_ID]
+        app_annc = create :announcement,
+          target_logged_in: Announcement::YES,
+          exclude_observation_oauth_application_ids: [app.id]
+        oth_annc = create :announcement,
+          target_logged_in: Announcement::YES,
+          exclude_observation_oauth_application_ids: [OauthApplication::WEB_APP_ID]
         sign_in app_obs.user
         get :active, format: :json
         annc_ids = response.parsed_body.map {| a | a["id"] }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -108,7 +108,7 @@ describe UsersController, "dashboard" do
           donorbox_plan_type: "monthly"
         expect( user ).to be_monthly_donor
         sign_in user
-        a = create :announcement, prefers_exclude_monthly_supporters: true
+        a = create :announcement, target_logged_in: Announcement::YES, prefers_exclude_monthly_supporters: true
         get :dashboard
         expect( response.body ).not_to include a.body
       end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -344,6 +344,11 @@ describe Announcement do
         annc = create :announcement, user_created_start_date: 2.days.ago
         expect( annc.targeted_to_user?( create( :user, created_at: 3.day.ago ) ) ).to be false
       end
+
+      it "excludes signed out users" do
+        annc = create :announcement, user_created_start_date: 2.days.ago
+        expect( annc.targeted_to_user?( nil ) ).to be false
+      end
     end
 
     describe "user_created_end_date" do
@@ -362,6 +367,11 @@ describe Announcement do
       it "excludes users created after value" do
         annc = create :announcement, user_created_end_date: 2.days.ago
         expect( annc.targeted_to_user?( create( :user, created_at: 1.day.ago ) ) ).to be false
+      end
+
+      it "excludes signed out users" do
+        annc = create :announcement, user_created_end_date: 2.days.ago
+        expect( annc.targeted_to_user?( nil ) ).to be false
       end
     end
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -74,13 +74,14 @@ describe Announcement do
     end
 
     it "targets unconfirmed users" do
-      a = Announcement.make!( prefers_target_unconfirmed_users: true )
+      a = create( :announcement, target_logged_in: Announcement::YES, prefers_target_unconfirmed_users: true )
       expect( a.targeted_to_user?( User.make!( confirmed_at: Time.now ) ) ).to be false
       expect( a.targeted_to_user?( User.make!( confirmed_at: nil ) ) ).to be true
     end
 
     it "targets unconfirmed users and last observation date" do
       annc = create :announcement,
+        target_logged_in: Announcement::YES,
         prefers_target_unconfirmed_users: true,
         last_observation_start_date: 2.days.ago
       confirmed_user = create :user
@@ -102,19 +103,29 @@ describe Announcement do
         donorbox_plan_type: "monthly"
       )
       non_monthly_supporter = User.make!
-      a = Announcement.make!( prefers_exclude_monthly_supporters: true )
+      a = create( :announcement, target_logged_in: Announcement::YES, prefers_exclude_monthly_supporters: true )
       expect( a.targeted_to_user?( monthly_supporter ) ).to be false
       expect( a.targeted_to_user?( non_monthly_supporter ) ).to be true
     end
 
     it "can target users by ID parity" do
-      a = Announcement.make!( target_group_type: "user_id_parity", target_group_partition: "even" )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        target_group_type: "user_id_parity",
+        target_group_partition: "even"
+      )
       expect( a.targeted_to_user?( User.make!( id: 100 ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( id: 101 ) ) ).to be false
       expect( a.targeted_to_user?( User.make!( id: 200 ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( id: 201 ) ) ).to be false
 
-      a = Announcement.make!( target_group_type: "user_id_parity", target_group_partition: "odd" )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        target_group_type: "user_id_parity",
+        target_group_partition: "odd"
+      )
       expect( a.targeted_to_user?( User.make!( id: 300 ) ) ).to be false
       expect( a.targeted_to_user?( User.make!( id: 301 ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( id: 400 ) ) ).to be false
@@ -122,13 +133,23 @@ describe Announcement do
     end
 
     it "can target users by ID sum parity" do
-      a = Announcement.make!( target_group_type: "user_id_digit_sum_parity", target_group_partition: "even" )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        target_group_type: "user_id_digit_sum_parity",
+        target_group_partition: "even"
+      )
       expect( a.targeted_to_user?( User.make!( id: 100 ) ) ).to be false
       expect( a.targeted_to_user?( User.make!( id: 101 ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( id: 200 ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( id: 201 ) ) ).to be false
 
-      a = Announcement.make!( target_group_type: "user_id_digit_sum_parity", target_group_partition: "odd" )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        target_group_type: "user_id_digit_sum_parity",
+        target_group_partition: "odd"
+      )
       expect( a.targeted_to_user?( User.make!( id: 300 ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( id: 301 ) ) ).to be false
       expect( a.targeted_to_user?( User.make!( id: 400 ) ) ).to be false
@@ -136,7 +157,12 @@ describe Announcement do
     end
 
     it "can target users by created second parity" do
-      a = Announcement.make!( target_group_type: "created_second_parity", target_group_partition: "even" )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        target_group_type: "created_second_parity",
+        target_group_partition: "even"
+      )
       expect( a.targeted_to_user?( User.make!( created_at: "2024-01-01 00:00:00" ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( created_at: "2024-01-01 00:00:00" ) ) ).to be true
       expect( a.targeted_to_user?( User.make!( created_at: "2024-01-01 00:00:01" ) ) ).to be false
@@ -146,19 +172,30 @@ describe Announcement do
     end
 
     it "can target donors by donation date" do
-      a = Announcement.make!( include_donor_start_date: Date.today )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        include_donor_start_date: Date.today
+      )
       expect( a.targeted_to_user?( UserDonation.make!.user ) ).to be true
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 2.days.ago ).user ) ).to be false
       expect( a.targeted_to_user?( User.make! ) ).to be false
       expect( a.targeted_to_user?( nil ) ).to be false
 
-      a = Announcement.make!( include_donor_end_date: 1.day.ago )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        include_donor_end_date: 1.day.ago
+      )
       expect( a.targeted_to_user?( UserDonation.make!.user ) ).to be false
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 2.days.ago ).user ) ).to be true
       expect( a.targeted_to_user?( User.make! ) ).to be false
       expect( a.targeted_to_user?( nil ) ).to be false
 
-      a = Announcement.make!( include_donor_start_date: 10.days.ago, include_donor_end_date: 1.day.ago )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        include_donor_start_date: 10.days.ago, include_donor_end_date: 1.day.ago )
       expect( a.targeted_to_user?( UserDonation.make!.user ) ).to be false
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 2.days.ago ).user ) ).to be true
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 20.days.ago ).user ) ).to be false
@@ -167,24 +204,37 @@ describe Announcement do
     end
 
     it "can exclude donors by donation date" do
-      a = Announcement.make!( exclude_donor_start_date: Date.today )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        exclude_donor_start_date: Date.today
+      )
       expect( a.targeted_to_user?( UserDonation.make!.user ) ).to be false
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 2.days.ago ).user ) ).to be true
       expect( a.targeted_to_user?( User.make! ) ).to be true
-      expect( a.targeted_to_user?( nil ) ).to be true
+      expect( a.targeted_to_user?( nil ) ).to be false
 
-      a = Announcement.make!( exclude_donor_end_date: 1.day.ago )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        exclude_donor_end_date: 1.day.ago
+      )
       expect( a.targeted_to_user?( UserDonation.make!.user ) ).to be true
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 2.days.ago ).user ) ).to be false
       expect( a.targeted_to_user?( User.make! ) ).to be true
-      expect( a.targeted_to_user?( nil ) ).to be true
+      expect( a.targeted_to_user?( nil ) ).to be false
 
-      a = Announcement.make!( exclude_donor_start_date: 10.days.ago, exclude_donor_end_date: 1.day.ago )
+      a = create(
+        :announcement,
+        target_logged_in: Announcement::YES,
+        exclude_donor_start_date: 10.days.ago,
+        exclude_donor_end_date: 1.day.ago
+      )
       expect( a.targeted_to_user?( UserDonation.make!.user ) ).to be true
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 2.days.ago ).user ) ).to be false
       expect( a.targeted_to_user?( UserDonation.make!( donated_at: 20.days.ago ).user ) ).to be true
       expect( a.targeted_to_user?( User.make! ) ).to be true
-      expect( a.targeted_to_user?( nil ) ).to be true
+      expect( a.targeted_to_user?( nil ) ).to be false
     end
 
     describe "target_logged_in" do
@@ -217,15 +267,15 @@ describe Announcement do
       end
 
       it "can target curators" do
-        annc = create :announcement, target_curators: Announcement::YES
+        annc = create :announcement, target_logged_in: Announcement::YES, target_curators: Announcement::YES
         expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user, :as_curator ) ) ).to be true
         expect( annc.targeted_to_user?( create( :user ) ) ).to be false
       end
 
       it "can target non-curators" do
-        annc = create :announcement, target_curators: Announcement::NO
-        expect( annc.targeted_to_user?( nil ) ).to be true
+        annc = create :announcement, target_logged_in: Announcement::YES, target_curators: Announcement::NO
+        expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user, :as_curator ) ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be true
       end
@@ -240,15 +290,15 @@ describe Announcement do
       end
 
       it "can target project admins" do
-        annc = create :announcement, target_project_admins: Announcement::YES
+        annc = create :announcement, target_logged_in: Announcement::YES, target_project_admins: Announcement::YES
         expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :project ).user ) ).to be true
         expect( annc.targeted_to_user?( create( :user ) ) ).to be false
       end
 
       it "can target non-project admins" do
-        annc = create :announcement, target_project_admins: Announcement::NO
-        expect( annc.targeted_to_user?( nil ) ).to be true
+        annc = create :announcement, target_logged_in: Announcement::YES, target_project_admins: Announcement::NO
+        expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :project ).user ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be true
       end
@@ -263,7 +313,7 @@ describe Announcement do
       end
 
       it "includes users with more than value" do
-        annc = create :announcement, min_identifications: 1
+        annc = create :announcement, target_logged_in: Announcement::YES, min_identifications: 1
         expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be false
         identifier = create :user, identifications_count: 2
@@ -281,8 +331,8 @@ describe Announcement do
       end
 
       it "includes users with less than value" do
-        annc = create :announcement, max_identifications: 2
-        expect( annc.targeted_to_user?( nil ) ).to be true
+        annc = create :announcement, target_logged_in: Announcement::YES, max_identifications: 2
+        expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be true
         identifier = create :user, identifications_count: 1
         expect( identifier.identifications_count ).to eq 1
@@ -290,8 +340,8 @@ describe Announcement do
       end
 
       it "exclude users with more than value" do
-        annc = create :announcement, max_identifications: 2
-        expect( annc.targeted_to_user?( nil ) ).to be true
+        annc = create :announcement, target_logged_in: Announcement::YES, max_identifications: 2
+        expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be true
         identifier = create :user, identifications_count: 10
         expect( identifier.identifications_count ).to eq 10
@@ -309,8 +359,8 @@ describe Announcement do
       end
 
       it "includes users with less than value" do
-        annc = create :announcement, max_observations: 2
-        expect( annc.targeted_to_user?( nil ) ).to be true
+        annc = create :announcement, target_logged_in: Announcement::YES, max_observations: 2
+        expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be true
         identifier = create :user, observations_count: 1
         expect( identifier.observations_count ).to eq 1
@@ -318,8 +368,8 @@ describe Announcement do
       end
 
       it "exclude users with more than value" do
-        annc = create :announcement, max_observations: 2
-        expect( annc.targeted_to_user?( nil ) ).to be true
+        annc = create :announcement, target_logged_in: Announcement::YES, max_observations: 2
+        expect( annc.targeted_to_user?( nil ) ).to be false
         expect( annc.targeted_to_user?( create( :user ) ) ).to be true
         identifier = create :user, observations_count: 10
         expect( identifier.observations_count ).to eq 10
@@ -336,17 +386,17 @@ describe Announcement do
       end
 
       it "includes users created after value" do
-        annc = create :announcement, user_created_start_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, user_created_start_date: 2.days.ago
         expect( annc.targeted_to_user?( create( :user, created_at: 1.day.ago ) ) ).to be true
       end
 
       it "excludes users created before value" do
-        annc = create :announcement, user_created_start_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, user_created_start_date: 2.days.ago
         expect( annc.targeted_to_user?( create( :user, created_at: 3.day.ago ) ) ).to be false
       end
 
       it "excludes signed out users" do
-        annc = create :announcement, user_created_start_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, user_created_start_date: 2.days.ago
         expect( annc.targeted_to_user?( nil ) ).to be false
       end
     end
@@ -360,30 +410,30 @@ describe Announcement do
       end
 
       it "includes users created before value" do
-        annc = create :announcement, user_created_end_date: 1.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, user_created_end_date: 1.days.ago
         expect( annc.targeted_to_user?( create( :user, created_at: 2.day.ago ) ) ).to be true
       end
 
       it "excludes users created after value" do
-        annc = create :announcement, user_created_end_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, user_created_end_date: 2.days.ago
         expect( annc.targeted_to_user?( create( :user, created_at: 1.day.ago ) ) ).to be false
       end
 
       it "excludes signed out users" do
-        annc = create :announcement, user_created_end_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, user_created_end_date: 2.days.ago
         expect( annc.targeted_to_user?( nil ) ).to be false
       end
     end
 
     describe "last_observation_start_date" do
       it "includes users with last observation after value" do
-        annc = create :announcement, last_observation_start_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, last_observation_start_date: 2.days.ago
         obs = create :observation, created_at: 1.day.ago
         expect( annc.targeted_to_user?( obs.user ) ).to be true
       end
 
       it "excludes users with last observation before value" do
-        annc = create :announcement, last_observation_start_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, last_observation_start_date: 2.days.ago
         obs = create :observation, created_at: 3.day.ago
         expect( annc.targeted_to_user?( obs.user ) ).to be false
       end
@@ -391,13 +441,13 @@ describe Announcement do
 
     describe "last_observation_end_date" do
       it "includes users with last observation before value" do
-        annc = create :announcement, last_observation_end_date: 1.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, last_observation_end_date: 1.days.ago
         obs = create :observation, created_at: 2.day.ago
         expect( annc.targeted_to_user?( obs.user ) ).to be true
       end
 
       it "excludes users with last observation after value" do
-        annc = create :announcement, last_observation_end_date: 2.days.ago
+        annc = create :announcement, target_logged_in: Announcement::YES, last_observation_end_date: 2.days.ago
         obs = create :observation, created_at: 1.day.ago
         expect( annc.targeted_to_user?( obs.user ) ).to be false
       end
@@ -407,6 +457,7 @@ describe Announcement do
       app_to_include = create :oauth_application, official: true
       app_to_exclude = create :oauth_application, official: true
       annc = create :announcement,
+        target_logged_in: Announcement::YES,
         include_observation_oauth_application_ids: [app_to_include.id],
         exclude_observation_oauth_application_ids: [app_to_exclude.id]
       include_user = create( :observation, oauth_application: app_to_include ).user


### PR DESCRIPTION
If one of the start date options is set, the announcement should not appear for signed out users. This also modifies the form so the person making/editing the announcement will not be able to target "any" or logged out users if they choose one of the start date options.

Closes WEB-699