### PR TITLE
Store reasons for suspension edits with audit history

### DIFF
--- a/app/controllers/moderator_actions_controller.rb
+++ b/app/controllers/moderator_actions_controller.rb
@@ -143,7 +143,7 @@ class ModeratorActionsController < ApplicationController
 
   def approved_update_params
     params.require( :moderator_action ).require( :audit_comment )
-    params.require( :moderator_action ).permit( :audit_comment, :suspended_until )
+    params.require( :moderator_action ).permit( :reason, :audit_comment, :suspended_until )
   end
 
   def resource_must_be_viewable_by_logged_in_user

--- a/app/controllers/moderator_actions_controller.rb
+++ b/app/controllers/moderator_actions_controller.rb
@@ -92,9 +92,6 @@ class ModeratorActionsController < ApplicationController
   end
 
   def update
-    if params[:moderator_action]&.key?( :audit_comment )
-      @moderator_action.audit_comment = params[:moderator_action][:audit_comment]
-    end
     if @moderator_action.update( approved_update_params.merge( last_edited_by_user_id: current_user.id ) )
       flash[:notice] = t( :updated )
       redirect_to moderation_person_path( @moderator_action.resource )
@@ -103,6 +100,11 @@ class ModeratorActionsController < ApplicationController
         errors: @moderator_action.errors.full_messages.to_sentence )
       render :edit, layout: "bootstrap", status: :unprocessable_entity
     end
+  rescue ActionController::ParameterMissing
+    @moderator_action.errors.add( :audit_comment, :blank )
+    flash[:error] = t( :failed_to_save_record_with_errors,
+      errors: @moderator_action.errors.full_messages.to_sentence )
+    render :edit, layout: "bootstrap", status: :unprocessable_entity
   end
 
   def resource_url
@@ -140,7 +142,8 @@ class ModeratorActionsController < ApplicationController
   end
 
   def approved_update_params
-    params.require( :moderator_action ).permit( :suspended_until )
+    params.require( :moderator_action ).require( :audit_comment )
+    params.require( :moderator_action ).permit( :audit_comment, :suspended_until )
   end
 
   def resource_must_be_viewable_by_logged_in_user

--- a/app/controllers/moderator_actions_controller.rb
+++ b/app/controllers/moderator_actions_controller.rb
@@ -92,13 +92,16 @@ class ModeratorActionsController < ApplicationController
   end
 
   def update
+    if params[:moderator_action]&.key?( :audit_comment )
+      @moderator_action.audit_comment = params[:moderator_action][:audit_comment]
+    end
     if @moderator_action.update( approved_update_params.merge( last_edited_by_user_id: current_user.id ) )
       flash[:notice] = t( :updated )
       redirect_to moderation_person_path( @moderator_action.resource )
     else
       flash[:error] = t( :failed_to_save_record_with_errors,
         errors: @moderator_action.errors.full_messages.to_sentence )
-      render :edit, layout: "bootstrap"
+      render :edit, layout: "bootstrap", status: :unprocessable_entity
     end
   end
 
@@ -137,7 +140,7 @@ class ModeratorActionsController < ApplicationController
   end
 
   def approved_update_params
-    params.require( :moderator_action ).permit( :reason, :suspended_until )
+    params.require( :moderator_action ).permit( :suspended_until )
   end
 
   def resource_must_be_viewable_by_logged_in_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1016,7 +1016,7 @@ class UsersController < ApplicationController
       where( "flaggable_type != 'Taxon'" ).
       order( "id desc" )
     scopes["ModeratorAction"] = ModeratorAction.
-      includes( :user, :last_edited_by_user ).
+      includes( :user, :last_edited_by_user, :audits ).
       where( "created_at < ?", before ).
       where( resource_user_id: @user ).
       order( "id desc" )

--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -65,7 +65,7 @@ class ModeratorAction < ApplicationRecord
   after_save :delete_resource_update_actions, if: ->( moderator_action ) { moderator_action.action == HIDE }
   after_destroy :notify_resource_on_destroy
 
