### PR TITLE
fix: pluralize leaderboard identifications title for previous month correctly

### DIFF
--- a/app/views/users/leaderboard.html.haml
+++ b/app/views/users/leaderboard.html.haml
@@ -23,8 +23,9 @@
       noun_plural: 'species', 
       time_unit: @time_unit, 
       data: @most_species
-    = render 'leaderboard_column', :noun => 'identification',
-      noun_plural: 'identification',
+    = render 'leaderboard_column',
+      noun: 'identification',
+      noun_plural: 'identifications',
       time_unit: @time_unit,
       data: @most_identifications,
       last: true,


### PR DESCRIPTION
fixes: https://forum.inaturalist.org/t/minor-leaderboard-shows-identification-for-month-year-instead-of-actual-date/65554

The change corrects the pluralization of the word "identification" to "identifications", which fixes the wrong translation variable naming. Additionally adjusted the syntax for consistency (consistent key-value pairs with colons instead of hash rockets).

## Example Image (EN)

![image](https://github.com/user-attachments/assets/0ee005e2-b0e3-4a6c-9df6-2dd128cdcbbc)


Cheers
Hannes