### PR TITLE
feat: allow filtering observations by whether there are disagreements

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -809,8 +809,6 @@ class Observation < ApplicationRecord
       search_filters << { term: { identifications_some_agree: true } }
     when "most_disagree"
       search_filters << { term: { identifications_most_disagree: true } }
-    when "some_disagree"
-      search_filters << { range: { num_identification_disagreements: { gt: 0 } } }
     end
 
     unless p[:nelat].blank? && p[:nelng].blank? && p[:swlat].blank? && p[:swlng].blank?

--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -809,6 +809,8 @@ class Observation < ApplicationRecord
       search_filters << { term: { identifications_some_agree: true } }
     when "most_disagree"
       search_filters << { term: { identifications_most_disagree: true } }
+    when "some_disagree"
+      search_filters << { range: { num_identification_disagreements: { gt: 0 } } }
     end
 
     unless p[:nelat].blank? && p[:nelng].blank? && p[:swlat].blank? && p[:swlng].blank?

--- a/app/webpack/observations/identify/components/filter_checkbox.jsx
+++ b/app/webpack/observations/identify/components/filter_checkbox.jsx
@@ -9,6 +9,7 @@ import { isBlank } from "../../../shared/util";
 
 const FilterCheckbox = ( {
   checked,
+  className,
   defaultParams,
   disabled,
   label,
@@ -22,7 +23,7 @@ const FilterCheckbox = ( {
   const checkedVal = ( checked || true ).toString( );
   const vals = _.has( params, param ) ? params[param].toString( ).split( "," ) : [];
   const thisValChecked = vals.indexOf( checkedVal ) >= 0;
-  const cssClass = "FilterCheckbox checkbox";
+  const cssClass = `FilterCheckbox checkbox ${className}`;
   let labelClass = "";
   if ( params[param] !== defaultParams[param] && thisValChecked ) {
     labelClass += " filter-changed";
@@ -79,6 +80,7 @@ const FilterCheckbox = ( {
           <button
             type="button"
             className="btn btn-nostyle"
+            alt={I18n.t( "info" )}
           >
             <i className="fa fa-info-circle" />
           </button>
@@ -94,6 +96,7 @@ FilterCheckbox.propTypes = {
     PropTypes.string,
     PropTypes.number
   ] ),
+  className: PropTypes.string,
   defaultParams: PropTypes.object,
   disabled: PropTypes.bool,
   label: PropTypes.string,

--- a/app/webpack/observations/identify/components/filters_button.jsx
+++ b/app/webpack/observations/identify/components/filters_button.jsx
@@ -90,15 +90,7 @@ class FiltersButton extends React.Component {
         config.currentUser.curator_projects,
         p => [p.id, p.slug].includes( params.project_id )
       );
-    const FilterCheckboxWrapper = checkbox => (
-      <FilterCheckbox
-        {...Object.assign( {}, checkbox, {
-          defaultParams,
-          params,
-          updateSearchParams
-        } )}
-      />
-    );
+
     const visibleRanks = [
       "kingdom",
       "phylum",
@@ -200,23 +192,32 @@ class FiltersButton extends React.Component {
         </Row>
         <Row>
           <Col className="quality-filters" xs="12">
-            <FilterCheckboxWrapper
-              param="quality_grade"
-              label={I18n.t( "casual_" )}
+            <FilterCheckbox
               checked="casual"
+              defaultParams={defaultParams}
+              label={I18n.t( "casual_" )}
               noBlank
-            />
-            <FilterCheckboxWrapper
               param="quality_grade"
-              label={I18n.t( "needs_id_" )}
+              params={params}
+              updateSearchParams={updateSearchParams}
+            />
+            <FilterCheckbox
               checked="needs_id"
+              defaultParams={defaultParams}
+              label={I18n.t( "needs_id_" )}
               noBlank
-            />
-            <FilterCheckboxWrapper
               param="quality_grade"
-              label={I18n.t( "research_grade" )}
+              params={params}
+              updateSearchParams={updateSearchParams}
+            />
+            <FilterCheckbox
               checked="research"
+              defaultParams={defaultParams}
+              label={I18n.t( "research_grade" )}
               noBlank
+              param="quality_grade"
+              params={params}
+              updateSearchParams={updateSearchParams}
             />
           </Col>
         </Row>
@@ -233,20 +234,46 @@ class FiltersButton extends React.Component {
               { param: "captive", key: "show-filter-captive" },
               { param: "threatened", key: "show-filter-threatened" },
               { param: "introduced", key: "show-filter-introduced" },
-              { param: "popular", key: "show-filter-popular" }
-            ].map( FilterCheckboxWrapper ) }
+              { param: "popular", key: "show-filter-popular" },
+            ].map( props => (
+              <FilterCheckbox
+                checked={props.checked}
+                defaultParams={defaultParams}
+                key={props.key}
+                label={props.label}
+                param={props.param}
+                params={params}
+                updateSearchParams={updateSearchParams}
+              />
+            ) ) }
           </Col>
           <Col className="filters-left-col" xs="6">
             { [
               { param: "sounds", key: "show-filter-sounds", label: I18n.t( "has_sounds" ) },
               { param: "photos", key: "show-filter-photos", label: I18n.t( "has_photos" ) },
               {
+                param: "identifications",
+                key: "show-filter-disagreements",
+                label: I18n.t( "disagreements" ),
+                checked: "some_disagree"
+              },
+              {
                 param: "user_id",
                 key: "show-filter-user_id",
                 label: I18n.t( "your_observations" ),
                 checked: CURRENT_USER.id
               }
-            ].map( FilterCheckboxWrapper ) }
+            ].map( props => (
+              <FilterCheckbox
+                checked={props.checked}
+                defaultParams={defaultParams}
+                key={props.key}
+                label={props.label}
+                param={props.param}
+                params={params}
+                updateSearchParams={updateSearchParams}
+              />
+            ) ) }
           </Col>
         </Row>
         <Row>
@@ -536,11 +563,14 @@ class FiltersButton extends React.Component {
             <input value={params.project_id} type="hidden" name="project_id" />
           </div>
           { params.project_id && viewerCuratesProject && (
-            <FilterCheckboxWrapper
-              param="coords_viewable_for_proj"
-              label={I18n.t( "coords_viewable_for_proj_label" )}
-              tipText={I18n.t( "coords_viewable_for_proj_desc" )}
+            <FilterCheckbox
               checked="true"
+              defaultParams={defaultParams}
+              label={I18n.t( "coords_viewable_for_proj_label" )}
+              param="coords_viewable_for_proj"
+              params={params}
+              tipText={I18n.t( "coords_viewable_for_proj_desc" )}
+              updateSearchParams={updateSearchParams}
             />
           ) }
         </div>
@@ -711,15 +741,21 @@ class FiltersButton extends React.Component {
         <label className="sectionlabel">
           { I18n.t( "geospatial" ) }
         </label>
-        <FilterCheckboxWrapper
-          param="with_private_location"
+        <FilterCheckbox
+          checked="false"
+          defaultParams={defaultParams}
           label={I18n.t( "hide_observations_with_private_locations" )}
-          checked="false"
+          param="with_private_location"
+          params={params}
+          updateSearchParams={updateSearchParams}
         />
-        <FilterCheckboxWrapper
-          param="expected_nearby"
-          label={I18n.t( "not_expected_nearby" )}
+        <FilterCheckbox
           checked="false"
+          defaultParams={defaultParams}
+          label={I18n.t( "not_expected_nearby" )}
+          param="expected_nearby"
+          params={params}
+          updateSearchParams={updateSearchParams}
         />
         <div className="form-group">
           <div className="input-group accuracy" title={I18n.t( "accuracy_meters" )}>

--- a/app/webpack/observations/identify/components/filters_button.jsx
+++ b/app/webpack/observations/identify/components/filters_button.jsx
@@ -252,10 +252,9 @@ class FiltersButton extends React.Component {
               { param: "sounds", key: "show-filter-sounds", label: I18n.t( "has_sounds" ) },
               { param: "photos", key: "show-filter-photos", label: I18n.t( "has_photos" ) },
               {
-                param: "identifications",
+                param: "disagreements",
                 key: "show-filter-disagreements",
-                label: I18n.t( "disagreements" ),
-                checked: "some_disagree"
+                label: I18n.t( "disagreements" )
               },
               {
                 param: "user_id",

--- a/app/webpack/observations/identify/components/filters_button.jsx
+++ b/app/webpack/observations/identify/components/filters_button.jsx
@@ -177,6 +177,28 @@ class FiltersButton extends React.Component {
       "CC-BY-NC-SA",
       "CC-BY-NC-ND"
     ];
+
+    const loggedInUser = ( config && config.currentUser ) ? config.currentUser : null;
+    const viewerIsAdmin = loggedInUser && loggedInUser.roles
+      && loggedInUser.roles.indexOf( "admin" ) >= 0;
+    const lastColCheckboxProps = [
+      { param: "sounds", key: "show-filter-sounds", label: I18n.t( "has_sounds" ) },
+      { param: "photos", key: "show-filter-photos", label: I18n.t( "has_photos" ) },
+      {
+        param: "user_id",
+        key: "show-filter-user_id",
+        label: I18n.t( "your_observations" ),
+        checked: CURRENT_USER.id
+      }
+    ];
+    if ( viewerIsAdmin ) {
+      lastColCheckboxProps.splice( 2, 0, {
+        param: "disagreements",
+        key: "show-filter-disagreements",
+        label: I18n.t( "disagreements" ),
+        className: "admin"
+      } );
+    }
     const mainLeftCol = (
       <Col xs="4">
         <Row>
@@ -234,7 +256,7 @@ class FiltersButton extends React.Component {
               { param: "captive", key: "show-filter-captive" },
               { param: "threatened", key: "show-filter-threatened" },
               { param: "introduced", key: "show-filter-introduced" },
-              { param: "popular", key: "show-filter-popular" },
+              { param: "popular", key: "show-filter-popular" }
             ].map( props => (
               <FilterCheckbox
                 checked={props.checked}
@@ -248,23 +270,10 @@ class FiltersButton extends React.Component {
             ) ) }
           </Col>
           <Col className="filters-left-col" xs="6">
-            { [
-              { param: "sounds", key: "show-filter-sounds", label: I18n.t( "has_sounds" ) },
-              { param: "photos", key: "show-filter-photos", label: I18n.t( "has_photos" ) },
-              {
-                param: "disagreements",
-                key: "show-filter-disagreements",
-                label: I18n.t( "disagreements" )
-              },
-              {
-                param: "user_id",
-                key: "show-filter-user_id",
-                label: I18n.t( "your_observations" ),
-                checked: CURRENT_USER.id
-              }
-            ].map( props => (
+            { lastColCheckboxProps.map( props => (
               <FilterCheckbox
                 checked={props.checked}
+                className={props.className}
                 defaultParams={defaultParams}
                 key={props.key}
                 label={props.label}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1889,6 +1889,9 @@ en:
   disable_comments: Disable comments
   disable_comments_desc: Prevent people from adding new comments
   disagree_: Disagree
+  # Checkbox controlling whether to show observations that have disagreeing
+  # identifications or not
+  disagreements: Disagreements
   # Label for a button to disconnect your iNat account from another account,
   # e.g. disconnecting your Flickr account
   disconnect: Disconnect

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -543,6 +543,8 @@ describe "Observation Index" do
         filters: [ { term: { identifications_some_agree: true } } ] )
       expect( Observation.params_to_elastic_query({ identifications: "most_disagree" }) ).to include(
         filters: [ { term: { identifications_most_disagree: true } } ] )
+      expect( Observation.params_to_elastic_query( { identifications: "some_disagree" } ) ).
+        to include( filters: [{ range: { num_identification_disagreements: { gt: 0 } } }] )
     end
 
     it "filters by bounding box" do

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -543,8 +543,6 @@ describe "Observation Index" do
         filters: [ { term: { identifications_some_agree: true } } ] )
       expect( Observation.params_to_elastic_query({ identifications: "most_disagree" }) ).to include(
         filters: [ { term: { identifications_most_disagree: true } } ] )
-      expect( Observation.params_to_elastic_query( { identifications: "some_disagree" } ) ).
-        to include( filters: [{ range: { num_identification_disagreements: { gt: 0 } } }] )
     end
 
     it "filters by bounding box" do


### PR DESCRIPTION
Adds `disagreements=true` param to the Identify UI to allow people to search for observations that have some disagreement. Requires a new `identification_disagreements_count` attribute in the observations index, so we'll need to reindex ~20M observations, which I estimate will take about 2 weeks with a single process.

In terms of review, I'm never sure if I'm changing the index in the right way or not, so just want to double check. I imagine I'll need to update the production index before deploying like this:

```ruby
Observation.__elasticsearch__.client.indices.put_mapping(
  index: Observation.index_name,
  body: {
    properties: {
      identification_disagreements_count: { type: "integer" }
    }
  }
)
```

Identify integration depends on https://github.com/inaturalist/iNaturalistAPI/pull/517

WEB-508