### PR TITLE
fix: link identifications leaderboard users to their identifications

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1795,4 +1795,19 @@ module ApplicationHelper
 
     URI.join( site.url.to_s, url.to_s ).to_s
   end
+
+  def leaderboard_id_link_for_user( user, count, time_unit, date = Time.now )
+    path_params = { user_id: user.login }
+    if time_unit == "year"
+      path_params[:d1] = date.beginning_of_year.strftime( "%Y-%m-%d" )
+      path_params[:d2] = date.end_of_year.strftime( "%Y-%m-%d" )
+    else
+      path_params[:d1] = date.beginning_of_month.strftime( "%Y-%m-%d" )
+      path_params[:d2] = date.end_of_month.strftime( "%Y-%m-%d" )
+    end
+    link_to(
+      t( :x_identifications_html, count: count ),
+      identifications_path( path_params )
+    )
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1795,19 +1795,4 @@ module ApplicationHelper
 
     URI.join( site.url.to_s, url.to_s ).to_s
   end
-
-  def leaderboard_id_link_for_user( user, count, time_unit, date = Time.now )
-    path_params = { user_id: user.login }
-    if time_unit == "year"
-      path_params[:d1] = date.beginning_of_year.strftime( "%Y-%m-%d" )
-      path_params[:d2] = date.end_of_year.strftime( "%Y-%m-%d" )
-    else
-      path_params[:d1] = date.beginning_of_month.strftime( "%Y-%m-%d" )
-      path_params[:d2] = date.end_of_month.strftime( "%Y-%m-%d" )
-    end
-    link_to(
-      t( :x_identifications_html, count: count ),
-      identifications_path( path_params )
-    )
-  end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -128,7 +128,7 @@
           :time_unit => 'month', 
           :data => @most_identifications, 
           :last => true,
-          :sub => Proc.new {|user, count| link_to( t(:x_identifications_html, count: count ), observations_path( user_id: user.login, on: Time.now.strftime( "%Y-%m" ) ) )} %>
+          :sub => Proc.new {|user, count| leaderboard_id_link_for_user(user, count, 'month') } %>
         <div class="column span-24">
           <div class='meta'><%=raw t :observations_observed_this_month %></div>
           <%- prev_date = Date.today - 1.month -%>
@@ -145,7 +145,7 @@
           :time_unit => 'year', 
           :data => @most_identifications_year, 
           :last => true,
-          :sub => Proc.new {|user, count| link_to( t(:x_identifications_html, count: count ), observations_path( user_id: user.login, on: Time.now.strftime( "%Y-%m" ) ) )} %>
+          :sub => Proc.new {|user, count| leaderboard_id_link_for_user(user, count, 'year') } %>
         <div class="column span-24">
           <%- prev_date = Date.today - 1.year -%>
           <%= link_to t(:view_leaderboard_from_last_year), leaderboard_for_people_path(:year => prev_date.year), :class => "readmore" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -145,7 +145,7 @@
           :time_unit => 'year', 
           :data => @most_identifications_year, 
           :last => true,
-          :sub => Proc.new {|user, count| link_to( t(:x_identifications_html, count: count ), identifications_by_login_path( user.login, on: Time.now.strftime( "%Y" ) ) )} %>      
+          :sub => Proc.new {|user, count| link_to( t(:x_identifications_html, count: count ), identifications_by_login_path( user.login, on: Time.now.strftime( "%Y" ) ) )} %>
         <div class="column span-24">
           <%- prev_date = Date.today - 1.year -%>
           <%= link_to t(:view_leaderboard_from_last_year), leaderboard_for_people_path(:year => prev_date.year), :class => "readmore" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -128,7 +128,7 @@
           :time_unit => 'month', 
           :data => @most_identifications, 
           :last => true,
-          :sub => Proc.new {|user, count| leaderboard_id_link_for_user(user, count, 'month') } %>
+          :sub => Proc.new {|user, count| link_to( t(:x_identifications_html, count: count ), identifications_by_login_path( user.login, on: Time.now.strftime( "%Y-%m" ) ) )} %>
         <div class="column span-24">
           <div class='meta'><%=raw t :observations_observed_this_month %></div>
           <%- prev_date = Date.today - 1.month -%>
@@ -145,7 +145,7 @@
           :time_unit => 'year', 
           :data => @most_identifications_year, 
           :last => true,
-          :sub => Proc.new {|user, count| leaderboard_id_link_for_user(user, count, 'year') } %>
+          :sub => Proc.new {|user, count| link_to( t(:x_identifications_html, count: count ), identifications_by_login_path( user.login, on: Time.now.strftime( "%Y" ) ) )} %>      
         <div class="column span-24">
           <%- prev_date = Date.today - 1.year -%>
           <%= link_to t(:view_leaderboard_from_last_year), leaderboard_for_people_path(:year => prev_date.year), :class => "readmore" %>

--- a/app/views/users/leaderboard.html.haml
+++ b/app/views/users/leaderboard.html.haml
@@ -29,7 +29,7 @@
       time_unit: @time_unit,
       data: @most_identifications,
       last: true,
-      sub: Proc.new {|user, count| link_to("<span class='count'>#{count}</span> #{count == 1 ? 'identification' : 'identifications'}".html_safe, identifications_by_login_path(user.login, :on => @time_unit == 'year' ? @year : "#{@year}-#{@month}"))}
+      sub: Proc.new {|user, count| leaderboard_id_link_for_user(user, count, @time_unit, @date) }
 .column.span-24
   - if @time_unit == 'year'
     %strong.left= link_to "‹ #{@year - 1}".html_safe, :year => @year - 1

--- a/app/views/users/leaderboard.html.haml
+++ b/app/views/users/leaderboard.html.haml
@@ -29,7 +29,7 @@
       time_unit: @time_unit,
       data: @most_identifications,
       last: true,
-      sub: Proc.new {|user, count| leaderboard_id_link_for_user(user, count, @time_unit, @date) }
+      sub: Proc.new {|user, count| link_to("#{t :x_identifications_html, count: count}".html_safe, identifications_by_login_path(user.login, :on => @time_unit == 'year' ? @year : "#{@year}-#{@month}"))}
 .column.span-24
   - if @time_unit == 'year'
     %strong.left= link_to "‹ #{@year - 1}".html_safe, :year => @year - 1


### PR DESCRIPTION
fixes: https://github.com/inaturalist/inaturalist/issues/4594

## Update:

Modified the _/people_ identification page to ensure it links to the correct URL with the appropriate parameters, as specified in the issue.

## Additional Fix:

Updated the _/people/leaderboard/x/x_ page to utilize the translation string.

Cheers
Hannes

