### PR TITLE
feat: Add search link when search bar is not displayed, WEB-1004

### DIFF
--- a/app/assets/stylesheets/welcome_v2.scss
+++ b/app/assets/stylesheets/welcome_v2.scss
@@ -77,6 +77,7 @@ $letter-spacing-tight: -0.03em;
 
   .navtabs {
     margin: 0;
+    align-self: stretch;
 
     .signin_link {
       padding-inline: 2px !important;

--- a/app/assets/stylesheets/welcome_v2.scss
+++ b/app/assets/stylesheets/welcome_v2.scss
@@ -41,18 +41,11 @@ $letter-spacing-tight: -0.03em;
 // ── Header overwrites, incorporate into main header styles once ready ────────
 
 #header {
-  display: flex;
-  align-items: center;
-  gap: 15px;
-  flex: 1 0 0;
   background-color: $white;
-  padding: 0 16px;
   position: sticky;
   top: 0;
   z-index: 1000;
   margin-bottom: 0;
-
-  #logonav { min-width: max-content; }
 
   .donate-cta .btn-focus {
     background-color: $white;
@@ -76,19 +69,12 @@ $letter-spacing-tight: -0.03em;
   }
 
   .navtabs {
-    margin: 0;
-    align-self: stretch;
-
     .signin_link {
       padding-inline: 2px !important;
     }
     .signup_link {
       padding-inline: 2px !important;
     }
-  }
-
-  .signin-link {
-    padding-inline: 2px;
   }
 }
 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -111,7 +111,8 @@
           = t(:more)
           %i.fa.fa-angle-down
         %ul.dropdown-menu{ aria: { labelledby: "header-more-dropdown-toggle" } }
-          %li.header-md.header-lg= link_to t( :search ), search_path
+          - unless header_search_open
+            %li.header-md.header-lg= link_to t( :search ), search_path
           - if logged_in?
             %li.header-xs.header-sm= link_to t( :identify ), identify_observations_path
           %li= link_to t( :taxa_info ), taxa_path

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -65,9 +65,6 @@
         ( controller.action_name == "show" && @observation && @observation.user_id == current_user.id ) ||
         ( params[:user_id] == current_user.id.to_s || params[:user_id] === current_user.login )
       )
-    - unless logged_in?
-      %li.navtab{ class: controller.class.name == "SearchController" ? "active" : nil }
-        = link_to t( :search ), search_path
     %li.navtab{ class: controller.class.name == "ObservationsController" && %w( index show by_login ).include?( controller.action_name ) && !looking_at_own_observations || controller.class.name == "TaxaController" ? "active" : nil }
       = link_to t(:explore), observations_path
     - if logged_in?

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -114,6 +114,7 @@
           = t(:more)
           %i.fa.fa-angle-down
         %ul.dropdown-menu{ aria: { labelledby: "header-more-dropdown-toggle" } }
+          %li.header-md.header-lg= link_to t( :search ), search_path
           - if logged_in?
             %li.header-xs.header-sm= link_to t( :identify ), identify_observations_path
           %li= link_to t( :taxa_info ), taxa_path

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -111,7 +111,7 @@
           = t(:more)
           %i.fa.fa-angle-down
         %ul.dropdown-menu{ aria: { labelledby: "header-more-dropdown-toggle" } }
-          - unless header_search_open
+          - if @skip_external_connections
             %li.header-md.header-lg= link_to t( :search ), search_path
           - if logged_in?
             %li.header-xs.header-sm= link_to t( :identify ), identify_observations_path

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -65,6 +65,9 @@
         ( controller.action_name == "show" && @observation && @observation.user_id == current_user.id ) ||
         ( params[:user_id] == current_user.id.to_s || params[:user_id] === current_user.login )
       )
+    - unless logged_in?
+      %li.navtab{ class: controller.class.name == "SearchController" ? "active" : nil }
+        = link_to t( :search ), search_path
     %li.navtab{ class: controller.class.name == "ObservationsController" && %w( index show by_login ).include?( controller.action_name ) && !looking_at_own_observations || controller.class.name == "TaxaController" ? "active" : nil }
       = link_to t(:explore), observations_path
     - if logged_in?


### PR DESCRIPTION
- Add `Search` to `More` menu when the search bar isn't displayed in the header (i.e. user is logged out).
- Remove a lot of unnecessary overrides that were either useless or caused header dropdown menus to render too high.

**Search link demo:**
https://github.com/user-attachments/assets/b7317984-4451-449a-8383-94669d86f9ff

**Menu height before:**
<img width="207" height="119" alt="Screenshot 2026-04-21 at 4 26 58 PM" src="https://github.com/user-attachments/assets/700ea855-24c3-4cd0-8184-17afb8eec60c" />
**Menu height after:**
<img width="178" height="84" alt="Screenshot 2026-04-21 at 4 27 09 PM" src="https://github.com/user-attachments/assets/afb25165-cb95-4e10-823a-c28c1cad5534" />