-  audited only: [:suspended_until, :last_edited_by_user_id],
+  audited only: [:reason, :suspended_until, :last_edited_by_user_id],
     if: ->( moderator_action ) { moderator_action.action == SUSPEND }
 
   def self.current_private_actions

--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -42,6 +42,10 @@ class ModeratorAction < ApplicationRecord
   validates :action, inclusion: ACTIONS
   validates :reason, length: { minimum: MINIMUM_REASON_LENGTH, maximum: MAXIMUM_REASON_LENGTH }
   validates :reason, length: { maximum: MAXIMUM_SUSPEND_REASON_LENGTH }, if: -> { action == SUSPEND }
+  validates :audit_comment, presence: true, on: :update, if: -> { action == SUSPEND }
+  validates :audit_comment,
+    length: { minimum: MINIMUM_REASON_LENGTH, maximum: MAXIMUM_REASON_LENGTH },
+    allow_blank: true
   validate :only_curators_and_staff_can_hide, on: :create
   validate :only_staff_can_make_private
   validate :only_staff_can_rename, on: :create
@@ -59,6 +63,9 @@ class ModeratorAction < ApplicationRecord
   after_save :notify_resource
   after_save :delete_resource_update_actions, if: ->( moderator_action ) { moderator_action.action == HIDE }
   after_destroy :notify_resource_on_destroy
+
+  audited only: [:suspended_until, :last_edited_by_user_id],
+    if: ->( moderator_action ) { moderator_action.action == SUSPEND }
 
   def self.current_private_actions
     moderated_private_resource_ids = ModeratorAction.where( private: true ).pluck( :resource_id )

--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -45,6 +45,7 @@ class ModeratorAction < ApplicationRecord
   validates :audit_comment, presence: true, on: :update, if: -> { action == SUSPEND }
   validates :audit_comment,
     length: { minimum: MINIMUM_REASON_LENGTH, maximum: MAXIMUM_REASON_LENGTH },
+    on: :update,
     allow_blank: true
   validate :only_curators_and_staff_can_hide, on: :create
   validate :only_staff_can_make_private

--- a/app/views/moderator_actions/_suspension_form.html.haml
+++ b/app/views/moderator_actions/_suspension_form.html.haml
@@ -1,5 +1,4 @@
 - editing = local_assigns.fetch( :editing, false )
-- reason_field = editing ? :audit_comment : :reason
 - default_duration = local_assigns.fetch( :default_duration, "1_day" )
 - existing_suspended_until = local_assigns[:suspended_until_value]
 - reason_opts = { required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: local_assigns.fetch( :reason_maxlength, ModeratorAction::MAXIMUM_REASON_LENGTH ) }
@@ -12,12 +11,14 @@
     = f.form_field :suspension_reason, label: t( :suspension_reason_label ) do
       = select_tag :suspension_reason, options_for_select( reason_options, selected_reason || reason_options.first[1] ), class: "form-control", id: "suspension_reason"
     .custom-reason-field{ style: selected_reason == "custom" ? "" : "display: none;" }
-      = f.text_area reason_field, reason_opts.merge( id: "moderator_action_reason" )
+      = f.text_area :reason, reason_opts.merge( id: "moderator_action_reason" )
       %p.help-block= t( :suspension_reason_custom_note )
-    = f.hidden_field reason_field, id: "hidden_reason"
+    = f.hidden_field :reason, id: "hidden_reason"
   - else
-    = f.text_area reason_field, reason_opts
+    = f.text_area :reason, reason_opts
     %p.help-block= t( :suspension_reason_custom_note )
+  - if editing
+    = f.text_area :audit_comment, required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH, label: t( :edit_reason_label )
   - if current_user.is_admin?
     = f.form_field :suspension_duration, label: t( :suspension_duration ) do
       = select_tag :suspension_duration, options_for_select( [[t( :suspension_duration_1_day ), "1_day"], [t( :suspension_duration_3_days ), "3_days"], [t( :suspension_duration_1_week ), "1_week"], [t( :suspension_duration_1_month ), "1_month"], [t( :suspension_duration_2_months ), "2_months"], [t( :suspension_duration_indefinite ), "indefinite"], [t( :suspension_duration_custom ), "custom"]], default_duration ), class: "form-control", id: "suspension_duration"

