### PR TITLE
fix: update terrapin gem, related to WEB-754

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -701,7 +701,7 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     temple (0.8.2)
-    terrapin (1.0.1)
+    terrapin (1.1.1)
       climate_control
     terser (1.2.5)
       execjs (>= 0.3.0, < 3)


### PR DESCRIPTION
Terrapin 1.1.0 fixed  a bug, `Don't hang on stderr`, that we were occasionally affected by