### PR TITLE
Fix identification_disagreements_count for child disagreement IDs withdrawl

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -419,9 +419,11 @@ class Observation < ApplicationRecord
             # Don't want to compare to ourselves
             ident.id != other_ident.id &&
               # Did this ident disagree with a taxon that is associated with
-              # another current ident OR that contains the taxon in another
-              # current ident?
-              other_ident.taxon.self_and_ancestor_ids.include?( ident.previous_observation_taxon_id )
+              # another current ident OR when a current ident in ancestor or descendant of disagreed ID
+              (
+                other_ident.taxon.self_and_ancestor_ids.include?( ident.previous_observation_taxon_id ) ||
+                ident.previous_observation_taxon.self_and_ancestor_ids.include?(other_ident.taxon.id)
+              )
           end
         end.size,
         identifications_count: num_identifications_by_others,


### PR DESCRIPTION
random example:
ID A: some Spider species
ID B: Harvestmen order (disagreement recorded as spiders species ID A) 
ID C: Spider order
ID A - withdrawn.

because A is withdrawn, the comparison has to happen for parent C descendants too to capture ID C disagreement from ID B information as C's child A is not in active ids.

I believe this also directly fixes `disagreements=true` URL filter? 
please advise anything else (i have checked contribution guidelines, and i dont know if i should never PR without corresponding linked issue) and as this is my first commit :)