### PR TITLE
Account for method rename in Rails

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ class ActiveSupport::TestCase
   # in MySQL.  Turn off transactional fixtures in this case; however, if you
   # don't care one way or the other, switching from MyISAM to InnoDB tables
   # is recommended.
-  self.use_transactional_fixtures = true
+  self.use_transactional_tests = true
 
   # Instantiated fixtures are slow, but give you @david where otherwise you
   # would need people(:david).  If you don't want to migrate your existing


### PR DESCRIPTION
Rails deprecated the configuration method use_transactional_fixtures and renamed it to use_transactional_tests in Rails 5.1. iNat is using Rails 6.1, which no longer defines the old method. 