--- a/app/views/moderator_actions/_suspension_form.html.haml
+++ b/app/views/moderator_actions/_suspension_form.html.haml
@@ -11,7 +11,7 @@
     = f.form_field :suspension_reason, label: t( :suspension_reason_label ) do
       = select_tag :suspension_reason, options_for_select( reason_options, selected_reason || reason_options.first[1] ), class: "form-control", id: "suspension_reason"
     .custom-reason-field{ style: selected_reason == "custom" ? "" : "display: none;" }
-      = f.text_area :reason, reason_opts.merge( id: "moderator_action_reason" )
+      = f.text_area :reason, reason_opts
       %p.help-block= t( :suspension_reason_custom_note )
     = f.hidden_field :reason, id: "hidden_reason"
   - else

--- a/app/views/moderator_actions/_suspension_form.html.haml
+++ b/app/views/moderator_actions/_suspension_form.html.haml
@@ -1,3 +1,5 @@
+- editing = local_assigns.fetch( :editing, false )
+- reason_field = editing ? :audit_comment : :reason
 - default_duration = local_assigns.fetch( :default_duration, "1_day" )
 - existing_suspended_until = local_assigns[:suspended_until_value]
 - reason_opts = { required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: local_assigns.fetch( :reason_maxlength, ModeratorAction::MAXIMUM_REASON_LENGTH ) }
@@ -7,14 +9,14 @@
   - if current_user.is_admin?
     - reason_options = ModeratorAction::SUSPENSION_REASONS.keys.map { |key| [t( "suspension_reasons.#{key}" ), key] }
     - reason_options << [t( :suspension_reason_custom ), "custom"]
-    = f.form_field :suspension_reason, label: t( :suspension_reason_label ) do
+    = f.form_field :suspension_reason, label: t( editing ? :edit_reason_label : :suspension_reason_label ) do
       = select_tag :suspension_reason, options_for_select( reason_options, selected_reason || reason_options.first[1] ), class: "form-control", id: "suspension_reason"
     .custom-reason-field{ style: selected_reason == "custom" ? "" : "display: none;" }
-      = f.text_area :reason, reason_opts
+      = f.text_area reason_field, reason_opts.merge( id: "moderator_action_reason" )
       %p.help-block= t( :suspension_reason_custom_note )
-    = f.hidden_field :reason, id: "hidden_reason"
+    = f.hidden_field reason_field, id: "hidden_reason"
   - else
-    = f.text_area :reason, reason_opts
+    = f.text_area reason_field, reason_opts
     %p.help-block= t( :suspension_reason_custom_note )
   - if current_user.is_admin?
     = f.form_field :suspension_duration, label: t( :suspension_duration ) do

--- a/app/views/moderator_actions/_suspension_form.html.haml
+++ b/app/views/moderator_actions/_suspension_form.html.haml
@@ -9,7 +9,7 @@
   - if current_user.is_admin?
     - reason_options = ModeratorAction::SUSPENSION_REASONS.keys.map { |key| [t( "suspension_reasons.#{key}" ), key] }
     - reason_options << [t( :suspension_reason_custom ), "custom"]
-    = f.form_field :suspension_reason, label: t( editing ? :edit_reason_label : :suspension_reason_label ) do
+    = f.form_field :suspension_reason, label: t( :suspension_reason_label ) do
       = select_tag :suspension_reason, options_for_select( reason_options, selected_reason || reason_options.first[1] ), class: "form-control", id: "suspension_reason"
     .custom-reason-field{ style: selected_reason == "custom" ? "" : "display: none;" }
       = f.text_area reason_field, reason_opts.merge( id: "moderator_action_reason" )

--- a/app/views/moderator_actions/edit.html.haml
+++ b/app/views/moderator_actions/edit.html.haml
@@ -6,8 +6,10 @@
       %h2= @title
       %p.help-block.has-error= t( :suspension_reason_edit_note )
       %p= link_to_user( @moderator_action.resource )
