### PR TITLE
fix: inc height of news section in projects/show for safari/duck duck go

### DIFF
--- a/app/webpack/projects/show/components/umbrella_overview_tab.jsx
+++ b/app/webpack/projects/show/components/umbrella_overview_tab.jsx
@@ -31,7 +31,7 @@ const UmbrellaOverviewTab = props => {
       <PhotoModalContainer />
       <LazyLoad
         debounce={false}
-        height={90}
+        height={240}
         offset={100}
         onContentVisible={fetchPosts}
       >


### PR DESCRIPTION
I noticed a rendering issue for the 2025 Great Southern Bioblitz in my browser (duck duck go) (https://www.inaturalist.org/projects/great-southern-bioblitz-2025-umbrella) and it was just faster for me to solve for it rather than just make an issue, so here is my proposed solution.

currently: in duck duck go 1.160.1
<img width="1371" height="704" alt="Screenshot 2025-10-27 at 9 18 37 PM" src="https://github.com/user-attachments/assets/a842f627-6893-4af2-a07a-77ea7469702b" />

in safari 18.6
<img width="1304" height="679" alt="Screenshot 2025-10-27 at 9 42 52 PM" src="https://github.com/user-attachments/assets/5cec6c17-ecea-4d6a-8b66-da1d55993fc0" />

The issue doesn’t exist in Chrome for whatever reason.

The “Inappropriate content? [Flag As Inappropriate](https://www.inaturalist.org/login)” content overlaps the journal section. The journal section also isn’t fully rendered (The `View All` button is missing)

Changing the height of the element to 240px (the height of its child in safari & duck duck go) fixes the issue:
<img width="1367" height="621" alt="Screenshot 2025-10-28 at 11 06 04 AM" src="https://github.com/user-attachments/assets/82d163cc-ffd8-4875-9c5e-ffa7c570eb80" />

<img width="1308" height="716" alt="Screenshot 2025-10-28 at 11 06 38 AM" src="https://github.com/user-attachments/assets/d4d2f144-0c46-4753-ba24-7973b1b1a372" />

There are 2 places where this section is manually set to this height: `umbrella_overview_tab.jsx` and `before_event_tab.jsx`. I’m not sure if the `before_event_tab` also looks bad, so this only changes the height for the UmbrellaOverviewTab component (which is the source of this rendering issue).