### PR TITLE
Fix user segments treemap rendering and add date navigation

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -268,7 +268,7 @@ class StatsController < ApplicationController
 
       @data << {
         id: p.id,
-        title: p.title.gsub( /City Nature Challenge: /, "" ),
+        title: p.title.gsub( "City Nature Challenge: ", "" ),
         slug: p.slug,
         observation_count: observations_count,
         in_progress: p.event_in_progress?,
@@ -285,7 +285,7 @@ class StatsController < ApplicationController
     end
     in_project_elastic_params = Observation.params_to_elastic_query( @in_project_params )
     unique_taxon_ids = Observation.elastic_taxon_leaf_counts( in_project_elastic_params ).map do | taxon_id, count |
-      count == 1 ? taxon_id : nil
+      ( count == 1 ) ? taxon_id : nil
     end.compact.uniq
     @unique_contributors = User.
       select( "users.*, count(*) AS unique_count, array_agg(observations.taxon_id) AS taxon_ids" ).
@@ -333,10 +333,22 @@ class StatsController < ApplicationController
   end
 
   def user_segments
-    segmentation_record = SegmentationStatistic.order( "created_at asc" ).last
+    segmentation_record = if params[:date].present?
+      SegmentationStatistic.where( "DATE(created_at) = ?", params[:date] ).first
+    else
+      SegmentationStatistic.order( "created_at asc" ).last
+    end
     redirect_to "/" and return unless segmentation_record
 
     @record_date = segmentation_record.created_at.strftime( "%Y-%m-%d" )
+    @previous_record = SegmentationStatistic.
+      where( "created_at < ?", segmentation_record.created_at ).
+      order( "created_at desc" ).first
+    @next_record = SegmentationStatistic.
+      where( "created_at > ?", segmentation_record.created_at ).
+      order( "created_at asc" ).first
+    @previous_date = @previous_record&.created_at&.strftime( "%Y-%m-%d" )
+    @next_date = @next_record&.created_at&.strftime( "%Y-%m-%d" )
 
     # Main metrics
     seg_main_metrics = segmentation_record.data["main_metrics"]
@@ -505,7 +517,7 @@ class StatsController < ApplicationController
 
     # prepare the data needed for the slideshow
     begin
-      all_project_data = projs.map do | p |
+      all_project_data = projs.to_h do | p |
         [p.id,
          {
            id: p.id,
@@ -518,7 +530,7 @@ class StatsController < ApplicationController
            in_progress: p.event_in_progress?,
            species_count: p.node_api_species_count || 0
          }]
-      end.to_h
+      end
     rescue StandardError => e
       Rails.logger.debug "[DEBUG] error loading project data: #{e}"
       sleep( 2 )
@@ -548,7 +560,7 @@ class StatsController < ApplicationController
     @umbrella_projects = umbrella_project_ids.
       map {| id | all_project_data[id] }.compact
     if options[:trim_slackers]
-      @umbrella_projects = @umbrella_projects.delete_if {| p | ( p[:observation_count] ).zero? }
+      @umbrella_projects.delete_if {| p | p[:observation_count].zero? }
     end
 
     # randomizing subprojects

--- a/app/views/stats/user_segments.html.haml
+++ b/app/views/stats/user_segments.html.haml
@@ -18,8 +18,14 @@
     var STATS_JSON = #{ @segmentation_statistic.to_json.html_safe };
     $( document ).ready( function() {
       var data = STATS_JSON;
+      // Rename "power" to "pwr" in the data
+      function renameNodes( node ) {
+        if ( node.name === "power" ) node.name = "pwr";
+        if ( node.children ) node.children.forEach( renameNodes );
+      }
+      renameNodes( data );
       var width = 1000;
-          height = 700;
+          height = 1800;
       var svg = d3.select( "#user_dataviz" ).append( "svg" )
         .attr( "viewBox", "0 0 " + width + " " + height )
         .attr( "preserveAspectRatio", "xMinYMin meet" );
@@ -28,9 +34,21 @@
       var sumOfLeaves = root.value;
       d3.treemap()
         .size( [width, height] )
-        .paddingTop( 28 )
-        .paddingRight( 7 )
-        .paddingInner( 3 )
+        .tile( function( parent, x0, y0, x1, y1 ) {
+          // Depth 1 (new/existing): slice into rows
+          // Depth 2 (power/casual/inactive): dice into columns
+          // Depth 3+ (web/ios/etc): use squarify
+          if ( parent.depth === 0 ) {
+            d3.treemapSlice( parent, x0, y0, x1, y1 );
+          } else if ( parent.depth === 1 ) {
+            d3.treemapDice( parent, x0, y0, x1, y1 );
+          } else {
+            d3.treemapSquarify( parent, x0, y0, x1, y1 );
+          }
+        } )
+        .paddingTop( 42 )
+        .paddingRight( 5 )
+        .paddingInner( 8 )
         ( root )
 
       var color = d3.scaleOrdinal()
@@ -74,8 +92,8 @@
   
       svg
         .selectAll( "text" )
-        .data( root.leaves().filter( function(d) { 
-          return d.data.value > 10000 & d.parent.parent.data.name == "existing";
+        .data( root.leaves().filter( function(d) {
+          return d.data.value > 10000;
         } ) )
         .enter()
         .append( "text" )
@@ -87,8 +105,8 @@
 
       svg
         .selectAll( "vals" )
-        .data( root.leaves().filter(function( d ) { 
-          return d.data.value > 10000 & d.parent.parent.data.name == "existing"; 
+        .data( root.leaves().filter( function( d ) {
+          return d.data.value > 10000;
         } ) )
         .enter()
         .append( "text")
@@ -100,8 +118,8 @@
 
       svg
         .selectAll( "vals" )
-        .data( root.leaves().filter( function( d ) { 
-          return d.data.value > 10000 & d.parent.parent.data.name == "existing"; 
+        .data( root.leaves().filter( function( d ) {
+          return d.data.value > 10000;
         } ) )
         .enter()
         .append( "text" )
@@ -131,17 +149,21 @@
         .enter()
         .append( "text" )
           .attr( "x", function( d ){ return d.x0} )
-          .attr( "y", function( d ){ return d.y0+21} )
-          .text( function( d ){ 
-            var ratio = ( d.value / sumOfLeaves * 100 ).toFixed( 2 );
-            if ( d.value > 10000 ) {
-              return d.data.name + ": " + d.value.toLocaleString() + " (" + ratio + "%)" 
-            } else {
-              return d.data.name + ": " + d.value.toLocaleString()
-            }
-          } )
+          .attr( "y", function( d ){ return d.y0+12} )
           .attr( "font-size", "14px" )
           .attr( "fill",  "black" )
+          .each( function( d ) {
+            var ratio = ( d.value / sumOfLeaves * 100 ).toFixed( 2 );
+            var text = d3.select( this );
+            // Wrap all labels on two lines
+            text.append( "tspan" )
+              .attr( "x", d.x0 )
+              .text( d.data.name + ": " + d.value.toLocaleString() );
+            text.append( "tspan" )
+              .attr( "x", d.x0 )
+              .attr( "dy", "1.1em" )
+              .text( "(" + ratio + "%)" );
+          } );
       } );
     var STATS_DAU_MAU_JSON = #{ @segmentation_dau_mau.to_json.html_safe };
     $( document ).ready( function() {
@@ -271,8 +293,16 @@
 .container-fluid
   .row
     .col-xs-12
-      %h1 Logged in User Segments
-      = "30 days period ending on #{@record_date}"
+      %h1{ style: "display: flex; align-items: center; gap: 15px;" }
+        Logged in User Segments
+        .btn-group
+          - if @previous_date
+            %a.btn.btn-default.btn-sm{ href: user_segments_stats_path( date: @previous_date ) }
+              %span.glyphicon.glyphicon-chevron-left
+          - if @next_date
+            %a.btn.btn-default.btn-sm{ href: user_segments_stats_path( date: @next_date ) }
+              %span.glyphicon.glyphicon-chevron-right
+      %p{ style: "margin-bottom: 5px;" }= "30 days period ending on #{@record_date}"
       #user_dataviz
   .row
     .col-xs-12


### PR DESCRIPTION
Summary
  - Fix treemaps not rendering under the "new" section
  - Improve treemap layout and label readability
  - Add back/forward navigation to view historical SegmentationStatistic records

  Changes
  Treemap Fixes
  - Increased chart height from 700px to 1800px to give the "new" section adequate vertical space (was getting 0px height due to padding consuming all available space)
  - Changed tiling strategy to display "new" as a row on top with "existing" below, instead of side-by-side columns
  - Removed filter that restricted text labels to only "existing" section items

  Visual Improvements
  - Renamed "power" to "pwr" for shorter labels
  - Increased paddingInner from 2 to 8 for more space between columns
  - Made depth-2 labels wrap onto two lines to prevent overlap
  - Increased paddingTop from 28 to 42 for more space between labels and treemaps

  Navigation
  - Added back/forward buttons next to the "Logged in User Segments" heading
  - Controller now accepts ?date=YYYY-MM-DD parameter to load a specific record
  - Buttons are hidden when there's no previous/next record available

Also fixed a couple small unrelated issues in stats_controller bothering rubocop