### PR TITLE
fix: Prevent whitespace on chromium mobile landscape, WEB-1005

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -586,7 +586,6 @@ ul.leafylist li li:first-child {
   font-size: 100%;
   color: #999;
   width: 100%;
-  min-width: 980px;
 
   p {
     font-size: 14px;


### PR DESCRIPTION
Having `min-width` on the footer causes extra whitespace to the right of the page. This causes a a horizontal scroll to 980px on desktop when the viewport is smaller and whitespace to appear to the right of the page on mobile chromium.

**Before (desktop):**
<img width="818" height="401" alt="Screenshot 2026-04-21 at 11 38 01 AM" src="https://github.com/user-attachments/assets/87a97dc6-76cb-452b-a7ce-428e050f37e6" />
**After (desktop):**
<img width="818" height="382" alt="Screenshot 2026-04-21 at 11 38 14 AM" src="https://github.com/user-attachments/assets/37300f96-f110-481e-95d3-25eea2c0ef7c" />

**Before (mobile):**
<img width="1278" height="590" alt="Screenshot 2026-04-21 at 11 45 36 AM" src="https://github.com/user-attachments/assets/29d91569-2763-44ff-871c-f8ba8b450bbb" />
**After (mobile)**
<img width="1278" height="590" alt="Screenshot 2026-04-21 at 11 44 59 AM" src="https://github.com/user-attachments/assets/238e0f33-27f9-4137-a0f7-58de0124dedd" />
