### PR TITLE
fix: prevents mentions from sending if body/desc did not change

### DIFF
--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -132,7 +132,16 @@ class Identification < ApplicationRecord
     on: :save,
     delay: false,
     notification: "mention",
-    if: lambda( &:prefers_receive_mentions? )
+    if: lambda( &:prefers_receive_mentions? ),
+    unless: lambda {| identification |
+      # body hasn't changed, so mentions haven't changed
+      return true unless identification.previous_changes[:body]
+
+      # body has changed, but neither version mentioned users
+      identification.previous_changes[:body].map do | d |
+        d ? d.mentioned_users.any? : false
+      end.none?
+    }
 
   earns_privilege UserPrivilege::SPEECH
   earns_privilege UserPrivilege::COORDINATE_ACCESS

--- a/app/models/taxon_change.rb
+++ b/app/models/taxon_change.rb
@@ -35,7 +35,16 @@ class TaxonChange < ApplicationRecord
     on: :save,
     delay: false,
     notification: "mention",
-    if: lambda( &:prefers_receive_mentions? )
+    if: lambda( &:prefers_receive_mentions? ),
+    unless: lambda {| tct |
+      # description hasn't changed, so mentions haven't changed
+      return true unless tct.previous_changes[:description]
+
+      # description has changed, but neither version mentioned users
+      tct.previous_changes[:description].map do | d |
+        d ? d.mentioned_users.any? : false
+      end.none?
+    }
 
   TAXON_CHANGE_TAXA_JOINS = [
     "LEFT OUTER JOIN taxon_change_taxa tct ON tct.taxon_change_id = taxon_changes.id"


### PR DESCRIPTION
The `Observation` model seems to already do this, so the same logic should probably be used for all other models that notify on mentions (with a little difference in `Post` due to draft -> publish logic). This should, in theory, at least prevent "identifications from sending mentions if the remarks didn’t change"

Closes #3923 