### PR TITLE
Display warning if user is suspended

### DIFF
--- a/app/webpack/observations/show/components/user_with_icon.jsx
+++ b/app/webpack/observations/show/components/user_with_icon.jsx
@@ -45,6 +45,12 @@ const UserWithIcon = ( {
         { !hideSubtitle && (
           <div className="subtitle">{ subtitleLink }</div>
         ) }
+        { user.suspended && (
+          <div class="alert alert-warning">
+            <strong>This user has been suspended</strong>
+            <p class="unstacked">If this is your account and you think this was done by mistake, please <a href="mailto:help@inaturalist.org">contact us</a>.</p>
+          </div>
+        ) }
       </div>
     </div>
   );


### PR DESCRIPTION
Per request at https://forum.inaturalist.org/t/observations-by-suspended-users-should-indicate-the-user-is-suspended/67360. This code has not been tested and relies heavily on Cunningham’s Law.