### PR TITLE
Fix: Correct community taxon opt-out logic in quality metrics

### DIFF
--- a/app/webpack/observations/show/components/quality_metrics.jsx
+++ b/app/webpack/observations/show/components/quality_metrics.jsx
@@ -110,7 +110,7 @@ class QualityMetrics extends React.Component {
         />
       );
     const observerOptedOutOfCommunityTaxon = (
-      ( !observation.user.preferences.prefers_community_taxa && observation.preferences.prefers_community_taxon === null )
+      ( observation.user.preferences.prefers_community_taxa === false && observation.preferences.prefers_community_taxon === null )
       || observation.preferences.prefers_community_taxon === false
     );
     const needsIDVoteDisabled = (


### PR DESCRIPTION
[Linear ticket](https://linear.app/inaturalist/issue/WEB-882/bug-can-community-taxon-be-improved-dqa-question-incorrectly-enabled)
The "Based on the evidence, can the Community Taxon be improved?" DQA question was incorrectly enabled when the observer's `prefers_community_taxa` preference was `null` (unset).

When `prefers_community_taxa` is `null`, it should default to `true` (user DOES prefer community taxa), but the logic was treating `!null` as `true`, incorrectly considering these users as opted out.

Changed the condition from `!observation.user.preferences.prefers_community_taxa` to `observation.user.preferences.prefers_community_taxa === false` to only treat explicit `false` values as opted out, matching the Rails-side behavior where `nil` defaults to preferring community taxa.