-      - selected_reason = ModeratorAction::SUSPENSION_REASONS.key?( @moderator_action.reason ) ? @moderator_action.reason : "custom"
-      = render "moderator_actions/suspension_form", moderator_action: @moderator_action, default_duration: @moderator_action.suspended_until.present? ? "custom" : "indefinite", suspended_until_value: @moderator_action.suspended_until, selected_reason: selected_reason, submit_text: t( :update ), cancel_path: moderation_person_path( @moderator_action.resource )
+      .form-group
+        %label= t( :original_suspension_reason )
+        %p.form-control-static= @moderator_action.translated_reason
+      = render "moderator_actions/suspension_form", moderator_action: @moderator_action, editing: true, default_duration: @moderator_action.suspended_until.present? ? "custom" : "indefinite", suspended_until_value: @moderator_action.suspended_until, selected_reason: "custom", submit_text: t( :update ), cancel_path: moderation_person_path( @moderator_action.resource )
       .form-group
         - if @moderator_action.last_edited_by_user
           %label= t( :last_edited_by )

--- a/app/views/moderator_actions/edit.html.haml
+++ b/app/views/moderator_actions/edit.html.haml
@@ -6,10 +6,8 @@
       %h2= @title
       %p.help-block.has-error= t( :suspension_reason_edit_note )
       %p= link_to_user( @moderator_action.resource )
-      .form-group
-        %label= t( :original_suspension_reason )
-        %p.form-control-static= @moderator_action.translated_reason
-      = render "moderator_actions/suspension_form", moderator_action: @moderator_action, editing: true, default_duration: @moderator_action.suspended_until.present? ? "custom" : "indefinite", suspended_until_value: @moderator_action.suspended_until, selected_reason: "custom", submit_text: t( :update ), cancel_path: moderation_person_path( @moderator_action.resource )
+      - selected_reason = ModeratorAction::SUSPENSION_REASONS.key?( @moderator_action.reason ) ? @moderator_action.reason : "custom"
+      = render "moderator_actions/suspension_form", moderator_action: @moderator_action, editing: true, default_duration: @moderator_action.suspended_until.present? ? "custom" : "indefinite", suspended_until_value: @moderator_action.suspended_until, selected_reason: selected_reason, submit_text: t( :update ), cancel_path: moderation_person_path( @moderator_action.resource )
       .form-group
         - if @moderator_action.last_edited_by_user
           %label= t( :last_edited_by )

--- a/app/views/users/moderation.html.haml
+++ b/app/views/users/moderation.html.haml
@@ -90,6 +90,11 @@
                 = "#{t( :last_edited_by )} "
                 = link_to_user( record.last_edited_by_user )
                 %time.datetime{ datetime: record.updated_at.iso8601, title: record.updated_at.iso8601 }= l record.updated_at, format: :long
+              - last_edit_audit = record.audits.select { |a| a.action == "update" && a.comment.present? }.last
+              - if last_edit_audit
+                %div.text-muted
+                  %strong= "#{t( :edit_reason )}: "
+                  = truncate_with_more formatted_user_text( last_edit_audit.comment ), length: 512
             - if record.user
               %div.text-muted
                 = "#{t( :created_by )} "

--- a/app/views/users/unsuspend.html.haml
+++ b/app/views/users/unsuspend.html.haml
@@ -3,7 +3,7 @@
     .col-md-6.col-md-offset-3
       %h1=t :unsuspend_user_html, user: link_to_user( @user )
       = form_for @moderator_action, builder: BootstrapFormBuilder do | f |
-        = f.text_area :reason, description: t( :unsuspend_user_reason_instructions ), required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH - 5
+        = f.text_area :reason, description: "#{t( :unsuspend_user_reason_instructions )} #{t( :suspension_reason_custom_note)}", required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH - 5
         = f.hidden_field :user_id
         = f.hidden_field :resource_type
         = f.hidden_field :resource_id

