### PR TITLE
refactor: refactor observation update_observations_places to help prevent deadlocks, related to WEB-513

### DIFF
--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -768,6 +768,51 @@ describe Observation do
     end
   end
 
+  describe "update_observations_places" do
+    let!( :place1 ) do
+      make_place_with_geom( wkt: "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)))" )
+    end
+    let!( :place2 ) do
+      make_place_with_geom( wkt: "MULTIPOLYGON(((0.25 0.25,0.25 1.25,1.25 1.25,1.25 0.25,0.25 0.25)))" )
+    end
+    let!( :place3 ) do
+      make_place_with_geom( wkt: "MULTIPOLYGON(((1.2 1.2,1.2 2.2,2.2 2.2,2.2 1.2,1.2 1.2)))" )
+    end
+
+    it "adds and removes observations from places based on location" do
+      o = Observation.make!( latitude: nil, longitude: nil )
+      expect( o.public_places ).to be_empty
+      expect( o.observations_places ).to be_empty
+      o.update( latitude: 0.1, longitude: 0.1 )
+      expect( o.observations_places.length ).to eq 1
+      expect( o.public_places ).to include( place1 )
+      expect( o.public_places ).not_to include( place2 )
+      expect( o.public_places ).not_to include( place3 )
+
+      o.update( latitude: 0.3, longitude: 0.3 )
+      expect( o.observations_places.length ).to eq 2
+      expect( o.public_places ).to include( place1 )
+      expect( o.public_places ).to include( place2 )
+      expect( o.public_places ).not_to include( place3 )
+
+      o.update( latitude: 1.21, longitude: 1.21 )
+      expect( o.observations_places.length ).to eq 2
+      expect( o.public_places ).not_to include( place1 )
+      expect( o.public_places ).to include( place2 )
+      expect( o.public_places ).to include( place3 )
+
+      o.update( latitude: 1.5, longitude: 1.5 )
+      expect( o.observations_places.length ).to eq 1
+      expect( o.public_places ).not_to include( place1 )
+      expect( o.public_places ).not_to include( place2 )
+      expect( o.public_places ).to include( place3 )
+
+      o.update( latitude: 2.5, longitude: 2.5 )
+      expect( o.public_places ).to be_empty
+      expect( o.observations_places ).to be_empty
+    end
+  end
+
   describe "update_for_taxon_change" do
     before( :each ) do
       @taxon_swap = TaxonSwap.make


### PR DESCRIPTION
We've seen a few deadlocks related to deleting observations places within the context of `update_observations_places`. This PR refactors the method to not just delete all observations_places for all affected observations every time the method is run, rather to only delete the entries that no longer apply, and to only add the entries not yet added. This should hopefully reduce the chances this method might lead to a deadlock on deleted rows.