### PR TITLE
show current community taxon under DQA (#3990)

### DIFF
--- a/app/assets/stylesheets/shared/quality_metrics.scss
+++ b/app/assets/stylesheets/shared/quality_metrics.scss
@@ -35,7 +35,6 @@
   tr.improve {
     background: $light-grey;
     .inputs {
-      margin-inline-start: 35px;
       margin-top: 5px;
       .yes, .no {
         display: inline-block;
@@ -51,8 +50,11 @@
         }
       }
     }
+    div.grid-container {
+      display: grid;
+      grid-template-columns: auto 1fr;
+    }
     .current-community-taxon {
-      margin-inline-start: 35px;
       .SplitTaxon > span {
         color: #333;
       }

--- a/app/assets/stylesheets/shared/quality_metrics.scss
+++ b/app/assets/stylesheets/shared/quality_metrics.scss
@@ -51,6 +51,12 @@
         }
       }
     }
+    .current-community-taxon {
+      margin-inline-start: 35px;
+      .SplitTaxon > span {
+        color: #333;
+      }
+    }
   }
   h3 {
     margin-top: 30px;

--- a/app/webpack/observations/show/components/quality_metrics.jsx
+++ b/app/webpack/observations/show/components/quality_metrics.jsx
@@ -147,46 +147,58 @@ class QualityMetrics extends React.Component {
         />
       )
       : null;
-    const currentCommunityTaxon = observation.communityTaxon 
-      ? <>
+    const currentUser = config?.currentUser;
+    const currentCommunityTaxon = observation.communityTaxon
+      ? (
+        <>
           <br />
           <span className="current-community-taxon">
             {
               inatreact.t( "current_community_id", {
-                taxon: <SplitTaxon taxon={observation.communityTaxon} /> 
-              })
+                taxon: <SplitTaxon
+                  taxon={observation.communityTaxon}
+                  user={currentUser}
+                />
+              } )
             }
           </span>
         </>
+      )
       : null;
     return (
       <tr className={`improve${needsIDVoteDisabled ? " disabled" : ""}`}>
         <td className="metric_title" colSpan={3}>
-          <i className="fa fa-gavel" />
-          { I18n.t( "based_on_the_evidence_can_id_be_improved" ) }
-          { currentCommunityTaxon }
-          <div className="inputs">
-            <div className="yes">
-              { checkboxYes }
-              <label
-                htmlFor="improveYes"
-                className={needsIDInfo.mostAgree ? "bold" : ""}
-              >
-                { I18n.t( "yes" ) }
-              </label>
-              { " " }
-              { votesForCount }
+          <div className="grid-container">
+            <div className="column">
+              <i className="fa fa-gavel" />
             </div>
-            <div className="no">
-              { checkboxNo }
-              <label
-                htmlFor="improveNo"
-                className={needsIDInfo.mostDisagree ? "bold" : ""}
-              >
-                { I18n.t( "no_its_as_good_as_it_can_be" ) }
-              </label>
-              { " " }
-              { votesAgainstCount }
+            <div className="column">
+              { I18n.t( "based_on_the_evidence_can_id_be_improved" ) }
+              { currentCommunityTaxon }
+              <div className="inputs">
+                <div className="yes">
+                  { checkboxYes }
+                  <label
+                    htmlFor="improveYes"
+                    className={needsIDInfo.mostAgree ? "bold" : ""}
+                  >
+                    { I18n.t( "yes" ) }
+                  </label>
+                  { " " }
+                  { votesForCount }
+                </div>
+                <div className="no">
+                  { checkboxNo }
+                  <label
+                    htmlFor="improveNo"
+                    className={needsIDInfo.mostDisagree ? "bold" : ""}
+                  >
+                    { I18n.t( "no_its_as_good_as_it_can_be" ) }
+                  </label>
+                  { " " }
+                  { votesAgainstCount }
+                </div>
+              </div>
             </div>
           </div>
         </td>
@@ -293,8 +305,8 @@ class QualityMetrics extends React.Component {
       && observation.communityTaxon.rank_level <= 10
     );
     const communityTaxonAtLeastSubfamily = (
-      observation.taxon
-      && observation.taxon.rank_level < 30
+      observation.communityTaxon
+      && observation.communityTaxon.rank_level < 30
     );
     let locationSpecified = false;
     if ( observation.geojson ) {

--- a/app/webpack/observations/show/components/quality_metrics.jsx
+++ b/app/webpack/observations/show/components/quality_metrics.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import FlagAnItemContainer from "../../../shared/containers/flag_an_item_container";
 import UsersPopover from "./users_popover";
+import SplitTaxon from "../../../shared/components/split_taxon";
+import { inatreact } from "../../../shared/util";
 
 class QualityMetrics extends React.Component {
   constructor( ) {
@@ -145,11 +147,24 @@ class QualityMetrics extends React.Component {
         />
       )
       : null;
+    const currentCommunityTaxon = observation.communityTaxon 
+      ? <>
+          <br />
+          <span className="current-community-taxon">
+            {
+              inatreact.t( "current_community_id", {
+                taxon: <SplitTaxon taxon={observation.communityTaxon} /> 
+              })
+            }
+          </span>
+        </>
+      : null;
     return (
       <tr className={`improve${needsIDVoteDisabled ? " disabled" : ""}`}>
         <td className="metric_title" colSpan={3}>
           <i className="fa fa-gavel" />
           { I18n.t( "based_on_the_evidence_can_id_be_improved" ) }
+          { currentCommunityTaxon }
           <div className="inputs">
             <div className="yes">
               { checkboxYes }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1660,6 +1660,7 @@ en:
     observations in projects. Observers can also choose to change this for
     individual observations.
   curator_identification: Curator identification
+  current_community_id: "Current Community Taxon: %{taxon}"
   current_flags: Current Flags
   # Label for a custom boundary for an observation search
   custom_boundary: Custom Boundary

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1660,6 +1660,7 @@ en:
     observations in projects. Observers can also choose to change this for
     individual observations.
   curator_identification: Curator identification
+  # Text to inform the user what the current consensus is for a given specimen's identification (aka taxon)
   current_community_id: "Current Community Taxon: %{taxon}"
   current_flags: Current Flags
   # Label for a custom boundary for an observation search


### PR DESCRIPTION
I’m not fully sure how internationalization works for the project (is this OK to merge as is? or do translations need to be added first / does a process need to be kicked off?), but here’s the requested change. I’ve tested the changes locally and I’ve provided screenshots for what it looks like on my end (please ignore the broken map; I’ve had to comment out the mapnik stuff for my dev env if that is related at all).

Before DQA is available:
<img width="1303" height="800" alt="Screenshot 2025-09-18 at 10 28 49 PM" src="https://github.com/user-attachments/assets/9f7dcdc4-1e89-42fc-a0fc-6735fc3f307b" />
<img width="696" height="773" alt="Screenshot 2025-09-18 at 10 28 59 PM" src="https://github.com/user-attachments/assets/5507cd37-8010-48e0-afd0-466554dc1157" />

After DQA is available:
<img width="1272" height="884" alt="Screenshot 2025-09-18 at 10 30 58 PM" src="https://github.com/user-attachments/assets/84e81f82-0f2f-4650-aae5-2f80a638e1f5" />
<img width="708" height="786" alt="Screenshot 2025-09-18 at 10 31 05 PM" src="https://github.com/user-attachments/assets/011447b0-5f16-48b5-a74d-6ef86a170920" />

Note: The current community taxon is NOT a link currently, but it can be updated to link to `/taxa/${taxon.id}` or whatever else if desired. Just let me know if it should be the whole line or just the taxon name
