### PR TITLE
feat: add color banding on DQA for accessibility - small change

### DIFF
--- a/app/assets/stylesheets/shared/quality_metrics.scss
+++ b/app/assets/stylesheets/shared/quality_metrics.scss
@@ -33,7 +33,6 @@
     }
   }
   tr.improve {
-    background: $light-grey;
     .inputs {
       margin-top: 5px;
       .yes, .no {
@@ -59,6 +58,9 @@
         color: #333;
       }
     }
+  }
+  tbody tr:nth-child(even) {
+    background: $light-grey;
   }
   h3 {
     margin-top: 30px;


### PR DESCRIPTION
Seemed small to add and is based off of a forum post… I don’t think this will get much pushback but I leave it up to the team to decide whether to include.

https://forum.inaturalist.org/t/add-row-banding-to-the-data-quality-assessment/71680

implementing for annotations seems a little more complicated so I’m leaving that aside for now

<img width="1202" height="760" alt="Screenshot 2025-10-17 at 4 54 45 PM" src="https://github.com/user-attachments/assets/20f5245e-64fa-4a76-8540-458516b10100" />