--- a/app/views/users/unsuspend.html.haml
+++ b/app/views/users/unsuspend.html.haml
@@ -3,7 +3,7 @@
     .col-md-6.col-md-offset-3
       %h1=t :unsuspend_user_html, user: link_to_user( @user )
       = form_for @moderator_action, builder: BootstrapFormBuilder do | f |
-        = f.text_area :reason, description: "#{t( :unsuspend_user_reason_instructions )} #{t( :suspension_reason_custom_note)}", required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH - 5
+        = f.text_area :reason, description: "#{t( :unsuspend_user_reason_instructions )} #{t( :suspension_reason_custom_note )}", required: true, minlength: ModeratorAction::MINIMUM_REASON_LENGTH, maxlength: ModeratorAction::MAXIMUM_REASON_LENGTH - 5
         = f.hidden_field :user_id
         = f.hidden_field :resource_type
         = f.hidden_field :resource_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5725,8 +5725,6 @@ en:
   suspension_reason_custom_note: Please note this reason will be displayed to the suspended user.
   # note displayed when a curator is editing a suspension
   suspension_reason_edit_note: Please update the reason and explain why you are changing the user's suspension.
-  # label for the original suspension reason displayed when editing
-  original_suspension_reason: Original suspension reason
   # label for the edit reason dropdown when editing a suspension
   edit_reason_label: Reason for editing
   # label for the edit reason field in the moderation history table

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5724,7 +5724,7 @@ en:
   # note displayed when entering a custom suspension reason
   suspension_reason_custom_note: Please note this reason will be displayed to the suspended user.
   # note displayed when a curator is editing a suspension
-  suspension_reason_edit_note: Please provide a reason for editing this suspension.
+  suspension_reason_edit_note: Please update the reason and explain why you are changing the user's suspension.
   # label for the original suspension reason displayed when editing
   original_suspension_reason: Original suspension reason
   # label for the edit reason dropdown when editing a suspension

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5724,7 +5724,13 @@ en:
   # note displayed when entering a custom suspension reason
   suspension_reason_custom_note: Please note this reason will be displayed to the suspended user.
   # note displayed when a curator is editing a suspension
-  suspension_reason_edit_note: Please update the reason and explain why you are changing the user's suspension.
+  suspension_reason_edit_note: Please provide a reason for editing this suspension.
+  # label for the original suspension reason displayed when editing
+  original_suspension_reason: Original suspension reason
+  # label for the edit reason dropdown when editing a suspension
+  edit_reason_label: Reason for editing
+  # label for the edit reason field in the moderation history table
+  edit_reason: Edit reason
   # predefined reasons for user suspension which are listed to curators in the user suspension form
   suspension_reasons:
     # reason displayed to users who have been suspended for posting hate speech
@@ -10684,6 +10690,8 @@ en:
         # The reason a moderator action was taken, e.g. an explanation for why
         # someone thought a comment should be hidden
         reason: Reason
+        # The reason provided when editing a suspension, stored as an audit comment
+        audit_comment: Edit reason
       observation:
         description: Notes
         geo_x: Easting

--- a/spec/controllers/moderator_actions_controller_spec.rb
+++ b/spec/controllers/moderator_actions_controller_spec.rb
@@ -115,6 +115,7 @@ describe ModeratorActionsController do
       audit = suspend_action.audits.where( action: "update" ).last
       expect( audit ).not_to be_nil
       expect( audit.comment ).to eq audit_comment_text
+      suspended_user.reload
       expect( suspended_user.suspended_until ).to be_within( 1.second ).of( new_date )
     end
 

--- a/spec/controllers/moderator_actions_controller_spec.rb
+++ b/spec/controllers/moderator_actions_controller_spec.rb
@@ -96,18 +96,43 @@ describe ModeratorActionsController do
   end
 
   describe "update" do
-    it "updates the reason" do
+    let( :audit_comment_text ) { "Editing suspension: #{Faker::Lorem.sentence}" }
+
+    it "saves audit_comment and preserves the original reason" do
       sign_in suspend_action.user
