### PR TITLE
Fix duplicate observations in grid infinite scroll (#971)

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1075,9 +1075,10 @@ var SearchController = function (
         $scope.pagination.stopped = true;
       }
       var appendedObservations = ObservationsFactory.responseToInstances( response );
-      var existingObservationIDs = _.object( _.map( $scope.observations, function ( observation ) {
-        return [observation.id, true];
-      } ) );
+      var existingObservationIDs = { };
+      _.each( $scope.observations, function ( observation ) {
+        existingObservationIDs[observation.id] = true;
+      } );
       $scope.observations = $scope.observations.concat( _.filter(
         appendedObservations,
         function ( observation ) {

--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1074,9 +1074,18 @@ var SearchController = function (
       ) || ( $scope.pagination.section >= $scope.pagination.maxSections ) ) {
         $scope.pagination.stopped = true;
       }
-      $scope.observations = $scope.observations.concat(
-        ObservationsFactory.responseToInstances( response )
-      );
+      var appendedObservations = ObservationsFactory.responseToInstances( response );
+      var existingObservationIDs = _.object( _.map( $scope.observations, function ( observation ) {
+        return [observation.id, true];
+      } ) );
+      $scope.observations = $scope.observations.concat( _.filter(
+        appendedObservations,
+        function ( observation ) {
+          if ( existingObservationIDs[observation.id] ) { return false; }
+          existingObservationIDs[observation.id] = true;
+          return true;
+        }
+      ) );
       $scope.pagination.searching = false;
     } );
   };


### PR DESCRIPTION
Fix duplicate observations in grid infinite scroll (#971)

Context
While scrolling in grid view on https://www.inaturalist.org/observations, duplicate observation tiles can appear. This occurs because pagination is page-based and operates on a live, shifting result set, which can cause overlapping results between successive API requests.

Previously, new results were appended using a raw concat:

$scope.observations = $scope.observations.concat(
  ObservationsFactory.responseToInstances(response)
);

Since there was no deduplication by observation ID, overlapping pages could introduce duplicate observations into the client state.

Solution
This change introduces a minimal, client-side deduplication step at the merge boundary in `showMoreObservations()`.

- Track existing observation IDs
- Append only observations whose `id` has not already been seen
- Preserve original ordering (first occurrence wins)

This ensures duplicates cannot enter the client state even if the API returns overlapping pages.

Scope
- No changes to pagination logic or API behavior
- No refactors outside the merge logic
- Limited to a single code path in the observations grid infinite scroll

Reproduction
1. Open https://www.inaturalist.org/observations
2. Switch to grid view
3. Scroll repeatedly to trigger infinite loading
4. Observe duplicate observation tiles in the grid

This behavior has been confirmed on production, with multiple observation IDs appearing more than once during a single scroll session.

Notes
This is a defensive client-side fix for overlapping page results. It does not alter server-side pagination behavior.