### PR TITLE
refactor: reduce reducer confusion in users/edit

### DIFF
--- a/app/webpack/users/edit/components/account.jsx
+++ b/app/webpack/users/edit/components/account.jsx
@@ -10,14 +10,14 @@ import PlaceAutocomplete from "../../../observations/identify/components/place_a
 
 const Account = ( {
   config,
-  profile,
   handleCustomDropdownSelect,
   handleInputChange,
   handlePlaceAutocomplete,
-  sites
+  sites,
+  userSettings
 } ) => {
   if ( !sites ) { return null; }
-  const siteId = profile.site_id || 1;
+  const siteId = userSettings.site_id || 1;
   const currentNetworkAffiliation = sites.filter( site => site.id === siteId )[0];
 
   // these locales are not available for all regions (like "en-US")
@@ -25,7 +25,7 @@ const Account = ( {
   const localeListKeys = Object.keys( I18n.t( "locales", { locale: "en" } ) );
 
   const setLocale = ( ) => {
-    let { locale } = profile;
+    let { locale } = userSettings;
     locale = locale || I18n.locale;
     if ( localeListKeys.includes( locale ) ) {
       return locale;
@@ -58,21 +58,6 @@ const Account = ( {
       <div className="caret" />
     </div>
   );
-
-  const createINatAffiliationList = ( ) => sites.map( site => {
-    const { id, name } = site;
-
-    return (
-      <MenuItem
-        key={`inat-affiliation-logo-${id}`}
-        eventKey={id}
-      >
-        {showNetworkLogo( id, site.icon_url )}
-        <div className="text-muted">{name}</div>
-        {siteId === id && <i className="fa fa-check blue-checkmark" aria-hidden="true" />}
-      </MenuItem>
-    );
-  } );
 
   const thirdPartyTrackingModalDescription = (
     <div>
@@ -150,7 +135,7 @@ const Account = ( {
             <PlaceAutocomplete
               config={config}
               resetOnChange={false}
-              initialPlaceID={profile.search_place_id}
+              initialPlaceID={userSettings.search_place_id}
               bootstrapClear
               afterSelect={e => handlePlaceAutocomplete( e, "search_place_id" )}
               afterClear={( ) => handlePlaceAutocomplete( { item: { id: 0 } }, "search_place_id" )}
@@ -158,7 +143,7 @@ const Account = ( {
           </SettingsItem>
           <SettingsItem header={I18n.t( "activerecord.attributes.user.time_zone" )} htmlFor="user_time_zone">
             <p className="text-muted">{I18n.t( "default_display_time_zone" )}</p>
-            <select id="user_time_zone" className="form-control dropdown" value={profile.time_zone} name="time_zone" onChange={handleInputChange}>
+            <select id="user_time_zone" className="form-control dropdown" value={userSettings.time_zone} name="time_zone" onChange={handleInputChange}>
               {createTimeZoneList( )}
             </select>
           </SettingsItem>
@@ -175,7 +160,7 @@ const Account = ( {
               label={I18n.t( "pi_consent_label" )}
               modalDescription={I18n.t( "pi_consent_desc_html", { privacy_url: "/privacy", terms_url: "/terms" } )}
               modalDescriptionTitle={I18n.t( "pi_consent_desc_title" )}
-              disabled={profile.pi_consent}
+              disabled={userSettings.pi_consent}
               confirm={I18n.t( "revoke_privacy_consent_warning" )}
             />
             <CheckboxRowContainer
@@ -183,7 +168,7 @@ const Account = ( {
               label={I18n.t( "data_transfer_consent_label" )}
               modalDescription={I18n.t( "data_transfer_consent_desc_html", { privacy_url: "/privacy", terms_url: "/terms" } )}
               modalDescriptionTitle={I18n.t( "data_transfer_consent_desc_title" )}
-              disabled={profile.data_transfer_consent}
+              disabled={userSettings.data_transfer_consent}
               confirm={I18n.t( "revoke_privacy_consent_warning" )}
             />
           </SettingsItem>
@@ -199,7 +184,16 @@ const Account = ( {
                     title={showCurrentNetwork( )}
                     noCaret
                   >
-                    {createINatAffiliationList( )}
+                    {sites.map( site => (
+                      <MenuItem
+                        key={`inat-affiliation-logo-${site.id}`}
+                        eventKey={site.id}
+                      >
+                        {showNetworkLogo( site.id, site.icon_url )}
+                        <div className="text-muted">{site.name}</div>
+                        {siteId === site.id && <i className="fa fa-check blue-checkmark" aria-hidden="true" />}
+                      </MenuItem>
+                    ) )}
                   </DropdownButton>
                 </div>
                 <p
@@ -240,11 +234,10 @@ const Account = ( {
 
 Account.propTypes = {
   config: PropTypes.object,
-  profile: PropTypes.object,
+  userSettings: PropTypes.object,
   handleCustomDropdownSelect: PropTypes.func,
   handleInputChange: PropTypes.func,
   handlePlaceAutocomplete: PropTypes.func,
-  showModalDescription: PropTypes.func,
   sites: PropTypes.array
 };
 

--- a/app/webpack/users/edit/components/app.jsx
+++ b/app/webpack/users/edit/components/app.jsx
@@ -34,9 +34,9 @@ class App extends Component {
 
   handleUnload( e ) {
     if ( !this.props ) return;
-    const { profile } = this.props;
+    const { userSettings } = this.props;
 
-    if ( profile && profile.saved_status === "unsaved" ) {
+    if ( userSettings?.saved_status === "unsaved" ) {
       // preventing default within this if statement makes this work on both Chrome and Firefox
       // https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#browser_compatibility
       e.preventDefault( );
@@ -109,9 +109,9 @@ class App extends Component {
 }
 
 App.propTypes = {
-  profile: PropTypes.object,
   section: PropTypes.number,
-  setContainerIndex: PropTypes.func
+  setContainerIndex: PropTypes.func,
+  userSettings: PropTypes.object
 };
 
 export default App;

--- a/app/webpack/users/edit/components/checkbox_row.jsx
+++ b/app/webpack/users/edit/components/checkbox_row.jsx
@@ -12,8 +12,8 @@ const CheckboxRow = ( {
   modalDescription,
   modalDescriptionTitle,
   name,
-  profile,
-  showModalDescription
+  showModalDescription,
+  userSettings
 } ) => (
   <div className="row">
     <div className="col-xs-12">
@@ -22,8 +22,8 @@ const CheckboxRow = ( {
           <input
             id={`user_${name}`}
             type="checkbox"
-            // false when profile[name] is undefined
-            checked={profile[name] || false}
+            // false when userSettings[name] is undefined
+            checked={userSettings[name] || false}
             name={name}
             disabled={disabled}
             onChange={e => {
@@ -76,7 +76,6 @@ const CheckboxRow = ( {
 );
 
 CheckboxRow.propTypes = {
-  profile: PropTypes.object,
   name: PropTypes.string,
   handleCheckboxChange: PropTypes.func,
   label: PropTypes.string,
@@ -87,7 +86,8 @@ CheckboxRow.propTypes = {
   modalClassName: PropTypes.string,
   modalDescription: PropTypes.any,
   modalDescriptionTitle: PropTypes.string,
-  showModalDescription: PropTypes.func
+  showModalDescription: PropTypes.func,
+  userSettings: PropTypes.object
 };
 
 export default CheckboxRow;

--- a/app/webpack/users/edit/components/content.jsx
+++ b/app/webpack/users/edit/components/content.jsx
@@ -21,11 +21,11 @@ const obsFields = {
 };
 
 const Content = ( {
-  profile,
   handleInputChange,
   handleCustomDropdownSelect,
   handleDisplayNames,
-  showModal
+  showModal,
+  userSettings
 } ) => {
   const iNatLicenses = iNaturalist.Licenses;
   const licenseList = ["cc0", "cc-by", "cc-by-nc", "cc-by-nc-sa", "cc-by-nc-nd", "cc-by-nd", "cc-by-sa", "c"];
@@ -38,7 +38,7 @@ const Content = ( {
           type="radio"
           value={button}
           name="preferred_project_addition_by"
-          checked={profile.preferred_project_addition_by === button}
+          checked={userSettings.preferred_project_addition_by === button}
           onChange={handleInputChange}
         />
         {radioButtons[button]}
@@ -68,14 +68,14 @@ const Content = ( {
         eventKey={code}
       >
         <LicenseImageRow license={license} />
-        {profile[name] === code && <i className="fa fa-check blue-checkmark" aria-hidden="true" />}
+        {userSettings[name] === code && <i className="fa fa-check blue-checkmark" aria-hidden="true" />}
       </MenuItem>
     );
   } );
 
   const setDisplayName = ( ) => {
-    if ( profile.prefers_common_names ) {
-      if ( !profile.prefers_scientific_name_first ) {
+    if ( userSettings.prefers_common_names ) {
+      if ( !userSettings.prefers_scientific_name_first ) {
         return "prefers_common_names";
       }
       return "prefers_scientific_name_first";
@@ -149,7 +149,7 @@ const Content = ( {
               <DropdownButton
                 id="preferred_observation_license"
                 onSelect={e => handleCustomDropdownSelect( e, "preferred_observation_license" )}
-                title={showDefaultLicense( profile.preferred_observation_license )}
+                title={showDefaultLicense( userSettings.preferred_observation_license )}
                 noCaret
               >
                 {createLicenseList( "preferred_observation_license" )}
@@ -168,7 +168,7 @@ const Content = ( {
               <DropdownButton
                 id="preferred_photo_license"
                 onSelect={e => handleCustomDropdownSelect( e, "preferred_photo_license" )}
-                title={showDefaultLicense( profile.preferred_photo_license )}
+                title={showDefaultLicense( userSettings.preferred_photo_license )}
                 noCaret
               >
                 {createLicenseList( "preferred_photo_license" )}
@@ -187,7 +187,7 @@ const Content = ( {
               <DropdownButton
                 id="preferred_sound_license"
                 onSelect={e => handleCustomDropdownSelect( e, "preferred_sound_license" )}
-                title={showDefaultLicense( profile.preferred_sound_license )}
+                title={showDefaultLicense( userSettings.preferred_sound_license )}
                 noCaret
               >
                 {createLicenseList( "preferred_sound_license" )}
@@ -243,7 +243,7 @@ const Content = ( {
             <select
               className="form-control dropdown"
               id="preferred_observation_fields_by"
-              value={profile.preferred_observation_fields_by}
+              value={userSettings.preferred_observation_fields_by}
               name="preferred_observation_fields_by"
               onChange={handleInputChange}
             >
@@ -259,11 +259,11 @@ const Content = ( {
 };
 
 Content.propTypes = {
-  profile: PropTypes.object,
   handleInputChange: PropTypes.func,
   handleCustomDropdownSelect: PropTypes.func,
   handleDisplayNames: PropTypes.func,
-  showModal: PropTypes.func
+  showModal: PropTypes.func,
+  userSettings: PropTypes.object
 };
 
 export default Content;

--- a/app/webpack/users/edit/components/notifications.jsx
+++ b/app/webpack/users/edit/components/notifications.jsx
@@ -5,7 +5,7 @@ import CheckboxRowContainer from "../containers/checkbox_row_container";
 import SettingsItem from "./settings_item";
 import ToggleSwitchContainer from "../containers/toggle_switch_container";
 
-const Notifications = ( { profile } ) => (
+const Notifications = ( { userSettings } ) => (
   <div className="row">
     <div className="col-xs-12 col-md-10">
       <SettingsItem>
@@ -17,7 +17,7 @@ const Notifications = ( { profile } ) => (
           </div>
           <ToggleSwitchContainer
             name="prefers_receive_mentions"
-            checked={profile.prefers_receive_mentions}
+            checked={userSettings.prefers_receive_mentions}
           />
         </div>
         <div className="row stacked">
@@ -27,7 +27,7 @@ const Notifications = ( { profile } ) => (
           </div>
           <ToggleSwitchContainer
             name="prefers_redundant_identification_notifications"
-            checked={profile.prefers_redundant_identification_notifications}
+            checked={userSettings.prefers_redundant_identification_notifications}
           />
         </div>
         <div className="row">
@@ -37,7 +37,7 @@ const Notifications = ( { profile } ) => (
           </div>
           <ToggleSwitchContainer
             name="prefers_infraspecies_identification_notifications"
-            checked={profile.prefers_infraspecies_identification_notifications}
+            checked={userSettings.prefers_infraspecies_identification_notifications}
           />
         </div>
         <div className="row">
@@ -47,7 +47,7 @@ const Notifications = ( { profile } ) => (
           </div>
           <ToggleSwitchContainer
             name="prefers_non_disagreeing_identification_notifications"
-            checked={profile.prefers_non_disagreeing_identification_notifications}
+            checked={userSettings.prefers_non_disagreeing_identification_notifications}
           />
         </div>
       </SettingsItem>
@@ -60,10 +60,10 @@ const Notifications = ( { profile } ) => (
           </div>
           <ToggleSwitchContainer
             name="prefers_no_email"
-            checked={!profile.prefers_no_email}
+            checked={!userSettings.prefers_no_email}
           />
         </div>
-        <div className={profile.prefers_no_email ? "collapse" : null}>
+        <div className={userSettings.prefers_no_email ? "collapse" : null}>
           <CheckboxRowContainer
             name="prefers_comment_email_notification"
             label={I18n.t( "views.users.edit.notification_preferences_comments" )}
@@ -111,7 +111,7 @@ const Notifications = ( { profile } ) => (
 );
 
 Notifications.propTypes = {
-  profile: PropTypes.object
+  userSettings: PropTypes.object
 };
 
 export default Notifications;

--- a/app/webpack/users/edit/components/profile.jsx
+++ b/app/webpack/users/edit/components/profile.jsx
@@ -15,38 +15,38 @@ const DESCRIPTION_WARNING_LENGTH = 8000;
 const MAX_DESCRIPTION_LENGTH = 10000;
 
 const Profile = ( {
-  profile,
   handleInputChange,
   handlePhotoUpload,
   onFileDrop,
   removePhoto,
   confirmResendConfirmation,
-  resendConfirmation
+  resendConfirmation,
+  userSettings
 } ) => {
   const hiddenFileInput = createRef( null );
   const iconDropzone = createRef( );
-  const descriptionLength = ( profile.description || "" ).length;
+  const descriptionLength = ( userSettings.description || "" ).length;
 
   const showFileDialog = ( ) => iconDropzone.current.open( );
 
   const showUserIcon = ( ) => {
-    if ( profile.icon && profile.icon.preview ) {
+    if ( userSettings.icon && userSettings.icon.preview ) {
       return (
         <a
           className="userimage UserImage"
-          href={`/people/${profile.login || profile.id}`}
-          title={profile.login}
+          href={`/people/${userSettings.login || userSettings.id}`}
+          title={userSettings.login}
           label={I18n.t( "profile_picture" )}
-          style={{ backgroundImage: `url("${profile.icon.preview}")` }}
+          style={{ backgroundImage: `url("${userSettings.icon.preview}")` }}
         />
       );
     }
-    return <UserImage user={profile} />;
+    return <UserImage user={userSettings} />;
   };
 
   // this gets rid of the React warning about inputs being controlled vs. uncontrolled
   // by ensuring user data is fetched before the Profile & User page loads
-  if ( _.isEmpty( profile ) ) {
+  if ( _.isEmpty( userSettings ) ) {
     return null;
   }
 
@@ -54,7 +54,7 @@ const Profile = ( {
     <div className="alert alert-warning alert-mini">
       <span
         dangerouslySetInnerHTML={{
-          __html: I18n.t( "change_to_email_requested_html", { email: profile.unconfirmed_email } )
+          __html: I18n.t( "change_to_email_requested_html", { email: userSettings.unconfirmed_email } )
         }}
       />
       { " " }
@@ -72,23 +72,23 @@ const Profile = ( {
     <div>
       <p className="text-success">
         { I18n.t( "confirmed_on_date", {
-          date: moment( profile.confirmed_at ).format( I18n.t( "momentjs.date_long" ) )
+          date: moment( userSettings.confirmed_at ).format( I18n.t( "momentjs.date_long" ) )
         } )}
       </p>
-      { profile.unconfirmed_email && unconfirmedEmailAlert }
+      { userSettings.unconfirmed_email && unconfirmedEmailAlert }
     </div>
   );
-  if ( !profile.confirmed_at && profile.unconfirmed_email ) {
+  if ( !userSettings.confirmed_at && userSettings.unconfirmed_email ) {
     emailConfirmation = unconfirmedEmailAlert;
-  } else if ( !profile.confirmed_at ) {
+  } else if ( !userSettings.confirmed_at ) {
     emailConfirmation = (
       <div
-        className={`alert alert-mini alert-${profile.confirmation_sent_at ? "warning" : "danger"}`}
+        className={`alert alert-mini alert-${userSettings.confirmation_sent_at ? "warning" : "danger"}`}
       >
         {
-          profile.confirmation_sent_at
+          userSettings.confirmation_sent_at
             ? I18n.t( "confirmation_email_sent_at_datetime", {
-              datetime: moment( profile.confirmation_sent_at ).format( I18n.t( "momentjs.datetime_with_zone_no_year" ) )
+              datetime: moment( userSettings.confirmation_sent_at ).format( I18n.t( "momentjs.datetime_with_zone_no_year" ) )
             } )
             : I18n.t( "you_have_not_confirmed_your_email_address" )
         }
@@ -99,7 +99,7 @@ const Profile = ( {
           onClick={( ) => confirmResendConfirmation( )}
         >
           {
-            profile.confirmation_sent_at
+            userSettings.confirmation_sent_at
               ? I18n.t( "resend_confirmation_email" )
               : I18n.t( "send_confirmation_email", {
                 defaultValue: I18n.t( "resend_confirmation_email" )
@@ -115,7 +115,7 @@ const Profile = ( {
       <div className="col-md-5 col-sm-10">
         <h4>{I18n.t( "profile" )}</h4>
         <SettingsItem header={I18n.t( "profile_picture" )} htmlFor="user_icon">
-          <UserError user={profile} attribute="icon_content_type" alias="profile_picture_file_type" />
+          <UserError user={userSettings} attribute="icon_content_type" alias="profile_picture_file_type" />
           <Dropzone
             ref={iconDropzone}
             className="dropzone"
@@ -177,51 +177,51 @@ const Profile = ( {
         </SettingsItem>
         <SettingsItem header={I18n.t( "username" )} required htmlFor="user_login">
           <div className="text-muted help-text">{I18n.t( "username_description" )}</div>
-          <UserError user={profile} attribute="login" alias="username" />
+          <UserError user={userSettings} attribute="login" alias="username" />
           <input
             id="user_login"
             type="text"
             className="form-control"
-            value={profile.login}
+            value={userSettings.login}
             name="login"
             onChange={handleInputChange}
           />
         </SettingsItem>
         <SettingsItem header={I18n.t( "email" )} required htmlFor="user_email">
           <div className="text-muted help-text">{I18n.t( "email_description" )}</div>
-          <UserError user={profile} attribute="email" />
+          <UserError user={userSettings} attribute="email" />
           <input
             id="user_email"
             type="text"
             className="form-control"
-            value={profile.email || ""}
+            value={userSettings.email || ""}
             name="email"
             onChange={handleInputChange}
           />
           { emailConfirmation }
         </SettingsItem>
-        <ChangePasswordContainer user={profile} />
+        <ChangePasswordContainer user={userSettings} />
       </div>
       <div className="col-md-offset-1 col-md-6 col-sm-10">
         <SettingsItem header={I18n.t( "display_name" )} htmlFor="user_name">
           <div className="text-muted help-text">{I18n.t( "display_name_description" )}</div>
-          <UserError user={profile} attribute="name" />
+          <UserError user={userSettings} attribute="name" />
           <input
             id="user_name"
             type="text"
             className="form-control"
-            value={profile.name || ""}
+            value={userSettings.name || ""}
             name="name"
             onChange={handleInputChange}
           />
         </SettingsItem>
         <SettingsItem header={I18n.t( "bio" )} htmlFor="user_description">
           <div className="text-muted help-text">{I18n.t( "bio_description" )}</div>
-          <UserError user={profile} attribute="description" />
+          <UserError user={userSettings} attribute="description" />
           <textarea
             id="user_description"
             className="form-control user-description"
-            value={profile.description || ""}
+            value={userSettings.description || ""}
             name="description"
             onChange={handleInputChange}
           />
@@ -242,7 +242,7 @@ const Profile = ( {
                 url: "https://www.inaturalist.org/monthly-supporters?utm_campaign=monthly-supporter&utm_content=inline-link&utm_medium=web&utm_source=inaturalist.org&utm_term=account-settings"
               } )
             }
-            disabled={!profile.monthly_supporter}
+            disabled={!userSettings.monthly_supporter}
           />
         </SettingsItem>
       </div>
@@ -251,13 +251,13 @@ const Profile = ( {
 };
 
 Profile.propTypes = {
-  profile: PropTypes.object,
+  confirmResendConfirmation: PropTypes.func,
   handleInputChange: PropTypes.func,
   handlePhotoUpload: PropTypes.func,
   onFileDrop: PropTypes.func,
   removePhoto: PropTypes.func,
   resendConfirmation: PropTypes.func,
-  confirmResendConfirmation: PropTypes.func
+  userSettings: PropTypes.object
 };
 
 export default Profile;

--- a/app/webpack/users/edit/components/save_button.jsx
+++ b/app/webpack/users/edit/components/save_button.jsx
@@ -2,17 +2,17 @@ import React from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
 
-const SaveButton = ( { saveUserSettings, profile } ) => {
-  const disabled = profile.saved_status === null || profile.saved_status === "saved";
+const SaveButton = ( { saveUserSettings, userSettings } ) => {
+  const disabled = userSettings.saved_status === null || userSettings.saved_status === "saved";
 
   return (
     <div className="flex-no-wrap save-button">
-      <div className={profile.saved_status === "saved" ? "text-muted saved-time status" : "collapse"}>
+      <div className={userSettings.saved_status === "saved" ? "text-muted saved-time status" : "collapse"}>
         { I18n.t( "saved_at_time", {
-          time: moment( profile.updated_at ).format( I18n.t( "momentjs.time_hours" ) )
+          time: moment( userSettings.updated_at ).format( I18n.t( "momentjs.time_hours" ) )
         } ) }
       </div>
-      <div className={profile.errors ? "text-danger status" : "collapse"}>
+      <div className={userSettings.errors ? "text-danger status" : "collapse"}>
         { I18n.t( "doh_something_went_wrong" ) }
       </div>
       <button
@@ -28,8 +28,8 @@ const SaveButton = ( { saveUserSettings, profile } ) => {
 };
 
 SaveButton.propTypes = {
-  profile: PropTypes.object,
-  saveUserSettings: PropTypes.func
+  saveUserSettings: PropTypes.func,
+  userSettings: PropTypes.object
 };
 
 export default SaveButton;

--- a/app/webpack/users/edit/containers/account_container.js
+++ b/app/webpack/users/edit/containers/account_container.js
@@ -10,7 +10,7 @@ import {
 function mapStateToProps( state ) {
   return {
     config: state.config,
-    profile: state.profile,
+    userSettings: state.userSettings,
     sites: state.sites.sites
   };
 }

--- a/app/webpack/users/edit/containers/app_container.js
+++ b/app/webpack/users/edit/containers/app_container.js
@@ -7,7 +7,7 @@ import { setSelectedSectionFromMenu } from "../ducks/app_sections";
 
 function mapStateToProps( state ) {
   return {
-    profile: state.profile,
+    userSettings: state.userSettings,
     section: state.section.section
   };
 }

--- a/app/webpack/users/edit/containers/checkbox_row_container.js
+++ b/app/webpack/users/edit/containers/checkbox_row_container.js
@@ -6,7 +6,7 @@ import { handleCheckboxChange } from "../ducks/user_settings";
 
 function mapStateToProps( state ) {
   return {
-    profile: state.profile
+    userSettings: state.userSettings
   };
 }
 

--- a/app/webpack/users/edit/containers/content_container.js
+++ b/app/webpack/users/edit/containers/content_container.js
@@ -12,7 +12,7 @@ import { showModal } from "../ducks/cc_licensing_modal";
 function mapStateToProps( state ) {
   return {
     config: state.config,
-    profile: state.profile
+    userSettings: state.userSettings
   };
 }
 

--- a/app/webpack/users/edit/containers/favorite_projects_container.js
+++ b/app/webpack/users/edit/containers/favorite_projects_container.js
@@ -4,7 +4,7 @@ import { fetchFavoriteProjects } from "../ducks/favorite_projects";
 import {
   addFavoriteProject,
   NO_CHANGE,
-  saveUserSettings,
+  postUserSettings,
   updateUserData
 } from "../ducks/user_settings";
 
@@ -24,11 +24,11 @@ function mapDispatchToProps( dispatch ) {
   return {
     addProject: project => {
       dispatch( addFavoriteProject( project ) );
-      dispatch( saveUserSettings( { only: ["faved_project_ids"], skipFetch: true } ) );
+      dispatch( postUserSettings( { only: ["faved_project_ids"], skipFetch: true } ) );
     },
     updateFavedProjectIds: projectIds => {
       dispatch( updateUserData( { faved_project_ids: projectIds }, { savedStatus: NO_CHANGE } ) );
-      dispatch( saveUserSettings( { only: ["faved_project_ids"], skipFetch: true } ) );
+      dispatch( postUserSettings( { only: ["faved_project_ids"], skipFetch: true } ) );
       dispatch( fetchFavoriteProjects( ) );
     }
   };

--- a/app/webpack/users/edit/containers/favorite_projects_container.js
+++ b/app/webpack/users/edit/containers/favorite_projects_container.js
@@ -12,7 +12,7 @@ function mapStateToProps( state ) {
   return {
     config: state.config,
     favoriteProjects: state.favoriteProjects,
-    user: state.profile
+    user: state.userSettings
   };
 }
 

--- a/app/webpack/users/edit/containers/notifications_container.js
+++ b/app/webpack/users/edit/containers/notifications_container.js
@@ -4,7 +4,7 @@ import Notifications from "../components/notifications";
 
 function mapStateToProps( state ) {
   return {
-    profile: state.profile
+    userSettings: state.userSettings
   };
 }
 

--- a/app/webpack/users/edit/containers/profile_container.js
+++ b/app/webpack/users/edit/containers/profile_container.js
@@ -13,7 +13,7 @@ import {
 
 function mapStateToProps( state ) {
   return {
-    profile: state.profile
+    userSettings: state.userSettings
   };
 }
 

--- a/app/webpack/users/edit/containers/save_button_container.js
+++ b/app/webpack/users/edit/containers/save_button_container.js
@@ -5,7 +5,7 @@ import { postUserSettings } from "../ducks/user_settings";
 
 function mapStateToProps( state ) {
   return {
-    profile: state.profile
+    userSettings: state.userSettings
   };
 }
 

--- a/app/webpack/users/edit/containers/save_button_container.js
+++ b/app/webpack/users/edit/containers/save_button_container.js
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 
 import SaveButton from "../components/save_button";
-import { saveUserSettings } from "../ducks/user_settings";
+import { postUserSettings } from "../ducks/user_settings";
 
 function mapStateToProps( state ) {
   return {
@@ -11,7 +11,7 @@ function mapStateToProps( state ) {
 
 function mapDispatchToProps( dispatch ) {
   return {
-    saveUserSettings: newState => { dispatch( saveUserSettings( newState ) ); }
+    saveUserSettings: newState => { dispatch( postUserSettings( newState ) ); }
   };
 }
 

--- a/app/webpack/users/edit/containers/taxon_name_priorities_container.js
+++ b/app/webpack/users/edit/containers/taxon_name_priorities_container.js
@@ -9,8 +9,8 @@ import {
 function mapStateToProps( state ) {
   return {
     config: state.config,
-    profile: state.profile,
-    taxonNamePriorities: state.profile.taxon_name_priorities
+    userSettings: state.userSettings,
+    taxonNamePriorities: state.userSettings.taxon_name_priorities
   };
 }
 

--- a/app/webpack/users/edit/containers/taxon_name_priorities_dragdrop_container.js
+++ b/app/webpack/users/edit/containers/taxon_name_priorities_dragdrop_container.js
@@ -9,7 +9,7 @@ import {
 function mapStateToProps( state ) {
   return {
     config: state.config,
-    taxonNamePriorities: state.profile.taxon_name_priorities
+    taxonNamePriorities: state.userSettings.taxon_name_priorities
   };
 }
 

--- a/app/webpack/users/edit/ducks/favorite_projects.js
+++ b/app/webpack/users/edit/ducks/favorite_projects.js
@@ -22,7 +22,7 @@ export function setFavoriteProjects( projects ) {
 
 export function fetchFavoriteProjects( userArg ) {
   return function ( dispatch, getState ) {
-    const user = userArg || getState( ).profile;
+    const user = userArg || getState( ).userSettings;
     if ( !user.faved_project_ids || Number( user.faved_project_ids ) === 0 ) {
       return dispatch( setFavoriteProjects( [] ) );
     }

--- a/app/webpack/users/edit/ducks/network_sites.js
+++ b/app/webpack/users/edit/ducks/network_sites.js
@@ -20,12 +20,12 @@ export function setNetworkSites( sites ) {
 
 export function fetchNetworkSites( ) {
   return ( dispatch, getState ) => {
-    const { profile, sites } = getState( );
+    const { userSettings, sites } = getState( );
     let sitesToFetch;
     if ( sites && sites.sites ) {
       const siteIds = sites.sites.map( s => s.id );
-      if ( siteIds.indexOf( profile.site_id ) < 0 ) {
-        sitesToFetch = siteIds.concat( [profile.site_id] );
+      if ( siteIds.indexOf( userSettings.site_id ) < 0 ) {
+        sitesToFetch = siteIds.concat( [userSettings.site_id] );
       }
     }
     const params = {
@@ -37,13 +37,13 @@ export function fetchNetworkSites( ) {
     };
     inatjs.sites.fetch( sitesToFetch, params ).then( ( { results } ) => {
       dispatch( setNetworkSites( results ) );
-      const { profile: profile2 } = getState( );
+      const { userSettings: userSettings2 } = getState( );
       // If we've loaded the current user's data and they seem to be affiliated
       // with a site that we don't know about (maybe a draft), try loading that
       // specific site and adding it
       const siteIds = results.map( s => s.id );
-      if ( profile2 && profile2.site_id && siteIds.indexOf( profile2.site_id ) < 0 ) {
-        inatjs.sites.fetch( [profile2.site_id] )
+      if ( siteIds && userSettings2?.site_id && siteIds.indexOf( userSettings2.site_id ) < 0 ) {
+        inatjs.sites.fetch( [userSettings2.site_id] )
           .then( ( { results: results2 } ) => {
             dispatch( setNetworkSites( results.concat( results2 ) ) );
           } )

--- a/app/webpack/users/edit/ducks/relationships.js
+++ b/app/webpack/users/edit/ducks/relationships.js
@@ -88,9 +88,9 @@ export function setFilters( filters ) {
 
 export function fetchMutedUsers( ) {
   return ( dispatch, getState ) => {
-    const { relationships, profile, config } = getState( );
+    const { relationships, userSettings } = getState( );
     const { mutedUsers } = relationships;
-    const currentMutedUsers = profile.muted_user_ids || [];
+    const currentMutedUsers = userSettings.muted_user_ids || [];
 
     const params = {
       fields: {
@@ -129,9 +129,9 @@ export function fetchMutedUsers( ) {
 
 export function fetchBlockedUsers( ) {
   return ( dispatch, getState ) => {
-    const { relationships, profile, config } = getState( );
+    const { relationships, userSettings } = getState( );
     const { blockedUsers } = relationships;
-    const currentBlockedUsers = profile.blocked_user_ids || [];
+    const currentBlockedUsers = userSettings.blocked_user_ids || [];
 
     const params = {
       fields: {

--- a/app/webpack/users/edit/ducks/user_settings.js
+++ b/app/webpack/users/edit/ducks/user_settings.js
@@ -126,7 +126,7 @@ export async function handleSaveError( e ) {
   return null;
 }
 
-export function saveUserSettings( options = {} ) {
+export function postUserSettings( options = {} ) {
   return ( dispatch, getState ) => {
     const { profile } = getState( );
     const { id } = profile;
@@ -378,7 +378,7 @@ export function confirmResendConfirmation( ) {
           ...getState( ).profile,
           confirmation_sent_at: ( new Date( ) ).toISOString( )
         } ) );
-        await dispatch( saveUserSettings( ) );
+        await dispatch( postUserSettings( ) );
         const { profile } = getState( );
         if ( !profile.errors || profile.errors.length <= 0 ) {
           dispatch( resendConfirmation( ) );

--- a/app/webpack/users/edit/ducks/user_settings.js
+++ b/app/webpack/users/edit/ducks/user_settings.js
@@ -22,7 +22,7 @@ export default function reducer( state = { }, action ) {
   return state;
 }
 
-export function setUserData( userData, savedStatus = UNSAVED ) {
+export function setUserSettings( userData, savedStatus = UNSAVED ) {
   if ( savedStatus !== NO_CHANGE ) userData.saved_status = savedStatus;
 
   return {
@@ -73,7 +73,7 @@ export function fetchUserSettings( savedStatus, relationshipsPage ) {
         userSettings.confirmation_sent_at = profile.confirmation_sent_at;
       }
 
-      dispatch( setUserData( userSettings, savedStatus ) );
+      dispatch( setUserSettings( userSettings, savedStatus ) );
 
       if ( initialLoad ) {
         dispatch( fetchRelationships( true ) );
@@ -182,7 +182,7 @@ export function saveUserSettings( options = {} ) {
 
     // fetching user settings here to get the source of truth
     // currently users.me returns different results than
-    // dispatching setUserData( results[0] ) from users.update response
+    // dispatching setUserSettings( results[0] ) from users.update response
     return inatjs.users.update( params, { useAuth: true } )
       .then( ( ) => {
         // If we want to update without fetching the user again...
@@ -192,7 +192,7 @@ export function saveUserSettings( options = {} ) {
       } )
       .catch( e => handleSaveError( e ).then( errors => {
         profile.errors = errors;
-        dispatch( setUserData( profile, null ) );
+        dispatch( setUserSettings( profile, null ) );
       } ) );
   };
 }
@@ -206,7 +206,7 @@ export function handleCheckboxChange( e ) {
     } else {
       profile[e.target.name] = e.target.checked;
     }
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
@@ -225,14 +225,14 @@ export function handleDisplayNames( { target } ) {
       profile.prefers_common_names = false;
       profile.prefers_scientific_name_first = false;
     }
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
 export function updateUserData( updates, options = {} ) {
   return ( dispatch, getState ) => {
     const { profile: userData } = getState( );
-    dispatch( setUserData( { ...userData, ...updates }, options.savedStatus ) );
+    dispatch( setUserSettings( { ...userData, ...updates }, options.savedStatus ) );
   };
 }
 
@@ -240,7 +240,7 @@ export function handleInputChange( e ) {
   return ( dispatch, getState ) => {
     const { profile } = getState( );
     profile[e.target.name] = e.target.value;
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
@@ -248,7 +248,7 @@ export function handleCustomDropdownSelect( eventKey, name ) {
   return ( dispatch, getState ) => {
     const { profile } = getState( );
     profile[name] = eventKey;
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
@@ -263,7 +263,7 @@ export function handlePlaceAutocomplete( { item }, name ) {
     }
 
     profile[name] = item.id;
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
@@ -271,7 +271,7 @@ export function handlePhotoUpload( e ) {
   return ( dispatch, getState ) => {
     const { profile } = getState( );
     profile.icon = e.target.files[0];
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
@@ -301,7 +301,7 @@ export function onFileDrop( droppedFiles, rejectedFiles ) {
     const droppedFile = droppedFiles[0];
     if ( droppedFile.type.match( /^image\// ) ) {
       profile.icon = droppedFile;
-      dispatch( setUserData( profile ) );
+      dispatch( setUserSettings( profile ) );
     }
   };
 }
@@ -312,7 +312,7 @@ export function removePhoto( ) {
     profile.icon = null;
     profile.icon_url = null;
     profile.icon_delete = true;
-    dispatch( setUserData( profile ) );
+    dispatch( setUserSettings( profile ) );
   };
 }
 
@@ -337,7 +337,7 @@ export function changePassword( input ) {
       .catch( e => handleSaveError( e ).then( errors => {
         // catch errors such as validation errors so they can be displayed
         profile.errors = errors;
-        dispatch( setUserData( profile, null ) );
+        dispatch( setUserSettings( profile, null ) );
       } ) );
   };
 }
@@ -353,7 +353,7 @@ export function resendConfirmation( ) {
     } ).catch( e => {
       handleSaveError( e ).then( errors => {
         profile.errors = errors;
-        dispatch( setUserData( profile, null ) );
+        dispatch( setUserSettings( profile, null ) );
       } );
     } );
   };
@@ -374,7 +374,7 @@ export function confirmResendConfirmation( ) {
       onConfirm: async ( ) => {
         // Preemptively set confirmation_sent_at so the user sees a change
         // immediately
-        await dispatch( setUserData( {
+        await dispatch( setUserSettings( {
           ...getState( ).profile,
           confirmation_sent_at: ( new Date( ) ).toISOString( )
         } ) );

--- a/app/webpack/users/edit/webpack-entry.js
+++ b/app/webpack/users/edit/webpack-entry.js
@@ -21,7 +21,7 @@ import sharedStore from "../../shared/shared_store";
 moment.locale( I18n.locale );
 
 sharedStore.injectReducers( {
-  profile: userSettingsReducer,
+  userSettings: userSettingsReducer,
   sites: sitesReducer,
   revokeAccess: revokeAccessModalReducer,
   deleteRelationship: deleteRelationshipModalReducer,


### PR DESCRIPTION
* make user_settings.js export a reducer that reduces a part of state called userSettings
* action in user_settings.js that sets userSettings is now called setUserSettings
* action in user_settings.js that actually posts data to the server is now called postUserSettings

Closes WEB-690