-      new_reason = "New reason for suspension #{Faker::Lorem.sentence}"
-      patch :update, params: { id: suspend_action.id, moderator_action: { reason: new_reason } }
+      original_reason = suspend_action.reason
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: { audit_comment: audit_comment_text }
+      }
       suspend_action.reload
-      expect( suspend_action.reason ).to eq new_reason
+      expect( suspend_action.reason ).to eq original_reason
+      audit = suspend_action.audits.where( action: "update" ).last
+      expect( audit ).not_to be_nil
+      expect( audit.comment ).to eq audit_comment_text
+    end
+
+    it "requires audit_comment when updating" do
+      sign_in suspend_action.user
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: { suspended_until: 30.days.from_now }
+      }
+      expect( response.status ).to eq 422
+      suspend_action.reload
+      expect( suspend_action.audits.where( action: "update" ).count ).to eq 0
     end
 
     it "updates suspended_until" do
       sign_in suspend_action.user
       new_date = 30.days.from_now
-      patch :update, params: { id: suspend_action.id, moderator_action: { suspended_until: new_date } }
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: {
+          audit_comment: audit_comment_text,
+          suspended_until: new_date
+        }
+      }
       suspend_action.reload
       expect( suspend_action.suspended_until ).to be_within( 1.second ).of( new_date )
     end
@@ -115,7 +140,10 @@ describe ModeratorActionsController do
     it "sets last_edited_by_user to the current user" do
       editor = make_admin
       sign_in editor
-      patch :update, params: { id: suspend_action.id, moderator_action: { reason: generic_reason } }
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: { audit_comment: audit_comment_text }
+      }
       suspend_action.reload
       expect( suspend_action.last_edited_by_user ).to eq editor
     end
@@ -123,7 +151,13 @@ describe ModeratorActionsController do
     it "syncs suspended_until to the suspended user" do
       sign_in suspend_action.user
       new_date = 21.days.from_now
-      patch :update, params: { id: suspend_action.id, moderator_action: { suspended_until: new_date } }
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: {
+          audit_comment: audit_comment_text,
+          suspended_until: new_date
+        }
+      }
       suspended_user.reload
       expect( suspended_user.suspended_until ).to be_within( 1.second ).of( new_date )
     end
@@ -132,23 +166,38 @@ describe ModeratorActionsController do
       sign_in suspend_action.user
       suspended_user.reload
       original_suspended_at = suspended_user.suspended_at
-      patch :update, params: { id: suspend_action.id, moderator_action: { suspended_until: 7.days.from_now } }
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: {
+          audit_comment: audit_comment_text,
+          suspended_until: 7.days.from_now
+        }
+      }
       suspended_user.reload
       expect( suspended_user.suspended_at ).to eq original_suspended_at
     end
 
     it "redirects to moderation page on success" do
       sign_in make_admin
-      patch :update, params: { id: suspend_action.id, moderator_action: { reason: generic_reason } }
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: { audit_comment: audit_comment_text }
+      }
       expect( response ).to redirect_to( moderation_person_path( suspended_user ) )
     end
 
     it "does not allow updates from unauthorized users" do
       sign_in make_curator
-      original_reason = suspend_action.reason
-      patch :update, params: { id: suspend_action.id, moderator_action: { reason: "New unauthorized reason here" } }
+      patch :update, params: {
+        id: suspend_action.id,
+        moderator_action: {
+          audit_comment: "Unauthorized edit reason here"
+        }
+      }
+      expect( response ).to redirect_to( root_url )
+      expect( flash[:error] ).to eq I18n.t( :you_dont_have_permission_to_do_that )
       suspend_action.reload
-      expect( suspend_action.reason ).to eq original_reason
+      expect( suspend_action.audits.where( action: "update" ).count ).to eq 0
     end
   end
 

--- a/spec/controllers/moderator_actions_controller_spec.rb
+++ b/spec/controllers/moderator_actions_controller_spec.rb
@@ -98,18 +98,24 @@ describe ModeratorActionsController do
   describe "update" do
     let( :audit_comment_text ) { "Editing suspension: #{Faker::Lorem.sentence}" }
 
