### PR TITLE
fix: users that hide content are not themselves hidden, related to WEB-724

### DIFF
--- a/app/controllers/shared/filters_module.rb
+++ b/app/controllers/shared/filters_module.rb
@@ -52,7 +52,7 @@ module Shared
       if params[:inat_site_id]
         @site ||= Site.find_by_id( params[:inat_site_id] )
       end
-      @site ||= Site.where( "url LIKE '%#{request.host}%'" ).first
+      @site ||= Site.where( "url LIKE ?", "%#{request.host}%" ).first
       @site ||= Site.default
       @site
     end

--- a/config/initializers/has_moderator_actions.rb
+++ b/config/initializers/has_moderator_actions.rb
@@ -18,14 +18,22 @@ module HasModeratorActions
 
   module InstanceMethods
     def hidden?
+      return false if is_a?( User )
+
       most_recent_moderator_action&.action == ModeratorAction::HIDE
     end
 
     def moderated_as_private?
+      return false if is_a?( User )
+
       hidden? && most_recent_moderator_action&.private?
     end
 
     def most_recent_moderator_action
+      if is_a?( User )
+        return ModeratorAction.where( resource: self ).last
+      end
+
       moderator_actions.sort_by( &:id ).last
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -161,9 +161,39 @@ describe ApplicationController do
         expect( I18n.locale.to_s ).to eq "pt-BR"
       end
     end
-  end
 
-  describe WelcomeController do
+    describe "set_site" do
+      let!( :site2 ) { Site.make!( url: "https://testingsetsite" ) }
+
+      it "uses default site by default" do
+        get :index
+        expect( assigns( :site ) ).to eq Site.default
+      end
+
+      it "can set site via inat_site_id parameter" do
+        get :index, params: { inat_site_id: site2.id }
+        expect( assigns( :site ) ).to eq site2
+      end
+
+      it "can set site via request host" do
+        request.headers["Host"] = "testingsetsite"
+        get :index
+        expect( assigns( :site ) ).to eq site2
+      end
+
+      it "can set site via request x-forwarded-host" do
+        request.headers["X-Forwarded-Host"] = "testingsetsite"
+        get :index
+        expect( assigns( :site ) ).to eq site2
+      end
+
+      it "reverts to default host if requested host not found" do
+        request.headers["X-Forwarded-Host"] = "test'); select 1; --"
+        get :index
+        expect( assigns( :site ) ).to eq Site.default
+      end
+    end
+
     describe "network affiliation prompt" do
       describe "for user in partner site place" do
         let( :place ) { make_place_with_geom }

--- a/spec/lib/has_moderator_actions_spec.rb
+++ b/spec/lib/has_moderator_actions_spec.rb
@@ -35,6 +35,65 @@ describe HasModeratorActions do
       comment.reload
       expect( comment.hidden? ).to be true
     end
+
+    it "users cannot be marked as hidden" do
+      user = make_curator
+      expect( user.hidden? ).to be false
+      ModeratorAction.make!( user: user, resource: Comment.make!, action: ModeratorAction::HIDE )
+      user.reload
+      expect( user.hidden? ).to be false
+    end
+  end
+
+  describe "moderated_as_private?" do
+    it "resources with private HIDE moderator actions are moderated_as_private" do
+      comment = Comment.make!
+      expect( comment.hidden? ).to be false
+      ModeratorAction.make!(
+        resource: comment, action: ModeratorAction::HIDE, private: true, user: make_admin
+      )
+      comment.reload
+      expect( comment.moderated_as_private? ).to be true
+    end
+
+    it "users cannot be marked as moderated_as_private" do
+      user = make_admin
+      expect( user.hidden? ).to be false
+      ModeratorAction.make!(
+        user: user, resource: Comment.make!, action: ModeratorAction::HIDE, private: true
+      )
+      user.reload
+      expect( user.moderated_as_private? ).to be false
+    end
+  end
+
+  describe "most_recent_moderator_action" do
+    it "returns the most recent moderator action on non-User resources" do
+      comment = Comment.make!
+      expect( comment.most_recent_moderator_action ).to be nil
+      _first_action = ModeratorAction.make!(
+        resource: comment, action: ModeratorAction::HIDE, user: make_admin
+      )
+      last_action = ModeratorAction.make!(
+        resource: comment, action: ModeratorAction::HIDE, private: true, user: make_admin
+      )
+      comment.reload
+      expect( comment.most_recent_moderator_action ).to eq last_action
+    end
+
+    it "returns the most recent moderator action on Users" do
+      user = make_curator
+      comment = Comment.make!
+      expect( comment.most_recent_moderator_action ).to be nil
+      action_on_user = ModeratorAction.make!(
+        resource: user, action: ModeratorAction::SUSPEND
+      )
+      _user_action = ModeratorAction.make!(
+        resource: comment, action: ModeratorAction::HIDE, user: user
+      )
+      user.reload
+      expect( user.most_recent_moderator_action ).to eq action_on_user
+    end
   end
 
   describe "hideable_by?" do


### PR DESCRIPTION
The main issue was `has_subscribers` was [recently updated](https://github.com/inaturalist/inaturalist/blob/55fa6321dab3c207e377975ed97996acdf390afe/lib/has_subscribers.rb#L214) to not notify users about hidden content, but there was a bug with `has_moderator_actions` where users that hid content were responding `true` to `.hidden?`. This fix makes it so users return false to `.hidden?` and return appropriate responses to other `has_moderator_actions` methods. The way `User` implements `has_moderator_actions` is a little different from other models because `User` redeclares the `has_many :moderator_actions` associations to be moderator actions the user has created, not actions on the instance itself like all other uses. We weren't handling that different properly for all `has_moderator_actions` methods