### PR TITLE
fix: stop dashboard updates after user unsubscribed from resource

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -435,7 +435,10 @@ class UsersController < ApplicationController
     @pagination_updates = current_user.recent_notifications(
       filters: filters, per_page: 50
     )
-    @updates = UpdateAction.load_additional_activity_updates( @pagination_updates, current_user.id )
+    @updates = UpdateAction.load_all_update_actions_for_updated_resources_for_user(
+      @pagination_updates,
+      current_user.id
+    )
     UpdateAction.preload_associations( @updates, [:resource, :notifier, :resource_owner] )
     obs = UpdateAction.components_of_class( Observation, @updates )
     taxa = UpdateAction.components_of_class( Taxon, @updates )
@@ -460,7 +463,7 @@ class UsersController < ApplicationController
     Taxon.preload_associations( taxa, { taxon_names: :place_taxon_names } )
     User.preload_associations( with_user, :user )
     @updates.delete_if {| u | u.resource.nil? || u.notifier.nil? }
-    @grouped_updates = UpdateAction.group_and_sort( @updates, hour_groups: true )
+    @grouped_updates = UpdateAction.group_and_sort( @updates, hour_groups: true, viewer: current_user )
     respond_to do | format |
       format.html do
         render partial: "dashboard_updates", layout: false

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -20,7 +20,11 @@ class Emailer < ActionMailer::Base
     return if user.email_suppressed_in_group?( EmailSuppression::TRANSACTIONAL_EMAILS )
 
     @user = user
-    @grouped_updates = UpdateAction.group_and_sort( updates, skip_past_activity: true )
+    @grouped_updates = UpdateAction.group_and_sort(
+      updates,
+      skip_past_activity: true,
+      viewer: @user
+    )
     mail_with_defaults(
       to: user.email,
       subject: [:updates_notification_email_subject, { prefix: subject_prefix, date: Date.today }]

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subscription do
+    resource { create :observation }
+    user { association( :user_privilege, privilege: UserPrivilege::INTERACTION ).user }
+  end
+end

--- a/spec/factories/update_actions.rb
+++ b/spec/factories/update_actions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :update_action do
+    resource { create :observation }
+    notifier { create :comment, parent: resource }
+    notification { "activity" }
+  end
+end


### PR DESCRIPTION
The dashboard stubs out UpdateActions for additional content associated with resources that might generate notifications, e.g. if you are subscribed to a journal post and an UpdateAction exists for a comment on that post, you will both be notified about it on your dashboard *and* all the additional comments on that post will be loaded as well, so you can see the full context. However, we were doing that loading even if you had unsubscribed from the post, so in situations where you were subscribed, a comment was made and thus an UpdateAction existed for you, but when you unsubscribed from the post, we were showing you that UpdateAction as well as all the subsequent comments made after you unsubscribed, which made it seem like you were still subscribed to subsequent updates. This stops that additional loading if you've unsubscribed.

Closes WEB-571