-    it "saves audit_comment and preserves the original reason" do
+    it "saves audit_comment, preserves the original reason, and updates suspended_until" do
       sign_in suspend_action.user
       original_reason = suspend_action.reason
+      new_date = 30.days.from_now
+
       patch :update, params: {
         id: suspend_action.id,
-        moderator_action: { audit_comment: audit_comment_text }
+        moderator_action: {
+          audit_comment: audit_comment_text,
+          suspended_until: new_date
+        }
       }
       suspend_action.reload
       expect( suspend_action.reason ).to eq original_reason
       audit = suspend_action.audits.where( action: "update" ).last
       expect( audit ).not_to be_nil
       expect( audit.comment ).to eq audit_comment_text
+      expect( suspended_user.suspended_until ).to be_within( 1.second ).of( new_date )
     end
 
     it "requires audit_comment when updating" do
@@ -121,20 +127,6 @@ describe ModeratorActionsController do
       expect( response.status ).to eq 422
       suspend_action.reload
       expect( suspend_action.audits.where( action: "update" ).count ).to eq 0
-    end
-
-    it "updates suspended_until" do
-      sign_in suspend_action.user
-      new_date = 30.days.from_now
-      patch :update, params: {
-        id: suspend_action.id,
-        moderator_action: {
-          audit_comment: audit_comment_text,
-          suspended_until: new_date
-        }
-      }
-      suspend_action.reload
-      expect( suspend_action.suspended_until ).to be_within( 1.second ).of( new_date )
     end
 
     it "sets last_edited_by_user to the current user" do

--- a/spec/controllers/moderator_actions_controller_spec.rb
+++ b/spec/controllers/moderator_actions_controller_spec.rb
@@ -98,23 +98,25 @@ describe ModeratorActionsController do
   describe "update" do
     let( :audit_comment_text ) { "Editing suspension: #{Faker::Lorem.sentence}" }
 
-    it "saves audit_comment, preserves the original reason, and updates suspended_until" do
+    it "saves audit_comment, updates reason, and updates suspended_until" do
       sign_in suspend_action.user
-      original_reason = suspend_action.reason
+      new_reason = "Updated reason for suspension"
       new_date = 30.days.from_now
 
       patch :update, params: {
         id: suspend_action.id,
         moderator_action: {
+          reason: new_reason,
           audit_comment: audit_comment_text,
           suspended_until: new_date
         }
       }
       suspend_action.reload
-      expect( suspend_action.reason ).to eq original_reason
+      expect( suspend_action.reason ).to eq new_reason
       audit = suspend_action.audits.where( action: "update" ).last
       expect( audit ).not_to be_nil
       expect( audit.comment ).to eq audit_comment_text
+      expect( audit.audited_changes ).to have_key( "reason" )
       suspended_user.reload
       expect( suspended_user.suspended_until ).to be_within( 1.second ).of( new_date )
     end

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -566,23 +566,18 @@ describe ModeratorAction do
         u = create :user
         ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
         u.reload
+        original_suspended_at = u.suspended_at
+
         expect( u.suspended_until ).to be_nil
         new_time = 14.days.from_now
-        ma.audit_comment = "Adjusting suspension duration"
+        audit_comment = "Adjusting suspension duration"
+        ma.audit_comment = audit_comment
         ma.update!( suspended_until: new_time )
         u.reload
-        expect( u.suspended_until ).to be_within( 1.second ).of( new_time )
-      end
 
-      it "does not reset suspended_at when updating" do
-        u = create :user
-        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
-        u.reload
-        original_suspended_at = u.suspended_at
-        ma.audit_comment = "Adjusting suspension duration"
-        ma.update!( suspended_until: 7.days.from_now )
-        u.reload
         expect( u.suspended_at ).to eq original_suspended_at
+        expect( u.suspended_until ).to be_within( 1.second ).of( new_time )
+        expect( ma.audits.last.comment ).to eq( audit_comment )
       end
 
       it "requires audit_comment on update" do

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -595,6 +595,14 @@ describe ModeratorAction do
         expect( ma.update( suspended_until: 7.days.from_now ) ).to be false
         expect( ma.errors[:audit_comment] ).not_to be_empty
       end
