### PR TITLE
WEB-737 Ignore Taxon Change when calculating Active Users

### DIFF
--- a/app/models/site_statistic.rb
+++ b/app/models/site_statistic.rb
@@ -311,6 +311,13 @@ class SiteStatistic < ApplicationRecord
               lte: at_time
             }
           }
+        },
+        {
+          bool: {
+            must_not: {
+              exists: { field: "taxon_change" }
+            }
+          }
         }
       ],
       aggregate: {

--- a/app/models/site_statistic.rb
+++ b/app/models/site_statistic.rb
@@ -196,9 +196,20 @@ class SiteStatistic < ApplicationRecord
       size: 0,
       track_total_hits: true,
       filters: [
-        range: {
-          created_at: {
-            lte: at_time
+        {
+          range: {
+            created_at: {
+              lte: at_time
+            }
+          }
+        },
+        {
+          bool: {
+            must_not: {
+              exists: {
+                field: "taxon_change.id"
+              }
+            }
           }
         }
       ]
@@ -207,10 +218,21 @@ class SiteStatistic < ApplicationRecord
       size: 0,
       track_total_hits: true,
       filters: [
-        range: {
-          created_at: {
-            gte: at_time - 7.days,
-            lte: at_time
+        {
+          range: {
+            created_at: {
+              gte: at_time - 7.days,
+              lte: at_time
+            }
+          }
+        },
+        {
+          bool: {
+            must_not: {
+              exists: {
+                field: "taxon_change.id"
+              }
+            }
           }
         }
       ]
@@ -219,10 +241,21 @@ class SiteStatistic < ApplicationRecord
       size: 0,
       track_total_hits: true,
       filters: [
-        range: {
-          created_at: {
-            gte: at_time - 1.days,
-            lte: at_time
+        {
+          range: {
+            created_at: {
+              gte: at_time - 1.days,
+              lte: at_time
+            }
+          }
+        },
+        {
+          bool: {
+            must_not: {
+              exists: {
+                field: "taxon_change.id"
+              }
+            }
           }
         }
       ]
@@ -315,7 +348,9 @@ class SiteStatistic < ApplicationRecord
         {
           bool: {
             must_not: {
-              exists: { field: "taxon_change" }
+              exists: {
+                field: "taxon_change.id"
+              }
             }
           }
         }
@@ -380,6 +415,15 @@ class SiteStatistic < ApplicationRecord
         },
         {
           term: { own_observation: false }
+        },
+        {
+          bool: {
+            must_not: {
+              exists: {
+                field: "taxon_change.id"
+              }
+            }
+          }
         }
       ],
       aggs: {


### PR DESCRIPTION
We should probably add also this exclusion filter to:
https://github.com/inaturalist/inaturalist/blob/main/app/models/site_statistic.rb#L195
https://github.com/inaturalist/inaturalist/blob/main/app/models/site_statistic.rb#L362

as these taxon change identifications are generated and should not be counted as user's identifications
