### PR TITLE
fix: show pluralizations in all languages in obs Uploader

### DIFF
--- a/app/assets/javascripts/application_bundle.js
+++ b/app/assets/javascripts/application_bundle.js
@@ -1,10 +1,5 @@
 //= require iso8601
-//= require i18n
-//= require i18n/translations/en
-//= require i18n/pluralizations
-//= require i18n/inflections
-//= require i18n/default_value_pre_fallback
-//= require i18n/to_time
+//= require i18n_bundle
 //= require jquery/plugins/jquery.qtip2.min
 //= require jquery/plugins/jquery.multiselect
 //= require jquery/plugins/jquery.ui.autocomplete.html.js

--- a/app/assets/javascripts/i18n_bundle.js
+++ b/app/assets/javascripts/i18n_bundle.js
@@ -1,2 +1,6 @@
 //= require i18n
 //= require i18n/translations/en
+//= require i18n/pluralizations
+//= require i18n/inflections
+//= require i18n/default_value_pre_fallback
+//= require i18n/to_time


### PR DESCRIPTION
Since the Uploader uses a different layout, it wasn't actually loading all of
our pluralization customization. This consolidates that stuff into a single
bundle.

Closes WEB-731