+
+      it "validates audit_comment maximum length" do
+        u = create :user
+        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        ma.audit_comment = "a" * 2049
+        expect( ma.update( suspended_until: 7.days.from_now ) ).to be false
+        expect( ma.errors[:audit_comment] ).not_to be_empty
+      end
     end
   end
 

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -581,6 +581,18 @@ describe ModeratorAction do
         expect( ma.audits.last.comment ).to eq( audit_comment )
       end
 
+      it "audits reason changes" do
+        u = create :user
+        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        original_reason = ma.reason
+        new_reason = "Updated suspension reason"
+        ma.audit_comment = "Changing the reason"
+        ma.update!( reason: new_reason )
+        audit = ma.audits.last
+        expect( audit.audited_changes ).to have_key( "reason" )
+        expect( audit.audited_changes["reason"] ).to eq( [original_reason, new_reason] )
+      end
+
       it "requires audit_comment on update" do
         u = create :user
         ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -568,6 +568,7 @@ describe ModeratorAction do
         u.reload
         expect( u.suspended_until ).to be_nil
         new_time = 14.days.from_now
+        ma.audit_comment = "Adjusting suspension duration"
         ma.update!( suspended_until: new_time )
         u.reload
         expect( u.suspended_until ).to be_within( 1.second ).of( new_time )
@@ -578,9 +579,36 @@ describe ModeratorAction do
         ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
         u.reload
         original_suspended_at = u.suspended_at
+        ma.audit_comment = "Adjusting suspension duration"
         ma.update!( suspended_until: 7.days.from_now )
         u.reload
         expect( u.suspended_at ).to eq original_suspended_at
+      end
+
+      it "requires audit_comment on update" do
+        u = create :user
+        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        expect( ma.update( suspended_until: 7.days.from_now ) ).to be false
+        expect( ma.errors[:audit_comment] ).not_to be_empty
+      end
+
+      it "validates audit_comment minimum length" do
+        u = create :user
+        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        ma.audit_comment = "short"
+        expect( ma.update( suspended_until: 7.days.from_now ) ).to be false
+        expect( ma.errors[:audit_comment] ).not_to be_empty
+      end
+
+      it "creates an audit record with the comment" do
+        u = create :user
+        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
+        comment = "Updating suspension duration for reason"
+        ma.audit_comment = comment
+        ma.update!( suspended_until: 7.days.from_now )
+        audit = ma.audits.where( action: "update" ).last
+        expect( audit ).not_to be_nil
+        expect( audit.comment ).to eq comment
       end
     end
   end

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -594,17 +594,6 @@ describe ModeratorAction do
         expect( ma.update( suspended_until: 7.days.from_now ) ).to be false
         expect( ma.errors[:audit_comment] ).not_to be_empty
       end
-
-      it "creates an audit record with the comment" do
-        u = create :user
-        ma = create( :moderator_action, action: ModeratorAction::SUSPEND, resource: u )
-        comment = "Updating suspension duration for reason"
-        ma.audit_comment = comment
-        ma.update!( suspended_until: 7.days.from_now )
-        audit = ma.audits.where( action: "update" ).last
-        expect( audit ).not_to be_nil
-        expect( audit.comment ).to eq comment
-      end
     end
   end
 

--- a/spec/models/moderator_action_spec.rb
+++ b/spec/models/moderator_action_spec.rb
@@ -569,6 +569,7 @@ describe ModeratorAction do
         original_suspended_at = u.suspended_at
 
         expect( u.suspended_until ).to be_nil
+
         new_time = 14.days.from_now
         audit_comment = "Adjusting suspension duration"
         ma.audit_comment = audit_comment


### PR DESCRIPTION
- feat: store suspension edits as audit
- unsuspend page includes a note warning that users will see unsuspension reasons
-   require `audit_comment` when updating a ModerationHistory::SUSPEND `suspended_until`