### PR TITLE
fix: adds white row banding for identify modal DQA

### DIFF
--- a/app/assets/stylesheets/shared/quality_metrics.scss
+++ b/app/assets/stylesheets/shared/quality_metrics.scss
@@ -62,6 +62,10 @@
   tbody tr:nth-child(even) {
     background: $light-grey;
   }
+  // have to specify both because the identify modal has a light-gray background by default
+  tbody tr:nth-child(odd) {
+    background: white;
+  }
   h3 {
     margin-top: 30px;
     display: inline-block;


### PR DESCRIPTION
addresses: https://forum.inaturalist.org/t/add-row-banding-to-the-data-quality-assessment/71680/12

# Problem
The row banding style I added was to set even rows’ background light-gray, which works for the DQA in obs/show since it is against a white background.
However, in the identify modal DQA, the background is already light-gray, so it just looks completely light-gray.

# Solution
Set odd rows’ background to white as well for the DQA.
(Annotations do not have this issue because they have a light-gray background in both obs/show and the identify modal, and it sets odd children’s background to white in both)

<img width="1294" height="667" alt="Screenshot 2025-11-14 at 3 01 02 PM" src="https://github.com/user-attachments/assets/acb44adb-5724-4f4e-ae90-3bb459369d51" />
