### PR TITLE
Taxon change indexing fix

### DIFF
--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -739,7 +739,7 @@ class Identification < ApplicationRecord
       next unless taxon_change.automatable_for_output?( output_taxon.id )
 
       ident.observation&.skip_update_observations_places = true
-      ident.observation.skip_indexing = true
+      ident.observation&.skip_indexing = true
       new_ident = Identification.new(
         observation: ident.observation,
         taxon: output_taxon,

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -739,6 +739,7 @@ class Identification < ApplicationRecord
       next unless taxon_change.automatable_for_output?( output_taxon.id )
 
       ident.observation&.skip_update_observations_places = true
+      ident.observation.skip_indexing = true
       new_ident = Identification.new(
         observation: ident.observation,
         taxon: output_taxon,


### PR DESCRIPTION
We are already later in this method indexing all observations from identifications modified here. There is no need to also index each observation individually within each batch - its very inefficient and redundant