### PR TITLE
web 969 suspension api changes

### DIFF
--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -13,7 +13,7 @@ class OauthTokensController < Doorkeeper::TokensController
     user = User.find_by_id( resource_owner_id ) unless resource_owner_id.blank?
     user&.unsuspend_if_timed_suspension_expired!
     # A suspended user might have a valid access token
-    raise INat::Auth::SuspendedError if user&.suspended?
+    raise INat::Auth::SuspendedError, user.inactive_message if user&.suspended?
   rescue INat::Auth::BadUsernamePasswordError
     headers.delete "WWW-Authenticate"
     self.status = 400
@@ -21,12 +21,12 @@ class OauthTokensController < Doorkeeper::TokensController
       error: "invalid_grant",
       error_description: I18n.t( "devise.failure.invalid" )
     }.to_json
-  rescue INat::Auth::SuspendedError
+  rescue INat::Auth::SuspendedError => e
     headers.delete "WWW-Authenticate"
-    self.status = 400
+    self.status = 403
     self.response_body = {
-      error: "invalid_grant",
-      error_description: I18n.t( :this_user_has_been_suspended )
+      error: "suspended",
+      error_description: e.message.presence || I18n.t( :this_user_has_been_suspended )
     }.to_json
   rescue INat::Auth::ChildWithoutPermissionError
     headers.delete "WWW-Authenticate"

--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -23,10 +23,10 @@ class OauthTokensController < Doorkeeper::TokensController
     }.to_json
   rescue INat::Auth::SuspendedError => e
     headers.delete "WWW-Authenticate"
-    self.status = 403
+    self.status = 401
     self.response_body = {
-      error: "suspended",
-      error_description: e.message.presence || I18n.t( :this_user_has_been_suspended )
+      error: "invalid_grant",
+      error_description: "#{I18n.t( :this_user_has_been_suspended )} #{e.message.presence}"
     }.to_json
   rescue INat::Auth::ChildWithoutPermissionError
     headers.delete "WWW-Authenticate"

--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -25,8 +25,8 @@ class OauthTokensController < Doorkeeper::TokensController
     }.to_json
   rescue INat::Auth::SuspendedError => e
     headers.delete "WWW-Authenticate"
-    self.status = 401
-    self.response_body = e.json.to_json
+    self.status = 400
+    self.response_body = e.to_h.to_json
   rescue INat::Auth::ChildWithoutPermissionError
     headers.delete "WWW-Authenticate"
     self.status = 400

--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -13,7 +13,9 @@ class OauthTokensController < Doorkeeper::TokensController
     user = User.find_by_id( resource_owner_id ) unless resource_owner_id.blank?
     user&.unsuspend_if_timed_suspension_expired!
     # A suspended user might have a valid access token
-    raise INat::Auth::SuspendedError, user.inactive_message if user&.suspended?
+    if user&.suspended?
+      raise INat::Auth::SuspendedError.new( user.inactive_message, suspended_until: user.suspended_until )
+    end
   rescue INat::Auth::BadUsernamePasswordError
     headers.delete "WWW-Authenticate"
     self.status = 400
@@ -25,8 +27,9 @@ class OauthTokensController < Doorkeeper::TokensController
     headers.delete "WWW-Authenticate"
     self.status = 401
     self.response_body = {
-      error: "invalid_grant",
-      error_description: "#{I18n.t( :this_user_has_been_suspended )} #{e.message.presence}"
+      error: "suspended",
+      error_description: e.message.presence || I18n.t( :this_user_has_been_suspended ),
+      suspended_until: e.suspended_until&.iso8601
     }.to_json
   rescue INat::Auth::ChildWithoutPermissionError
     headers.delete "WWW-Authenticate"

--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -26,11 +26,7 @@ class OauthTokensController < Doorkeeper::TokensController
   rescue INat::Auth::SuspendedError => e
     headers.delete "WWW-Authenticate"
     self.status = 401
-    self.response_body = {
-      error: "suspended",
-      error_description: e.message.presence || I18n.t( :this_user_has_been_suspended ),
-      suspended_until: e.suspended_until&.iso8601
-    }.to_json
+    self.response_body = e.json.to_json
   rescue INat::Auth::ChildWithoutPermissionError
     headers.delete "WWW-Authenticate"
     self.status = 400

