### PR TITLE
refactor: support ES6 / ES2020 Javascript syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ gem "savon" # allow to consume soap services with WSDL
 gem "soundcloud"
 gem "sprockets"
 gem "terrapin"
-gem "uglifier"
+gem "terser"
 gem "utf8-cleaner"
 gem "watu_table_builder", require: "table_builder"
 gem "whenever", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
       base64
       simpleidn
     erubi (1.13.1)
-    execjs (2.8.1)
+    execjs (2.10.0)
     exifr (1.3.9)
     exiftool (1.2.4)
       json
@@ -703,13 +703,13 @@ GEM
     temple (0.8.2)
     terrapin (1.0.1)
       climate_control
+    terser (1.2.5)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.0.10)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8)
@@ -873,7 +873,7 @@ DEPENDENCIES
   soundcloud
   sprockets
   terrapin
-  uglifier
+  terser
   utf8-cleaner
   vcr
   watu_table_builder

--- a/app/assets/javascripts/announcements/form.js
+++ b/app/assets/javascripts/announcements/form.js
@@ -7,16 +7,16 @@
 $( function ( ) {
   // show/hide inputs depending on placement selected
   $( "#announcement_placement" ).change( function ( ) {
-    var placement = $( "#announcement_placement" ).val( );
-    var clientsSelect = $( "#announcement_clients" );
-    var valuesToSelect = clientsSelect.val( ) || clientsSelect.data( "originalValues" ) || [];
+    const placement = $( "#announcement_placement" ).val( );
+    const clientsSelect = $( "#announcement_clients" );
+    const valuesToSelect = clientsSelect.val( ) || clientsSelect.data( "originalValues" ) || [];
     clientsSelect.empty( );
-    clientsSelect.append( $( "<option value>" + I18n.t( "all" ) + "</option>" ) );
+    clientsSelect.append( $( `<option value>${I18n.t( "all" )}</option>` ) );
     // Some placements are only relevant to certain clients, so if the user
     // chooses a placement we need to show/hide the relevant clients
     if ( PLACEMENT_CLIENTS[placement] ) {
       _.each( PLACEMENT_CLIENTS[placement], function ( placementClient ) {
-        var option = $( "<option value='" + placementClient + "'>" + placementClient + "</option>" );
+        const option = $( `<option value="${placementClient}">${placementClient}</option>` );
         if ( valuesToSelect.indexOf( placementClient ) >= 0 ) {
           option.attr( "selected", true );
         }
@@ -41,8 +41,8 @@ $( function ( ) {
   $( "#announcement_clients" ).data( "originalValues", $( "#announcement_clients" ).val( ) );
 
   $( "#announcement_target_group_type" ).change( function ( ) {
-    var targetGroupType = $( "#announcement_target_group_type" ).val( );
-    var partitionSelect = $( "#announcement_target_group_partition" );
+    const targetGroupType = $( "#announcement_target_group_type" ).val( );
+    const partitionSelect = $( "#announcement_target_group_partition" );
     if ( targetGroupType ) {
       partitionSelect.prop( "disabled", false );
     } else {
@@ -52,17 +52,17 @@ $( function ( ) {
     partitionSelect.empty( );
     if ( TARGET_GROUP_PARTITIONS[targetGroupType] ) {
       _.each( TARGET_GROUP_PARTITIONS[targetGroupType], function ( partition ) {
-        partitionSelect.append( $( "<option value='" + partition + "'>" + partition + "</option>" ) );
+        partitionSelect.append( $( `<option value="${partition}">${partition}</option>` ) );
       } );
     } else {
-      partitionSelect.append( $( "<option value>" + I18n.t( "none" ) + "</option>" ) );
+      partitionSelect.append( $( `<option value>${I18n.t( "none" )}</option>` ) );
     }
   } );
 
   // Enable / disable inputs that require a signed in user
   $( "[name='announcement[target_logged_in]']" ).change( function ( ) {
-    var form = $( this ).parents( "form" ).get( 0 );
-    var val = $( "[name='announcement[target_logged_in]']:checked", form ).val( );
+    const form = $( this ).parents( "form" ).get( 0 );
+    const val = $( "[name='announcement[target_logged_in]']:checked", form ).val( );
 
     // show / hide the options that concern users
     if ( val === "yes" ) {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -131,7 +131,7 @@ function buildHelpTips() {
   $('.helptip').not('.helptipified').each(function() {
     $(this).addClass('helptipified')
     var content
-    if ($(this).attr('rel') && $(this).attr('rel').match(/^#/)) {
+    if ( $( this ).attr( "rel" )?.match( /^#/ ) ) {
       content = $($(this).attr('rel')).html()
     } else {
       content = $(this).attr('rel')

--- a/app/assets/javascripts/messages/new.js
+++ b/app/assets/javascripts/messages/new.js
@@ -1,6 +1,6 @@
 /* global _ */
 
-$( document ).ready( function ( ) {
+$( document ).ready( ( ) => {
   if ( $( "#new_message .user_name" ).length > 0 ) {
     $( "#new_message .user_name" ).userAutocomplete( {
       resetOnChange: false,
@@ -16,13 +16,13 @@ $( document ).ready( function ( ) {
     } );
   }
 
-  $( "#new_message" ).submit( function ( ) {
+  $( "#new_message" ).submit( ( ) => {
     $( "#new_message" ).data( { submitted: true } );
   } );
 
   // use `window.onbeforeunload` to trigger a browser warning when leaving the page
   // and there is any text at all in either the subject or body of the new message
-  window.onbeforeunload = function ( ) {
+  window.onbeforeunload = ( ) => {
     if ( $( "#new_message" ).data( "submitted" ) ) {
       return null;
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # Compress JavaScripts and CSS
   # Choose the compressors to use (if any)
   config.assets.compress = true
-  config.assets.js_compressor = Uglifier.new( mangle: false )
+  config.assets.js_compressor = :terser
   config.assets.css_compressor = :yui
 
   # Don't fallback to assets pipeline if a precompiled asset is missed


### PR DESCRIPTION
Switches from uglifier to terser to support modern Javascript syntax. Uglifier supports ES6, but pretty much ends there, so if we want things like optional chaining, we need a different compressor. FWIW, [this seems to be what Rails itself uses these days](https://github.com/rails/sprockets/pull/713).

Closes WEB-704