### PR TITLE
feat: Final homepage changes

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -11,15 +11,11 @@ class WelcomeController < ApplicationController
         @announcements = Announcement.active_in_placement( Announcement::WELCOME_INDEX, { site: @site } )
         @google_webmaster_verification = @site.google_webmaster_verification if @site
 
-        # Admin preview: logged-in admins on the default site see the new homepage
-        if @site == Site.default && logged_in? && current_user.is_admin?
-          setup_v2_homepage
-          render template: "welcome_v2/index", layout: "bootstrap"
-          return
-        end
-
         if logged_in? && !@site.draft?
           redirect_to home_path
+        elsif @site == Site.default
+          setup_v2_homepage
+          render template: "welcome_v2/index", layout: "bootstrap"
         elsif !@page
           render layout: "bootstrap"
         end

--- a/app/views/welcome_v2/index.html.haml
+++ b/app/views/welcome_v2/index.html.haml
@@ -11,7 +11,7 @@
     %meta{content: image_url(@site.shareable_image.url), property: "twitter:image"}
   %meta{content: root_url, property: "og:url"}
   %meta{content: t(:x_site_is_a_social_network_for_naturalist, site: @site&.name), property: "og:description"}
-  %meta{content: t(:x_site_is_a_social_network_for_naturalist, site: @site&.name), property: "description"}
+  %meta{content: t(:x_site_is_a_social_network_for_naturalist, site: @site&.name), name: "description"}
   = tag.link rel: "preload", href: asset_path("welcome_v2/hero_video_fallback.webp"), as: "image", type: "image/webp"
 - s = "views.welcome_v2.index"
 :ruby

--- a/app/views/welcome_v2/index.html.haml
+++ b/app/views/welcome_v2/index.html.haml
@@ -112,7 +112,7 @@
     .wv2-stats
       .wv2-stats__cell
         %p.wv2-stat__number
-          = number_to_human(350_000_000, precision: 3, significant: false, strip_insignificant_zeros: true, units: :"number.human.compact_units", format: "%n%u")
+          = number_to_human(300_000_000, precision: 3, significant: false, strip_insignificant_zeros: true, units: :"number.human.compact_units", format: "%n%u")
           %span.wv2-stat__plus +
         %p.wv2-stat__label= t("#{s}.stats.observations_label")
       .wv2-stats__cell

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -4,28 +4,15 @@ require "spec_helper"
 
 describe WelcomeController do
   describe "index" do
-    it "renders the v2 template for logged-in admins on the default site" do
-      sign_in make_admin
-      get :index
-      expect( response ).to render_template( "welcome_v2/index" )
-    end
-
-    it "redirects logged-in non-admins on the default site to home" do
+    it "redirects logged-in users on the default site to home" do
       sign_in User.make!
       get :index
       expect( response ).to redirect_to( home_path )
     end
 
-    it "redirects logged-in admins on a non-default site to home" do
-      other_site = Site.make!
-      sign_in make_admin
-      get :index, params: { inat_site_id: other_site.id }
-      expect( response ).to redirect_to( home_path )
-    end
-
-    it "renders the v1 template for anonymous users" do
+    it "renders the v2 template for anonymous users" do
       get :index
-      expect( response ).to render_template( "welcome/index" )
+      expect( response ).to render_template( "welcome_v2/index" )
     end
   end
 


### PR DESCRIPTION
Final homepage changes for full production deployment.

- Fixes observation stat
- Removes admin gating and displays homepage v2 in logged out state for default site only
- Switches to correct meta attribute for "description"