### PR TITLE
fix: :bug: catch not defined site preference for social media links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
     <% if current_user %>
       <meta name="inaturalist-api-token" content="<%= JsonWebToken.encode( user_id: current_user.id ) %>" />
     <% end %>
-    <% if @site && !@site.x_username.blank? -%>
+    <% if @site && @site.try(:x_username).present? -%>
       <meta name="twitter:site" content="<%= @site.x_username %>">
     <% end -%>
     <% if @site %>

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -42,7 +42,7 @@
     <% if logged_in? -%>
       <meta name="inaturalist-api-token" content="<%= JsonWebToken.encode( user_id: current_user.id ) %>">
     <% end -%>
-    <% if !@site&.x_username.blank? -%>
+    <% if @site.try(:x_username).present? -%>
       <meta name="twitter:site" content="<%= @site.x_username %>">
     <% end -%>
     <meta property="og:site_name" content="<%= @site&.name %>"/>

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -38,12 +38,12 @@
           - unless site.facebook_url.blank?
             = link_to site.facebook_url, :class => "social-media-link facebook", title: t(:facebook) do
               = image_tag "facebook-f-logo-white.svg", "aria-hidden" => true
-          - unless site.x_url.blank?
+          - if site.try(:x_url).present?
             = link_to site.x_url, :class => "social-media-link x", title: "X" do
               = image_tag "x-logo.svg", "aria-hidden" => true
           - unless site.instagram_url.blank?
             = link_to t(:instagram), site.instagram_url, :class => "social-media-link instagram", title: t(:instagram)
-          - unless site.bluesky_url.blank?
+          - if site.try(:bluesky_url).present?
             = link_to site.bluesky_url, :class => "social-media-link bluesky", title: "Bluesky" do
               = image_tag "bluesky-logo.svg", "aria-hidden" => true
       = raw site.custom_footer if site.custom_footer


### PR DESCRIPTION
This fix might not be necessary and could be more of an issue in my local development environment. I encounter a `method not defined` error because my development database lacks the site values?? This is likely due to my incomplete understanding of Rails.

## Changes

The changes replace `.blank?` checks with `.try(:attribute).present?` to avoid errors when accessing attributes of `nil` objects / preferences.
