### PR TITLE
3257 tab anchor change

### DIFF
--- a/app/assets/stylesheets/taxa/show.scss
+++ b/app/assets/stylesheets/taxa/show.scss
@@ -144,6 +144,13 @@
     }
   }
 }
+
+#main-tabs-content {
+  & [role="tabpanel"] {
+    scroll-margin-top: 80px; // add some spacing at the top to prevent anchor behavior to hide the tabs
+  }
+}
+
 #ChartsHelpModal .modal-title {
   line-height: 1;
   padding: 0;

--- a/app/webpack/taxa/shared/util.js
+++ b/app/webpack/taxa/shared/util.js
@@ -243,7 +243,6 @@ const tabFromLocationHash = (rankLevel ) => {
   return !chosenTab?undefined:{tab:chosenTab, hash: `${chosenTab}-tab`};
 };
 
-
 const getChosenTab = (tab, rankLevel) => {
   const speciesTabsSet = new Set([TABS.map, TABS.articles, TABS.interactions, TABS.taxonomy, TABS.status, TABS.similar]);
   const genusTabsSet = new Set([TABS.map, TABS.articles, TABS.highlights, TABS.taxonomy, TABS.similar]);

--- a/app/webpack/taxa/shared/util.js
+++ b/app/webpack/taxa/shared/util.js
@@ -145,10 +145,13 @@ const windowStateForTaxon = taxon => {
       ancestor_ids: taxon.ancestor_ids
     }
   };
+
+  const tabHash = tabFromLocationHash(taxon.rank_level )?.hash;
+  
   return {
     state,
     title,
-    url: `${urlForTaxon( taxon )}${window.location.search}`
+    url: `${urlForTaxon( taxon )}${window.location.search}${tabHash ? `#${tabHash}` : ""}`
   };
 };
 
@@ -216,26 +219,48 @@ const taxonLayerForTaxon = ( taxon, options = {} ) => {
   };
 };
 
-const tabFromLocationHash = ( ) => {
-  const validTabs = [
-    "map",
-    "articles",
-    "highlights",
-    "interactions",
-    "taxonomy",
-    "status",
-    "similar",
-    "curation"
-  ];
+const TABS = {
+    map:"map",
+    articles:"articles",
+    highlights:"highlights",
+    interactions:"interactions",
+    taxonomy:"taxonomy",
+    status:"status",
+    similar:"similar",
+    curation:"curation"
+}
+
+const tabFromLocationHash = (rankLevel ) => {
   const urlTabMatches = window.location.hash.match( /^#([a-z-]+)-tab$/ );
-  if ( urlTabMatches ) {
-    const tabMatch = urlTabMatches[1];
-    if ( _.includes( validTabs, tabMatch ) ) {
-      return tabMatch;
-    }
+  const tabMatch = urlTabMatches?.[1];
+
+  if ( !urlTabMatches || !tabMatch || !(tabMatch in TABS) ) {
+    return null;
   }
-  return null;
+
+  const chosenTab = getChosenTab(tabMatch, rankLevel);
+
+  return !chosenTab?undefined:{tab:chosenTab, hash: `${chosenTab}-tab`};
 };
+
+
+const getChosenTab = (tab, rankLevel) => {
+  const speciesTabsSet = new Set([TABS.map, TABS.articles, TABS.interactions, TABS.taxonomy, TABS.status, TABS.similar]);
+  const genusTabsSet = new Set([TABS.map, TABS.articles, TABS.highlights, TABS.taxonomy, TABS.similar]);
+  const aboveGenusTabsSet = new Set([TABS.map, TABS.articles, TABS.highlights, TABS.taxonomy]);
+
+  if (
+    ( rankLevel <= RANK_LEVELS.species && speciesTabsSet.has( tab ) >= 0 )
+    || ( rankLevel === RANK_LEVELS.genus && genusTabsSet.has( tab ) >= 0 )
+    || (
+      ( rankLevel > RANK_LEVELS.genus
+      || ( rankLevel > RANK_LEVELS.species && rankLevel < RANK_LEVELS.genus ) )
+      && aboveGenusTabsSet.has( tab ) >= 0
+    )
+  ) {
+     return tab;
+  }
+}
 
 const RANK_LEVELS = {
   root: 100,
@@ -288,5 +313,6 @@ export {
   taxonLayerForTaxon,
   tabFromLocationHash,
   RANK_LEVELS,
-  MAX_TAXON_PHOTOS
+  MAX_TAXON_PHOTOS,
+  getChosenTab
 };

--- a/app/webpack/taxa/show/containers/taxon_page_tabs_container.js
+++ b/app/webpack/taxa/show/containers/taxon_page_tabs_container.js
@@ -11,23 +11,12 @@ import {
   fetchSimilar,
   showPhotoChooser
 } from "../../shared/ducks/taxon";
+import { getChosenTab } from "../../shared/util";
+
 
 function mapStateToProps( state ) {
-  const speciesTabs = ["map", "articles", "interactions", "taxonomy", "status", "similar"];
-  const genusTabs = ["map", "articles", "highlights", "taxonomy", "similar"];
-  const aboveGenusTabs = ["map", "articles", "highlights", "taxonomy"];
-  let chosenTab;
-  if (
-    ( state.taxon.taxon.rank_level <= 10 && speciesTabs.indexOf( state.config.chosenTab ) >= 0 )
-    || ( state.taxon.taxon.rank_level === 20 && genusTabs.indexOf( state.config.chosenTab ) >= 0 )
-    || (
-      ( state.taxon.taxon.rank_level > 20
-      || ( state.taxon.taxon.rank_level > 10 && state.taxon.taxon.rank_level < 20 ) )
-      && aboveGenusTabs.indexOf( state.config.chosenTab ) >= 0
-    )
-  ) {
-    ( { chosenTab } = state.config );
-  }
+  const chosenTab= getChosenTab(state.config.chosenTab, state.taxon.taxon.rank_level);
+
   return {
     taxon: state.taxon.taxon,
     currentUser: state.config.currentUser,
@@ -61,6 +50,7 @@ function mapDispatchToProps( dispatch ) {
   return {
     showPhotoChooserModal: ( ) => dispatch( showPhotoChooser( ) ),
     choseTab: tab => {
+      location.hash = `#${tab}-tab`;
       dispatch( setConfig( { chosenTab: tab } ) );
       loadDataForTab( tab );
       updateSession( { preferred_taxon_page_tab: tab } );

--- a/app/webpack/taxa/show/webpack-entry.js
+++ b/app/webpack/taxa/show/webpack-entry.js
@@ -48,7 +48,7 @@ if ( serverPayload.place !== undefined && serverPayload.place !== null ) {
   } ) );
 }
 sharedStore.dispatch( setConfig( {
-  chosenTab: tabFromLocationHash( ) || serverPayload.chosenTab || "articles"
+  chosenTab: tabFromLocationHash( serverPayload.taxon.rank_level )?.tab || serverPayload.chosenTab || "articles"
 } ) );
 if ( serverPayload.ancestorsShown ) {
   sharedStore.dispatch( setConfig( {


### PR DESCRIPTION
This PR tackes Issue:   https://github.com/inaturalist/inaturalist/issues/3257

Related to changes in  https://github.com/inaturalist/inaturalist/issues/4085

## What changed
 
- added tab validation based on rank level
- when landing a page, keep the hash in the URL if is a valid one, remove if not valid
- when the user selects a tab it adds the hash in the URL. This way it would be easier to share I think.