### PR TITLE
fix: Add call to action string for Contribute

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1313,6 +1313,8 @@ en:
   continue_to_site: Continue to %{site_name}
   # e.g. "With iNaturalist, you can contribute to real science"
   contribute: Contribute
+  # e.g. "Contribute to iNaturalist"
+  contribute_cta: Contribute
   contributor_cannot_be_found: Contributor cannot be found
   contributors_to_project: "Contributors to %{project}"
   controlled_term_labels:


### PR DESCRIPTION
Contribute is used both as an imperative and indicative verb on the page, so we need two strings for them.

@sylvain-morin please let me know if there are any more that you can think of!