### PR TITLE
fix: prevent announcements CSS from affecting the rest of the site

### DIFF
--- a/app/views/announcements/_announcement.html.haml
+++ b/app/views/announcements/_announcement.html.haml
@@ -1,6 +1,12 @@
-- create_announcement_impression( announcement )
-.announcement
-  = announcement.body.html_safe
-  - if announcement.dismissible? && current_user
-    = button_to dismiss_announcement_path( announcement ), method: :put, remote: true, form_class: "dismiss-announcement", class: "dismiss-announcement-link", title: t(:dismiss) do
-      %i.fa.fa-close
+- preview = defined?( preview ) && preview
+- create_announcement_impression( announcement ) unless preview
+%template{ shadowrootmode: "open" }
+  = render "shared/common_stylesheets"
+  = stylesheet_link_tag 'bootstrap_bundle'
+  = stylesheet_link_tag 'bootstrap-rtl' if @rtl
+  .bootstrap
+    .announcement
+      = announcement.body.html_safe
+      - if announcement.dismissible? && current_user && !preview
+        = button_to dismiss_announcement_path( announcement ), method: :put, remote: true, form_class: "dismiss-announcement", class: "dismiss-announcement-link", title: t(:dismiss) do
+          %i.fa.fa-close

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -57,9 +57,11 @@
                   %span.label.label-success=t :active
               %td.announcement-body
                 - if announcement.placement === "users/dashboard#sidebar"
-                  %div.sidebar-body=raw announcement.body
+                  %div.sidebar-body
+                    = render "announcements/announcement", announcement: announcement, preview: true
                 - else
-                  %div.general-body=raw announcement.body
+                  %div.general-body
+                    = render "announcements/announcement", announcement: announcement, preview: true
               %td.user
                 = link_to( user_image( announcement.user), announcement.user ) if announcement.user
                 = link_to_user announcement.user, missing: t( :unknown )

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -97,7 +97,8 @@
               %p
                 = link_to "View in new window", url_for( body: true ), class: "readmore"
             - else
-              %div{style: "width: #{width};"}= raw @announcement.body
+              %div{style: "width: #{width};"}
+                = render "announcements/announcement", announcement: @announcement, preview: true
         %tr
           %th=t :dismissed_by
           %td


### PR DESCRIPTION
Puts the announcement in a shadow DOM with our bootstrap styles but nothing else. This definitely needs testing with some actual announcements b/c this changes the assumption that announcements have access to all the styles and Javascript available in the environment in which they're displayed (using an iframe would come with the same cost).