### PR TITLE
feat: Add filter for native or endemic, Creative Day

### DIFF
--- a/app/assets/javascripts/ang/templates/observation_search/filter_menu.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/filter_menu.html.haml
@@ -36,7 +36,15 @@
             .checkbox{ "ng-class" => "{ 'filter-changed': params.introduced }" }
               %label
                 %input{ type: 'checkbox', "ng-model" => "params.introduced", "ng-false-value" => ""}
-                {{ shared.t('introduced') }}
+                {{ shared.t('establishment.introduced') }}
+            .checkbox{ "ng-class" => "{ 'filter-changed': params.native }" }
+              %label
+                %input{ type: 'checkbox', "ng-model" => "params.native", "ng-false-value" => ""}
+                {{ shared.t('establishment.native') }}
+            .checkbox{ "ng-class" => "{ 'filter-changed': params.endemic }" }
+              %label
+                %input{ type: 'checkbox', "ng-model" => "params.endemic", "ng-false-value" => ""}
+                {{ shared.t('establishment.endemic') }}
             .checkbox{ "ng-class" => "{ 'filter-changed': params.popular }" }
               %label{ "uib-tooltip" => "{{ shared.t( 'has_one_or_more_faves' ) }}", "tooltip-placement" => "right" }
                 %input{ type: 'checkbox', "ng-model" => "params.popular", "ng-false-value" => ""}

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -2161,6 +2161,7 @@ class ObservationsController < ApplicationController
     @threatened = search_params[:threatened]
     @introduced = search_params[:introduced]
     @native = search_params[:native]
+    @endemic = search_params[:endemic]
     @popular = search_params[:popular]
     @spam = search_params[:spam]
     if stats_adequately_scoped?(search_params)

--- a/app/views/observations/_filter_fields.html.erb
+++ b/app/views/observations/_filter_fields.html.erb
@@ -450,6 +450,9 @@
 <% if show_all || @native -%>
   <%= render(partial: "yes_no_any_field", locals: { field: "native", value: @native }) %>
 <% end -%>
+<% if show_all || @endemic -%>
+  <%= render(partial: "yes_no_any_field", locals: { field: "endemic", value: @endemic }) %>
+<% end -%>
 <% if show_all || @popular -%>
   <%= render(partial: "yes_no_any_field", locals: { field: "popular", value: @popular }) %>
 <% end -%>

--- a/app/views/observations/_yes_no_any_field.html.haml
+++ b/app/views/observations/_yes_no_any_field.html.haml
@@ -7,6 +7,8 @@
         - case field
         - when "native"
           = t( "establishment.native" )
+        - when "endemic"
+          = t( "establishment.endemic" )
         - when "introduced"
           = t( "establishment.introduced" )
         - when "threatened"

--- a/app/webpack/observations/identify/components/filters_button.jsx
+++ b/app/webpack/observations/identify/components/filters_button.jsx
@@ -234,7 +234,9 @@ class FiltersButton extends React.Component {
             { [
               { param: "captive", key: "show-filter-captive" },
               { param: "threatened", key: "show-filter-threatened" },
-              { param: "introduced", key: "show-filter-introduced" },
+              { param: "introduced", key: "show-filter-introduced", label: I18n.t( "establishment.introduced" ) },
+              { param: "native", key: "show-filter-native", label: I18n.t( "establishment.native" ) },
+              { param: "endemic", key: "show-filter-endemic", label: I18n.t( "establishment.endemic" ) },
               { param: "popular", key: "show-filter-popular", title: I18n.t( "has_one_or_more_faves" ) }
             ].map( props => (
               <FilterCheckbox


### PR DESCRIPTION
Adds a filter for native and endemic by adding the params to the observations query. Follows existing patterns to add to the Explore (native and endemic) and Export (endemic only, native was already there) pages.