### PR TITLE
Adds tool to import observations from prod to dev

### DIFF
--- a/tools/development_tools/import_observation_from_production.rb
+++ b/tools/development_tools/import_observation_from_production.rb
@@ -52,7 +52,6 @@ module ImportObservationFromProduction
     opts[:photo_quality] ||= "medium"
 
     user_id = get_user_ids( ids )
-
     observations = API.get( "/v2/observations?id=#{ids}&user_id=#{user_id}&fields=all" )
     json = JSON.parse( observations.body, symbolize_names: true )
 
@@ -64,14 +63,17 @@ module ImportObservationFromProduction
       import_users( obs_data )
 
       # 2. Make the observation
-      already_exists = observation_already_exists?( obs_data )
-      observation = make_observation( obs_data )
+      is_newly_created, observation = make_observation( obs_data )
 
       # 3. Decorate with photos, identifications, etc.
-      add_photos( obs_data, observation, opts[:photo_quality] ) unless already_exists
-      add_identifications( obs_data, observation ) unless already_exists
+      add_photos( obs_data, observation, opts[:photo_quality] ) if is_newly_created
+      add_identifications( obs_data, observation ) if is_newly_created
     end
   end
+
+  #======================================#
+  ## Private Methods                    ##
+  ###==================================###
 
   def self.get_user_ids( observation_ids )
     resp = API.get( "/v2/observations?id=#{observation_ids}&fields=id,user.id" )
@@ -108,31 +110,27 @@ module ImportObservationFromProduction
     end
   end
 
-  def self.observation_already_exists?( obs_data )
-    longitude, latitude = obs_data.dig( :geojson, :coordinates )
-    Observation.exists?( { latitude:, longitude:, created_at: obs_data[:created_at] } )
-  end
-
   def self.make_observation( obs_data )
     observer = User.find_by( login: obs_data.dig( :user, :login ) )
     longitude, latitude = obs_data.dig( :geojson, :coordinates )
 
-    observation = Observation.find_or_create_by( {
-      latitude:,
-      longitude:,
-      created_at: obs_data[:created_at]
-    } ) do | obs |
+    observation = Observation.find_or_initialize_by( uuid: obs_data[:uuid] ) do | obs |
+      obs.created_at = obs_data[:created_at]
+      obs.latitude = latitude
+      obs.longitude = longitude
+      obs.user = observer
       obs.description = obs_data[:description]
       obs.observed_on_string = obs_data[:observed_on]
       obs.taxon = Taxon.find_by( name: obs_data[:taxon][:name], rank: obs_data[:taxon][:rank] )
-      obs.user = observer
     end
+    is_newly_created = observation.new_record?
     observation.save!
 
-    observation
+    [is_newly_created, observation]
   end
 
   def self.add_photos( obs_data, observation, photo_quality )
+    puts "Downloading #{obs_data[:photos].size} photos..."
     observer = User.find_by( login: obs_data.dig( :user, :login ) )
     obs_data[:photos].each do | photo |
       url = photo[:url].sub( "square", photo_quality )
@@ -151,6 +149,7 @@ module ImportObservationFromProduction
   end
 
   def self.add_identifications( obs_data, observation )
+    puts "Adding #{obs_data[:identifications].size} identifications..."
     obs_data[:identifications].each do | idn_data |
       ident = Identification.find_or_initialize_by(
         body: idn_data[:body],
@@ -159,7 +158,7 @@ module ImportObservationFromProduction
         taxon: Taxon.find_by( name: idn_data[:taxon][:name], rank: idn_data[:taxon][:rank] ),
         user: User.find_by( login: idn_data[:user][:login] )
       )
-      ident.assign_attributes( idn_data.slice( :body, :current, :category, :uuid, :created_at ) )
+      ident.assign_attributes( idn_data.slice( :body, :current, :category, :created_at ) )
       ident.save!
     end
   end


### PR DESCRIPTION
## what's all this?

Hey there, I recently tried setting up `inaturalist` and `iNaturalistAPI` locally and immediately ran into the problem of not having any seed data. I tried looking through the existing documentation/guides but failed to find any instructions for seeding so I added this tool. It lets you copy an observation from production locally.

```
rails r tools/development_tools/import_observation_from_production.rb --ids=137914892,142389012,124056026,175598147,36834943,1932333,55899839,36703818
```
Where `ids` corresponds to the ids of observations in prod.

## what's it do?

It has a couple of features:
- it also imports taxa as needed using @todtb's existing `TaxonImporter` ([added here](https://github.com/inaturalist/inaturalist/pull/3665))
- it can create fake users in order to imitate identifications, annotations, observation fields, votes, etc
- it copies photos at whatever photo_quality you set it to

It currently does import identifications. I did not add the logic for importing annotations, observation fields, or votes yet but I think you can see it would be trivial to add those features as well following the existing structure. 

## why tho?

I think being able to quickly and easily imitate data schemes seen in production data can be extremely useful for replicating bugs. In particular, I was motivated in chasing down [this issue with `term_id_or_unknown`](https://forum.inaturalist.org/t/term-id-or-unknown-query-parameter-not-working-with-term-value-id/52510) but I think you could see why it might be useful in other cases like the [newly proposed subspecies logic](https://www.inaturalist.org/blog/122781-proposed-change-to-subspecies-labels-try-the-demo-and-vote)

All the best,
culi