### PR TITLE
Fix Rails render deprecation in Guides

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -106,8 +106,9 @@ class GuidesController < ApplicationController
         if params[:print].yesish?
           @layout = params[:layout] if Guide::PDF_LAYOUTS.include?( params[:layout] )
           @layout ||= Guide::GRID
-          @template = "guides/show_#{@layout}.pdf.haml"
-          render layout: "bootstrap.pdf",
+          @template = "guides/show_#{@layout}"
+          render layout: "bootstrap",
+            formats: [:pdf],
             template: @template,
             orientation: ( @layout == "journal" ) ? "Landscape" : nil,
             margin: {


### PR DESCRIPTION
As I was setting up the repository, I noticed deprecation errors in the tests. This PR fixes one of them in the Guides controller

The following deprecation was fixed:
```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: guides/show_grid.pdf.haml (called from block (2 levels) in show at inaturalist/app/controllers/guides_controller.rb:110)
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: layouts/bootstrap.pdf (called from block (2 levels) in show at inaturalist/app/controllers/guides_controller.rb:110)
```

I noticed that the app is using Rails 6.1, and if it is useful, I'll be happy to resolve more deprecations that make Rails upgrades easier.

## Verification that it works

I verified the change by re-running the tests for the controller and by running it locally (screenshots below).

<img width="2624" height="1486" alt="image" src="https://github.com/user-attachments/assets/52fd8720-35de-404b-bd3f-010600cf4a71" />

<img width="2624" height="1392" alt="image" src="https://github.com/user-attachments/assets/f7b8f1a8-0803-44ae-82a2-140b1feb353e" />

