### PR TITLE
RG bug

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1573,7 +1573,11 @@ class Observation < ApplicationRecord
         NEEDS_ID
       end
     elsif community_taxon_at_species_or_lower?
-      RESEARCH_GRADE
+      if taxon < Taxon::SPECIES_LEVEL && community_taxon == Taxon::SPECIES_LEVEL
+        NEEDS_ID
+      else
+        RESEARCH_GRADE
+      end
     elsif community_taxon_id && voted_out_of_needs_id?
       if community_taxon_below_family?
         RESEARCH_GRADE

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1573,7 +1573,7 @@ class Observation < ApplicationRecord
         NEEDS_ID
       end
     elsif community_taxon_at_species_or_lower?
-      if taxon < Taxon::SPECIES_LEVEL && community_taxon == Taxon::SPECIES_LEVEL
+      if taxon.rank_level < Taxon::SPECIES_LEVEL && community_taxon.rank_level == Taxon::SPECIES_LEVEL
         NEEDS_ID
       else
         RESEARCH_GRADE


### PR DESCRIPTION
fixes https://linear.app/inaturalist/issue/WEB-633/observation-can-be-labeled-research-grade-at-wrong-taxonomic-level
by keeping obs at Needs ID
if the obs.taxon is an infraspecies (e.g. ssp) and there is not community support