### PR TITLE
refactor: update licenses in batches when changing user preference

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -674,7 +674,17 @@ class User < ApplicationRecord
   end
 
   def update_observation_licenses
-    Observation.where( user_id: id ).update_all( license: preferred_observation_license, updated_at: Time.now )
+    if observations_count > 1000
+      observation_ids.in_groups_of( 1000 ).each do | ids |
+        Observation.
+          where( id: ids ).
+          update_all( license: preferred_observation_license, updated_at: Time.now )
+      end
+    else
+      Observation.
+        where( user_id: id ).
+        update_all( license: preferred_observation_license, updated_at: Time.now )
+    end
     index_observations
   end
 
@@ -692,8 +702,18 @@ class User < ApplicationRecord
     license_number = Photo.license_number_for_code( preferred_photo_license )
     return true unless license_number
 
-    Photo.where( "user_id = ? AND type != 'GoogleStreetViewPhoto'", id ).
-      update_all( license: license_number, updated_at: Time.now )
+    if photos.count > 1000
+      photos.pluck( :id ).in_groups_of( 1000 ) do | ids |
+        Photo.
+          where( id: ids ).
+          where( "type != 'GoogleStreetViewPhoto'" ).
+          update_all( license: license_number, updated_at: Time.now )
+      end
+    else
+      Photo.where( "user_id = ? AND type != 'GoogleStreetViewPhoto'", id ).
+        update_all( license: license_number, updated_at: Time.now )
+    end
+
     index_observations
     User.enqueue_photo_bucket_moving_jobs( id )
   end
@@ -712,7 +732,13 @@ class User < ApplicationRecord
     license_number = Photo.license_number_for_code( preferred_sound_license )
     return true unless license_number
 
-    Sound.where( user_id: id ).update_all( license: license_number, updated_at: Time.now )
+    if sounds.count > 1000
+      sounds.pluck( :id ).in_groups_of( 1000 ) do | ids |
+        Sound.where( id: ids ).update_all( license: license_number, updated_at: Time.now )
+      end
+    else
+      Sound.where( user_id: id ).update_all( license: license_number, updated_at: Time.now )
+    end
     index_observations
   end
 


### PR DESCRIPTION
FWIW, the query to fetch all relevant IDs can still be a bit slow, but each batch is then only a few seconds.

Closes WEB-698