### PR TITLE
feat: adds place filter for top identifiers in obs/show

### DIFF
--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -1434,6 +1434,19 @@ time {
       }
     }
   }
+
+  .dropdown {
+    margin-bottom: 15px;
+    .place-type {
+      color: $text-grey;
+      &:before {
+        content: " (";
+      }
+      &:after {
+        content: ")"
+      }
+    }
+  }
 }
 
 .OptOutPopover {

--- a/app/webpack/observations/show/components/identifiers.jsx
+++ b/app/webpack/observations/show/components/identifiers.jsx
@@ -1,36 +1,122 @@
 import _ from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
-import { Panel } from "react-bootstrap";
+import { Dropdown, MenuItem, Panel } from "react-bootstrap";
 import UserWithIcon from "./user_with_icon";
+import util from "../util";
 
 class Identifiers extends React.Component {
   constructor( props ) {
     super( props );
     const currentUser = props.config && props.config.currentUser;
     this.state = {
-      open: currentUser ? !currentUser.prefers_hide_obs_show_identifiers : false
+      open: currentUser ? !currentUser.prefers_hide_obs_show_identifiers : false,
+      placeId: null
     };
   }
 
   componentDidMount( ) {
-    this.loadIdentifiers( );
+    this.loadIdentifiers( this.state.placeId );
   }
 
-  componentDidUpdate( ) {
-    this.loadIdentifiers( );
+  componentDidUpdate( prevProps ) {
+    const { observation, observationPlaces } = this.props;
+    if ( !observation || !observation.taxon || observation.taxon.rank_level > 50 || observation.geoprivacy === "private" ) {
+      return;
+    }
+    /* In the constructor, observationPlaces is not defined yet (can be an empty array).
+      We wait to set an initial value for placeId when props.observationPlaces is properly init'd.
+      This react hook activates when that happens, and should execute this if-block only once */
+    if ( ( !prevProps.observationPlaces || prevProps.observationPlaces.length === 0 )
+        && !!observationPlaces && observationPlaces.length > 0 ) {
+      const placeId = _.filter( observationPlaces, p => p.admin_level !== null )
+        .find( p => p.admin_level === -10 )?.id; // -10 = Place::CONTINENT_LEVEL
+      this.setState( { placeId } );
+      this.loadIdentifiers( placeId );
+    } else if ( prevProps.observationPlaces !== observationPlaces
+      && observationPlaces.length === 0 ) {
+      // if somehow observationPlaces is being updated TO an empty array, reset placeId
+      this.setState( { placeId: null } );
+      this.loadIdentifiers( null );
+    }
   }
 
-  loadIdentifiers( ) {
+  loadIdentifiers( placeId ) {
     const { identifiers, fetchTaxonIdentifiers } = this.props;
     if ( identifiers === null && this.state.open ) {
-      fetchTaxonIdentifiers( );
+      fetchTaxonIdentifiers( placeId );
     }
+  }
+
+  renderPlaceSelector( ) {
+    const { observation, observationPlaces, fetchTaxonIdentifiers } = this.props;
+    if ( !observation || !observation.taxon || observation.taxon.rank_level > 50 || observation.geoprivacy === "private" ) {
+      return ( <span /> );
+    }
+    const standardPlaces = !observationPlaces ? []
+      : _.filter( observationPlaces, p => p.admin_level !== null )
+        .sort( ( p1, p2 ) => p1.admin_level > p2.admin_level );
+    if ( standardPlaces.length !== 0 ) {
+      const globalText = (
+        <>
+          <i className="fa fa-globe" />
+          { " " }
+          { I18n.t( "global" ) }
+        </>
+      );
+      return (
+        <>
+          <Dropdown
+            id="identifiers-place-dropdown"
+            onSelect={index => {
+              const placeId = index === 0 ? null : standardPlaces[index - 1].id;
+              this.setState( { placeId } );
+              fetchTaxonIdentifiers( placeId );
+            }}
+          >
+            <Dropdown.Toggle>
+              <span className="toggle">
+                { !this.state.placeId
+                  ? globalText
+                  : util.placeToPlaceNameString(
+                    standardPlaces.find( p => p.id === this.state.placeId )
+                  ) }
+              </span>
+            </Dropdown.Toggle>
+            <Dropdown.Menu className="dropdown-menu-right">
+              <MenuItem
+                key="place-0"
+                eventKey={0}
+                title={I18n.t( "global" )}
+              >
+                { globalText }
+              </MenuItem>
+              {
+                standardPlaces.map( ( p, index ) => (
+                  <MenuItem
+                    key={`place-${index + 1}`}
+                    eventKey={index + 1}
+                    title={`${util.placeToPlaceNameString( p )} ${_.upperFirst( util.placeToPlaceTypeString( p ) )}`}
+                  >
+                    {util.placeToPlaceNameString( p )}
+                    { " " }
+                    <span className="place-type">
+                      { _.upperFirst( util.placeToPlaceTypeString( p ) ) }
+                    </span>
+                  </MenuItem>
+                ) )
+              }
+            </Dropdown.Menu>
+          </Dropdown>
+          <br />
+        </>
+      );
+    }
+    return null;
   }
 
   render( ) {
     const { observation, identifiers, config } = this.props;
-    if ( !observation || !observation.taxon ) { return ( <span /> ); }
     if ( !observation || !observation.taxon || observation.taxon.rank_level > 50 ) {
       return ( <span /> );
     }
@@ -78,6 +164,7 @@ class Identifiers extends React.Component {
         </h4>
         <Panel expanded={open} onToggle={() => {}}>
           <Panel.Collapse>
+            { this.renderPlaceSelector() }
             { panelContents }
           </Panel.Collapse>
         </Panel>
@@ -89,6 +176,7 @@ class Identifiers extends React.Component {
 Identifiers.propTypes = {
   config: PropTypes.object,
   observation: PropTypes.object,
+  observationPlaces: PropTypes.array,
   identifiers: PropTypes.array,
   updateSession: PropTypes.func,
   fetchTaxonIdentifiers: PropTypes.func

--- a/app/webpack/observations/show/components/map_details.jsx
+++ b/app/webpack/observations/show/components/map_details.jsx
@@ -2,17 +2,12 @@ import _ from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import util from "../util";
 
 class MapDetails extends React.Component {
   static placeList( places ) {
     return places.map( p => {
-      let placeType;
-      if ( p && p.place_type && iNatModels.Place.PLACE_TYPES[p.place_type] ) {
-        placeType = I18n.t( `place_geo.geo_planet_place_types.${
-          _.snakeCase( iNatModels.Place.PLACE_TYPES[p.place_type] )}` );
-      } else {
-        placeType = I18n.t( "unknown" );
-      }
+      const placeType = util.placeToPlaceTypeString( p );
       const label = placeType && (
         <span className="type">
           { _.upperFirst( placeType ) }
@@ -21,9 +16,7 @@ class MapDetails extends React.Component {
       return (
         <span className="place" key={`place-${p.id}`}>
           <a href={`/observations?place_id=${p.id}`}>
-            { I18n.t( `places_name.${_.snakeCase( p.name )}`, {
-              defaultValue: p.display_name || p.name
-            } ) }
+            { util.placeToPlaceNameString( p ) }
           </a>
           { label }
         </span>

--- a/app/webpack/observations/show/containers/identifiers_container.js
+++ b/app/webpack/observations/show/containers/identifiers_container.js
@@ -6,6 +6,7 @@ import { updateSession } from "../ducks/users";
 function mapStateToProps( state ) {
   return {
     observation: state.observation,
+    observationPlaces: state.observationPlaces,
     identifiers: state.identifications.identifiers,
     config: state.config
   };
@@ -14,7 +15,7 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
   return {
     updateSession: params => { dispatch( updateSession( params ) ); },
-    fetchTaxonIdentifiers: ( ) => { dispatch( fetchTaxonIdentifiers( ) ); }
+    fetchTaxonIdentifiers: placeId => { dispatch( fetchTaxonIdentifiers( { placeId } ) ); }
   };
 }
 

--- a/app/webpack/observations/show/ducks/observation.js
+++ b/app/webpack/observations/show/ducks/observation.js
@@ -1492,11 +1492,17 @@ export function showNewObservation( observation, options = { } ) {
   };
 }
 
-export function fetchTaxonIdentifiers( ) {
+export function fetchTaxonIdentifiers( options = {} ) {
   return ( dispatch, getState ) => {
     const { observation } = getState( );
     if ( !( observation.taxon && observation.taxon.rank_level <= 50 ) ) {
       dispatch( setIdentifiers( [] ) );
+      return;
+    }
+    if ( options && options.placeId ) {
+      dispatch( fetchIdentifiers( {
+        place_id: options.placeId, taxon_id: observation.taxon.id, quality_grade: "research", per_page: 10
+      } ) );
       return;
     }
     dispatch( fetchIdentifiers( {

--- a/app/webpack/observations/show/util.js
+++ b/app/webpack/observations/show/util.js
@@ -50,6 +50,23 @@ const util = class util {
     } );
     return missingFields;
   }
+
+  static placeToPlaceTypeString( place ) {
+    if ( place && place.place_type && iNatModels.Place.PLACE_TYPES[place.place_type] ) {
+      return I18n.t( `place_geo.geo_planet_place_types.${
+        _.snakeCase( iNatModels.Place.PLACE_TYPES[place.place_type] )}` );
+    }
+    return I18n.t( "unknown" );
+  }
+
+  static placeToPlaceNameString( place ) {
+    if ( place && place.name ) {
+      return I18n.t( `places_name.${_.snakeCase( place.name )}`, {
+        defaultValue: place.display_name || place.name
+      } );
+    }
+    return I18n.t( "unknown" );
+  }
 };
 
 export default util;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2441,6 +2441,8 @@ en:
   # Prompt to donate money once
   give_now_caps: GIVE NOW
   global_names: Global Names
+  # A selection choice for where to filter top identifiers of a taxon from (i.e. choosing this will fetch identifiers from all around the world).
+  global: Global
   globally: Globally
   go: Go
   go_back: Go back


### PR DESCRIPTION
This new place filter appears for any observation with an observation taxon that is as specific as or more specific than “class” and does not have a “private” geoprivacy. 

I am aware that the GitHub issue asks:
> The request is that, for observations identified from family to genus, we add a place filter 

But I think having the freedom to choose between continent and global at any allowed taxonomic rank gives enough flexibility for that requirement to be waived… And I am inclined to agree with Hussell’s response...  But I am not a taxonomist so if there is a strong reason to enforce this for whatever reason, just let me know.

You can filter by Global (the previous default) and by any standard place defined on the Observation. The default filtered place is by continent if defined, and global if a continent is not defined (I assume that would not happen in production, but in my local test data, I only have countries and states so… I DID test the default `placeId` functionality by stubbing in the country admin_level value, so I am confident it would work for continents)

I am open to any input from your team designer. Please mind that I placed the filters within the collapsible panel since it does not make sense for users to fiddle with it when the panel is closed.

Closes #3644 

Screenshots! I basically made an observation for a made up species: one based in China and one based in the US. I made the one in China research grade with two identifications, so those same identifiers show up in the Global & China filters, but not for US and the US-State filter.

Under the observation in China:
<img width="1377" height="805" alt="Screenshot 2025-10-31 at 11 34 59 PM" src="https://github.com/user-attachments/assets/970aa746-314f-4014-af5c-29095d0c896a" />

<img width="553" height="343" alt="Screenshot 2025-10-31 at 11 35 09 PM" src="https://github.com/user-attachments/assets/d13ba156-3592-442c-8ea9-c5b297d5d050" />

<img width="701" height="319" alt="Screenshot 2025-10-31 at 11 35 12 PM" src="https://github.com/user-attachments/assets/271eaabb-1fd3-4cf9-8202-da0bcd933a69" />

<img width="625" height="307" alt="Screenshot 2025-10-31 at 11 35 17 PM" src="https://github.com/user-attachments/assets/553e8ac6-78f3-41db-a82e-282f015033df" />

Under the observation in the US:

<img width="1214" height="692" alt="Screenshot 2025-10-31 at 11 58 12 PM" src="https://github.com/user-attachments/assets/eb86b9c4-6d68-42e8-92e1-83d6712a017e" />

<img width="738" height="304" alt="Screenshot 2025-10-31 at 11 58 20 PM" src="https://github.com/user-attachments/assets/d6915218-12ea-4c0a-be0e-2934e08f364e" />

<img width="595" height="264" alt="Screenshot 2025-10-31 at 11 58 24 PM" src="https://github.com/user-attachments/assets/f21384a9-4a77-40a1-85a3-63def676c166" />

<img width="702" height="266" alt="Screenshot 2025-10-31 at 11 58 28 PM" src="https://github.com/user-attachments/assets/63c5125d-8dd8-41af-95b1-334e9a59c6ff" />

When I change the US observation to private, it reverts to the regular view (global identifiers)

<img width="1030" height="527" alt="Screenshot 2025-10-31 at 11 58 55 PM" src="https://github.com/user-attachments/assets/b045433f-f819-4a60-ab13-a57278806a08" />

<img width="604" height="195" alt="Screenshot 2025-10-31 at 11 58 59 PM" src="https://github.com/user-attachments/assets/9fbec632-31f9-4373-9ea8-9d1b2d3f8695" />




