### PR TITLE
feat: add color banding for annotations table for accessibility

### DIFF
--- a/app/assets/stylesheets/shared/annotations.scss
+++ b/app/assets/stylesheets/shared/annotations.scss
@@ -16,6 +16,9 @@ body > [role="dialog"] .Annotations {
   tbody td {
     line-height: 22px !important;
   }
+  tbody tr:nth-child(odd) {
+    background: white;
+  }
   .dropdown {
     button {
       margin: 0px 0px 2px 12px;


### PR DESCRIPTION
Sibling pull request to #4701 

Also asked for in https://forum.inaturalist.org/t/add-row-banding-to-the-data-quality-assessment/71680 in the comments

<img width="541" height="300" alt="Screenshot 2025-10-18 at 12 05 23 AM" src="https://github.com/user-attachments/assets/1cfff4c8-8b35-4894-bf3e-18a0c529a66d" />

<img width="563" height="352" alt="Screenshot 2025-10-18 at 12 05 37 AM" src="https://github.com/user-attachments/assets/984fd61d-90fb-45d5-af19-a2a489fcd64a" />

<img width="565" height="391" alt="Screenshot 2025-10-18 at 12 05 47 AM" src="https://github.com/user-attachments/assets/1e2b7776-e098-4730-b788-d82e90110d7e" />
