### PR TITLE
fix(quick): automated unsuspend conditional fix

### DIFF
--- a/app/views/users/moderation.html.haml
+++ b/app/views/users/moderation.html.haml
@@ -66,7 +66,7 @@
         %td
           - if record.user_id == 0 && record.is_a?( Flag )
             = @site.site_name_short
-          - if record.user_id == nil && record.is_a?( ModeratorAction )
+          - elsif record.user_id == nil && record.is_a?( ModeratorAction ) && record.action == ModeratorAction::UNSUSPEND
             = t( :moderator_actions_suspension_expired )
           - else
             = link_to_user( record.user )


### PR DESCRIPTION
Quick fix for bug in ModerationAction index. Corrects conditional display for `Moderator/flagger` column to use elsif to fix displaying `deleted user` on `Flags`. Adds an additional check for `ModeratorAction::UNSUSPEND` to display the automated unsuspend text.

Testing Instruction:
1. Flag a user
2. Update flag `<flag>.update(user_id: 0)`
3. Load moderation history for user
4. Confirm that the Moderator/flagger column does not display `deleted user`

Before:
<img width="1275" height="77" alt="image" src="https://github.com/user-attachments/assets/4f0d6f09-486b-4ca2-ac1c-55ac74f6fa71" />

After:
<img width="1276" height="60" alt="image" src="https://github.com/user-attachments/assets/5d89d36a-7849-4c59-bb05-b6359de1be1e" />