--- a/app/controllers/oauth_tokens_controller.rb
+++ b/app/controllers/oauth_tokens_controller.rb
@@ -25,6 +25,8 @@ class OauthTokensController < Doorkeeper::TokensController
     }.to_json
   rescue INat::Auth::SuspendedError => e
     headers.delete "WWW-Authenticate"
+    # Note that this status code is different from the 401 returned by devise/doorkeeper
+    # for suspended users making requests.
     self.status = 400
     self.response_body = e.to_h.to_json
   rescue INat::Auth::ChildWithoutPermissionError

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -52,7 +52,7 @@ class ProviderOauthController < ApplicationController
       }
       return
     rescue INat::Auth::SuspendedError => e
-      return render status: :unauthorized, json: e.json
+      return render status: :bad_request, json: e.to_h
     rescue INat::Auth::ChildWithoutPermissionError
       render status: :bad_request, json: {
         error: "invalid_grant",

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -51,10 +51,10 @@ class ProviderOauthController < ApplicationController
         error_description: t( :provider_without_email_error_generic ).to_s.gsub( /\s+/, " " )
       }
       return
-    rescue INat::Auth::SuspendedError
-      return render status: :bad_request, json: {
-        error: "invalid_grant",
-        error_description: t( :this_user_has_been_suspended )
+    rescue INat::Auth::SuspendedError => e
+      return render status: :forbidden, json: {
+        error: "suspended",
+        error_description: e.message.presence || t( :this_user_has_been_suspended )
       }
     rescue INat::Auth::ChildWithoutPermissionError
       render status: :bad_request, json: {
@@ -268,7 +268,7 @@ class ProviderOauthController < ApplicationController
   def assertion_access_token_for_client_and_user( client, user )
     user.unsuspend_if_timed_suspension_expired!
     unless user.active_for_authentication?
-      raise INat::Auth::SuspendedError if user.suspended?
+      raise INat::Auth::SuspendedError, user.inactive_message if user.suspended?
       raise INat::Auth::ChildWithoutPermissionError if user.child_without_permission?
     end
     access_token = Doorkeeper::AccessToken.

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -54,7 +54,8 @@ class ProviderOauthController < ApplicationController
     rescue INat::Auth::SuspendedError => e
       return render status: :unauthorized, json: {
         error: "suspended",
-        error_description: e.message.presence || t( :this_user_has_been_suspended )
+        error_description: e.message.presence || t( :this_user_has_been_suspended ),
+        suspended_until: e.suspended_until&.iso8601
       }
     rescue INat::Auth::ChildWithoutPermissionError
       render status: :bad_request, json: {
@@ -268,7 +269,9 @@ class ProviderOauthController < ApplicationController
   def assertion_access_token_for_client_and_user( client, user )
     user.unsuspend_if_timed_suspension_expired!
     unless user.active_for_authentication?
-      raise INat::Auth::SuspendedError, user.inactive_message if user.suspended?
+      if user.suspended?
+        raise INat::Auth::SuspendedError.new( user.inactive_message, suspended_until: user.suspended_until )
+      end
       raise INat::Auth::ChildWithoutPermissionError if user.child_without_permission?
     end
     access_token = Doorkeeper::AccessToken.

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -52,7 +52,7 @@ class ProviderOauthController < ApplicationController
       }
       return
     rescue INat::Auth::SuspendedError => e
-      return render status: :forbidden, json: {
+      return render status: :unauthorized, json: {
         error: "suspended",
         error_description: e.message.presence || t( :this_user_has_been_suspended )
       }

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -52,6 +52,8 @@ class ProviderOauthController < ApplicationController
       }
       return
     rescue INat::Auth::SuspendedError => e
+      # Note that this status code is different from the 401 returned by devise/doorkeeper
+      # for suspended users making requests.
       return render status: :bad_request, json: e.to_h
     rescue INat::Auth::ChildWithoutPermissionError
       render status: :bad_request, json: {

--- a/app/controllers/provider_oauth_controller.rb
+++ b/app/controllers/provider_oauth_controller.rb
@@ -52,11 +52,7 @@ class ProviderOauthController < ApplicationController
       }
       return
     rescue INat::Auth::SuspendedError => e
-      return render status: :unauthorized, json: {
-        error: "suspended",
-        error_description: e.message.presence || t( :this_user_has_been_suspended ),
-        suspended_until: e.suspended_until&.iso8601
-      }
+      return render status: :unauthorized, json: e.json
     rescue INat::Auth::ChildWithoutPermissionError
       render status: :bad_request, json: {
         error: "invalid_grant",

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -15,7 +15,9 @@ Doorkeeper.configure do
       raise INat::Auth::BadUsernamePasswordError unless user.valid_password?( params[:password] )
 
       user.unsuspend_if_timed_suspension_expired!
-      raise INat::Auth::SuspendedError, user.inactive_message if user.suspended?
+      if user.suspended?
+        raise INat::Auth::SuspendedError.new( user.inactive_message, suspended_until: user.suspended_until )
+      end
       raise INat::Auth::ChildWithoutPermissionError if user.child_without_permission?
 
       user

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -13,8 +13,9 @@ Doorkeeper.configure do
     if username && params[:password]
       raise INat::Auth::BadUsernamePasswordError unless ( user = User.find_for_authentication( email: username ) )
       raise INat::Auth::BadUsernamePasswordError unless user.valid_password?( params[:password] )
+
       user.unsuspend_if_timed_suspension_expired!
-      raise INat::Auth::SuspendedError if user.suspended?
+      raise INat::Auth::SuspendedError, user.inactive_message if user.suspended?
       raise INat::Auth::ChildWithoutPermissionError if user.child_without_permission?
 
       user

--- a/config/initializers/inat_auth.rb
+++ b/config/initializers/inat_auth.rb
@@ -16,9 +16,9 @@ module INat
         @suspended_until = suspended_until
       end
 
-      def json
+      def to_h
         {
-          error: "suspended",
+          error: "invalid_grant",
           error_description: message.presence || I18n.t( :this_user_has_been_suspended ),
           suspended_until: @suspended_until&.iso8601
         }

--- a/config/initializers/inat_auth.rb
+++ b/config/initializers/inat_auth.rb
@@ -11,11 +11,17 @@ module INat
 
     # User is suspended
     class SuspendedError < StandardError
-      attr_reader :suspended_until
-
       def initialize( message = nil, suspended_until: nil )
         super( message )
         @suspended_until = suspended_until
+      end
+
+      def json
+        {
+          error: "suspended",
+          error_description: message.presence || I18n.t( :this_user_has_been_suspended ),
+          suspended_until: @suspended_until&.iso8601
+        }
       end
     end
 

--- a/config/initializers/inat_auth.rb
+++ b/config/initializers/inat_auth.rb
@@ -10,7 +10,14 @@ module INat
     class MissingEmailError < StandardError; end
 
     # User is suspended
-    class SuspendedError < StandardError; end
+    class SuspendedError < StandardError
+      attr_reader :suspended_until
+
+      def initialize( message = nil, suspended_until: nil )
+        super( message )
+        @suspended_until = suspended_until
+      end
+    end
 
     # User is a known child without parental permission
     class ChildWithoutPermissionError < StandardError; end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -329,6 +329,8 @@ describe ApplicationController do
         end
         after { ActionController::Base.allow_forgery_protection = false }
 
+        # Token requests return 400 for suspended users,
+        # other API requests for suspended users return 401
         it "returns 401 for a suspended OAuth user whose token was revoked" do
           token = Doorkeeper::AccessToken.create!(
             application: app,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -251,9 +251,7 @@ describe ApplicationController do
         end
       end
     end
-  end
 
-  describe WelcomeController do
     describe "sign_out_suspended_users" do
       it "signs out a suspended user" do
         user = User.make!( suspended_at: Time.now )
@@ -278,8 +276,8 @@ describe ApplicationController do
     end
   end
 
-  describe ObservationsController do
-    describe "sign_out_suspended_users" do
+  describe "sign_out_suspended_users" do
+    describe ObservationsController do
       elastic_models( Observation )
 
       describe "for JSON requests" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -253,6 +253,115 @@ describe ApplicationController do
     end
   end
 
+  describe WelcomeController do
+    describe "sign_out_suspended_users" do
+      it "signs out a suspended user" do
+        user = User.make!( suspended_at: Time.now )
+        sign_in( user )
+        get :index
+        expect( controller.send( :current_user ) ).to be_nil
+      end
+
+      it "does not sign out a non-suspended user" do
+        user = User.make!
+        sign_in( user )
+        get :index
+        expect( controller.send( :current_user ) ).to eq user
+      end
+
+      it "does not sign out a user whose timed suspension has expired" do
+        user = User.make!( suspended_at: 2.days.ago, suspended_until: 1.day.ago )
+        sign_in( user )
+        get :index
+        expect( controller.send( :current_user ) ).to eq user
+      end
+    end
+  end
+
+  describe ObservationsController do
+    describe "sign_out_suspended_users" do
+      elastic_models( Observation )
+
+      describe "for JSON requests" do
+        it "returns 401 with suspension details for a suspended user" do
+          user = User.make!( suspended_at: Time.now, suspension_reason: "spam", suspended_until: 1.week.from_now )
+          sign_in( user )
+          get :index, format: :json
+          expect( response.status ).to eq 401
+          json = JSON.parse( response.body )
+          expect( json["error"] ).not_to be_blank
+        end
+
+        it "includes suspension reason in error for timed suspension" do
+          user = User.make!( suspended_at: Time.now, suspension_reason: "spam", suspended_until: 1.week.from_now )
+          sign_in( user )
+          get :index, format: :json
+          json = JSON.parse( response.body )
+          expect( json["error"] ).to match( /spam/ )
+        end
+
+        it "does not include reason for indefinite suspension" do
+          user = User.make!( suspended_at: Time.now, suspension_reason: "spam" )
+          sign_in( user )
+          get :index, format: :json
+          json = JSON.parse( response.body )
+          expect( json["error"] ).not_to match( /spam/ )
+        end
+
+        it "does not return an error for a non-suspended user" do
+          user = User.make!
+          sign_in( user )
+          get :index, format: :json
+          expect( response ).to be_successful
+        end
+
+        it "does not return an error for a user whose timed suspension has expired" do
+          user = User.make!( suspended_at: 2.days.ago, suspended_until: 1.day.ago )
+          sign_in( user )
+          get :index, format: :json
+          expect( response ).to be_successful
+        end
+      end
+
+      describe "for OAuth requests" do
+        let( :user ) { User.make! }
+        let( :app ) { OauthApplication.make! }
+        before do
+          ActionController::Base.allow_forgery_protection = true
+        end
+        after { ActionController::Base.allow_forgery_protection = false }
+
+        it "returns 403 with suspension details for a suspended OAuth user" do
+          user.update!( suspended_at: Time.now, suspension_reason: "spam", suspended_until: 1.week.from_now )
+          # Create the token after suspension to simulate a token that was not
+          # revoked by the after_save callback
+          token = Doorkeeper::AccessToken.create!(
+            application: app,
+            resource_owner_id: user.id,
+            scopes: Doorkeeper.configuration.default_scopes
+          )
+          request.env["HTTP_AUTHORIZATION"] = "Bearer #{token.token}"
+          get :index, format: :json
+          expect( response.status ).to eq 403
+          json = JSON.parse( response.body )
+          expect( json["error"] ).to eq "suspended"
+          expect( json["error_description"] ).to match( /spam/ )
+        end
+
+        it "does not return 403 for a non-suspended OAuth user" do
+          token = Doorkeeper::AccessToken.create!(
+            application: app,
+            resource_owner_id: user.id,
+            scopes: Doorkeeper.configuration.default_scopes
+          )
+          request.env["HTTP_AUTHORIZATION"] = "Bearer #{token.token}"
+          get :index, format: :json
+          expect( response ).to be_successful
+        end
+      end
+    end
+  end
+
   describe "allow_external_iframes" do
     describe ObservationsController do
       describe "Content-Security-Policy header" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -331,21 +331,18 @@ describe ApplicationController do
         end
         after { ActionController::Base.allow_forgery_protection = false }
 
-        it "returns 401 with suspension details for a suspended OAuth user" do
-          user.update!( suspended_at: Time.now, suspension_reason: "spam", suspended_until: 1.week.from_now )
-          # Create the token after suspension to simulate a token that was not
-          # revoked by the after_save callback
+        it "returns 401 for a suspended OAuth user whose token was revoked" do
           token = Doorkeeper::AccessToken.create!(
             application: app,
             resource_owner_id: user.id,
             scopes: Doorkeeper.configuration.default_scopes
           )
+          user.suspend!( reason: "spam" )
+          token.reload
+          expect( token ).to be_revoked
           request.env["HTTP_AUTHORIZATION"] = "Bearer #{token.token}"
-          get :index, format: :json
+          post :create, format: :json
           expect( response.status ).to eq 401
-          json = JSON.parse( response.body )
-          expect( json["error"] ).to eq "suspended"
-          expect( json["error_description"] ).to match( /spam/ )
         end
 
         it "does not return 401 for a non-suspended OAuth user" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -331,7 +331,7 @@ describe ApplicationController do
         end
         after { ActionController::Base.allow_forgery_protection = false }
 
-        it "returns 403 with suspension details for a suspended OAuth user" do
+        it "returns 401 with suspension details for a suspended OAuth user" do
           user.update!( suspended_at: Time.now, suspension_reason: "spam", suspended_until: 1.week.from_now )
           # Create the token after suspension to simulate a token that was not
           # revoked by the after_save callback
@@ -342,13 +342,13 @@ describe ApplicationController do
           )
           request.env["HTTP_AUTHORIZATION"] = "Bearer #{token.token}"
           get :index, format: :json
-          expect( response.status ).to eq 403
+          expect( response.status ).to eq 401
           json = JSON.parse( response.body )
           expect( json["error"] ).to eq "suspended"
           expect( json["error_description"] ).to match( /spam/ )
         end
 
-        it "does not return 403 for a non-suspended OAuth user" do
+        it "does not return 401 for a non-suspended OAuth user" do
           token = Doorkeeper::AccessToken.create!(
             application: app,
             resource_owner_id: user.id,

--- a/spec/controllers/oauth_tokens_controller_spec.rb
+++ b/spec/controllers/oauth_tokens_controller_spec.rb
@@ -7,11 +7,23 @@ shared_examples_for "a token creator that blocks suspended users" do
     json = JSON.parse( response.body )
     expect( json["access_token"] ).not_to be_blank
   end
-  it "should return a 400 for a suspended user" do
+  it "should return a 403 for a suspended user" do
     user.suspend!
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy
-    expect( response.code ).to eq "400"
+    expect( response.code ).to eq "403"
+    json = JSON.parse( response.body )
+    expect( json["error"] ).to eq "suspended"
+    expect( json["error_description"] ).not_to be_blank
+  end
+  it "should include suspension details for a timed suspension" do
+    user.update!( suspended_at: Time.now, suspension_reason: "policy violation", suspended_until: 1.week.from_now )
+    expect( user ).to be_suspended
+    post :create, format: :json, params: default_params_for_strategy
+    expect( response.code ).to eq "403"
+    json = JSON.parse( response.body )
+    expect( json["error"] ).to eq "suspended"
+    expect( json["error_description"] ).to match( /policy violation/ )
   end
   it "should return a token and unsuspend a user with an expired timed suspension" do
     admin = make_admin

--- a/spec/controllers/oauth_tokens_controller_spec.rb
+++ b/spec/controllers/oauth_tokens_controller_spec.rb
@@ -7,11 +7,11 @@ shared_examples_for "a token creator that blocks suspended users" do
     json = JSON.parse( response.body )
     expect( json["access_token"] ).not_to be_blank
   end
-  it "should return a 403 for a suspended user" do
+  it "should return a 401 for a suspended user" do
     user.suspend!
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy
-    expect( response.code ).to eq "403"
+    expect( response.code ).to eq "401"
     json = JSON.parse( response.body )
     expect( json["error"] ).to eq "suspended"
     expect( json["error_description"] ).not_to be_blank
@@ -20,7 +20,7 @@ shared_examples_for "a token creator that blocks suspended users" do
     user.update!( suspended_at: Time.now, suspension_reason: "policy violation", suspended_until: 1.week.from_now )
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy
-    expect( response.code ).to eq "403"
+    expect( response.code ).to eq "401"
     json = JSON.parse( response.body )
     expect( json["error"] ).to eq "suspended"
     expect( json["error_description"] ).to match( /policy violation/ )

--- a/spec/controllers/oauth_tokens_controller_spec.rb
+++ b/spec/controllers/oauth_tokens_controller_spec.rb
@@ -11,18 +11,18 @@ shared_examples_for "a token creator that blocks suspended users" do
     user.suspend!
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy
-    expect( response.code ).to eq "401"
+    expect( response.code ).to eq "40o"
     json = JSON.parse( response.body )
-    expect( json["error"] ).to eq "suspended"
+    expect( json["error"] ).to eq "invalid_grant"
     expect( json["error_description"] ).not_to be_blank
   end
   it "should include suspension details for a timed suspension" do
     user.update!( suspended_at: Time.now, suspension_reason: "policy violation", suspended_until: 1.week.from_now )
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy
-    expect( response.code ).to eq "401"
+    expect( response.code ).to eq "400"
     json = JSON.parse( response.body )
-    expect( json["error"] ).to eq "suspended"
+    expect( json["error"] ).to eq "invalid_grant"
     expect( json["error_description"] ).to match( /policy violation/ )
     expect( json["suspended_until"] ).not_to be_blank
     expect( Time.parse( json["suspended_until"] ) ).to be_within( 1.minute ).of( 1.week.from_now )

--- a/spec/controllers/oauth_tokens_controller_spec.rb
+++ b/spec/controllers/oauth_tokens_controller_spec.rb
@@ -7,7 +7,9 @@ shared_examples_for "a token creator that blocks suspended users" do
     json = JSON.parse( response.body )
     expect( json["access_token"] ).not_to be_blank
   end
-  it "should return a 401 for a suspended user" do
+  # Token requests return 400 for suspended users,
+  # other API requests for suspended users return 401
+  it "should return a 400 for a suspended user" do
     user.suspend!
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy

--- a/spec/controllers/oauth_tokens_controller_spec.rb
+++ b/spec/controllers/oauth_tokens_controller_spec.rb
@@ -11,7 +11,7 @@ shared_examples_for "a token creator that blocks suspended users" do
     user.suspend!
     expect( user ).to be_suspended
     post :create, format: :json, params: default_params_for_strategy
-    expect( response.code ).to eq "40o"
+    expect( response.code ).to eq "400"
     json = JSON.parse( response.body )
     expect( json["error"] ).to eq "invalid_grant"
     expect( json["error_description"] ).not_to be_blank

--- a/spec/controllers/oauth_tokens_controller_spec.rb
+++ b/spec/controllers/oauth_tokens_controller_spec.rb
@@ -24,6 +24,15 @@ shared_examples_for "a token creator that blocks suspended users" do
     json = JSON.parse( response.body )
     expect( json["error"] ).to eq "suspended"
     expect( json["error_description"] ).to match( /policy violation/ )
+    expect( json["suspended_until"] ).not_to be_blank
+    expect( Time.parse( json["suspended_until"] ) ).to be_within( 1.minute ).of( 1.week.from_now )
+  end
+  it "should return null suspended_until for an indefinite suspension" do
+    user.suspend!
+    post :create, format: :json, params: default_params_for_strategy
+    json = JSON.parse( response.body )
+    expect( json ).to have_key( "suspended_until" )
+    expect( json["suspended_until"] ).to be_nil
   end
   it "should return a token and unsuspend a user with an expired timed suspension" do
     admin = make_admin

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -75,7 +75,9 @@ describe ProviderOauthController do
         expect( JSON.parse( response.body )["access_token"] ).not_to be_blank
       end
 
-      it "should return a 401 with suspension details for a confirmed suspended user" do
+      # Token requests return 400 for suspended users,
+      # other API requests for suspended users return 401
+      it "should return a 400 with suspension details for a confirmed suspended user" do
         u = create :user, email: google_response[:email], confirmed_at: Time.now
         u.suspend!
         expect( u ).to be_confirmed

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -97,6 +97,17 @@ describe ProviderOauthController do
         response_json = JSON.parse( response.body )
         expect( response_json["error"] ).to eq "suspended"
         expect( response_json["error_description"] ).to match( /policy violation/ )
+        expect( response_json["suspended_until"] ).not_to be_blank
+        expect( Time.parse( response_json["suspended_until"] ) ).to be_within( 1.minute ).of( 1.week.from_now )
+      end
+
+      it "should return null suspended_until for an indefinite suspension" do
+        u = create :user, email: google_response[:email], confirmed_at: Time.now
+        u.suspend!
+        post :assertion, format: :json, params: assertion_params
+        response_json = JSON.parse( response.body )
+        expect( response_json ).to have_key( "suspended_until" )
+        expect( response_json["suspended_until"] ).to be_nil
       end
 
       it "should not return a token for a confirmed child without permission" do

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -75,17 +75,28 @@ describe ProviderOauthController do
         expect( JSON.parse( response.body )["access_token"] ).not_to be_blank
       end
 
-      it "should not return a token for a confirmed suspended user" do
+      it "should return a 403 with suspension details for a confirmed suspended user" do
         u = create :user, email: google_response[:email], confirmed_at: Time.now
         u.suspend!
         expect( u ).to be_confirmed
         expect( u ).to be_suspended
         post :assertion, format: :json, params: assertion_params
-        expect( response ).not_to be_successful
+        expect( response.status ).to eq 403
         response_json = JSON.parse( response.body )
         expect( response_json["access_token"] ).to be_blank
-        expect( response_json["error"] ).to eq "invalid_grant"
+        expect( response_json["error"] ).to eq "suspended"
         expect( response_json["error_description"] ).not_to be_blank
+      end
+
+      it "should include suspension reason for a timed suspension" do
+        u = create :user, email: google_response[:email], confirmed_at: Time.now
+        u.update!( suspended_at: Time.now, suspension_reason: "policy violation", suspended_until: 1.week.from_now )
+        expect( u ).to be_suspended
+        post :assertion, format: :json, params: assertion_params
+        expect( response.status ).to eq 403
+        response_json = JSON.parse( response.body )
+        expect( response_json["error"] ).to eq "suspended"
+        expect( response_json["error_description"] ).to match( /policy violation/ )
       end
 
       it "should not return a token for a confirmed child without permission" do

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -81,10 +81,10 @@ describe ProviderOauthController do
         expect( u ).to be_confirmed
         expect( u ).to be_suspended
         post :assertion, format: :json, params: assertion_params
-        expect( response.status ).to eq 401
+        expect( response.status ).to eq 400
         response_json = JSON.parse( response.body )
         expect( response_json["access_token"] ).to be_blank
-        expect( response_json["error"] ).to eq "suspended"
+        expect( response_json["error"] ).to eq "invalid_grant"
         expect( response_json["error_description"] ).not_to be_blank
       end
 
@@ -93,9 +93,9 @@ describe ProviderOauthController do
         u.update!( suspended_at: Time.now, suspension_reason: "policy violation", suspended_until: 1.week.from_now )
         expect( u ).to be_suspended
         post :assertion, format: :json, params: assertion_params
-        expect( response.status ).to eq 401
+        expect( response.status ).to eq 400
         response_json = JSON.parse( response.body )
-        expect( response_json["error"] ).to eq "suspended"
+        expect( response_json["error"] ).to eq "invalid_grant"
         expect( response_json["error_description"] ).to match( /policy violation/ )
         expect( response_json["suspended_until"] ).not_to be_blank
         expect( Time.parse( response_json["suspended_until"] ) ).to be_within( 1.minute ).of( 1.week.from_now )

--- a/spec/controllers/provider_oauth_controller_spec.rb
+++ b/spec/controllers/provider_oauth_controller_spec.rb
@@ -75,13 +75,13 @@ describe ProviderOauthController do
         expect( JSON.parse( response.body )["access_token"] ).not_to be_blank
       end
 
-      it "should return a 403 with suspension details for a confirmed suspended user" do
+      it "should return a 401 with suspension details for a confirmed suspended user" do
         u = create :user, email: google_response[:email], confirmed_at: Time.now
         u.suspend!
         expect( u ).to be_confirmed
         expect( u ).to be_suspended
         post :assertion, format: :json, params: assertion_params
-        expect( response.status ).to eq 403
+        expect( response.status ).to eq 401
         response_json = JSON.parse( response.body )
         expect( response_json["access_token"] ).to be_blank
         expect( response_json["error"] ).to eq "suspended"
@@ -93,7 +93,7 @@ describe ProviderOauthController do
         u.update!( suspended_at: Time.now, suspension_reason: "policy violation", suspended_until: 1.week.from_now )
         expect( u ).to be_suspended
         post :assertion, format: :json, params: assertion_params
-        expect( response.status ).to eq 403
+        expect( response.status ).to eq 401
         response_json = JSON.parse( response.body )
         expect( response_json["error"] ).to eq "suspended"
         expect( response_json["error_description"] ).to match( /policy violation/ )


### PR DESCRIPTION
Updates JSON API response for suspended users to include message and suspended_until time. Achieves this by updating the SuspendedError class to include a default #to_h method.
