### PR TITLE
feat: update s3 upload to use transfer_manager; update kt-paperclip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,15 +26,15 @@ GIT
 
 GIT
   remote: https://github.com/inaturalist/kt-paperclip.git
-  revision: ec96bfe78298fe139374b7dc2bbc0a4f5fcbc4ef
+  revision: c5c5f51843cbb8e1919391f6d60580dd7b79af67
   ref: reset-original-content-type
   specs:
-    kt-paperclip (7.2.2)
+    kt-paperclip (7.4.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
-      marcel (~> 1.0.1)
+      marcel (>= 1.0.1)
       mime-types
-      terrapin (>= 0.6.0, < 2.0)
+      terrapin (>= 0.6.0)
 
 GIT
   remote: https://github.com/inaturalist/objectify_xml.git
@@ -333,6 +333,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.6.6)
       railties (>= 5)
+    drb (2.2.3)
     ed25519 (1.3.0)
     elastic-transport (8.3.5)
       faraday (< 3)
@@ -401,7 +402,7 @@ GEM
     httpi (2.5.0)
       rack
       socksify
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     i18n-inflector (2.6.7)
       i18n (>= 0.4.1)
@@ -431,19 +432,21 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
+    marcel (1.1.0)
     matrix (0.4.2)
     method_source (1.1.0)
-    mime-types (3.6.0)
+    mime-types (3.7.0)
       logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0304)
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0414)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
     multi_json (1.15.0)
     multi_xml (0.8.0)
       bigdecimal (>= 3.1, < 5)
@@ -525,6 +528,7 @@ GEM
       racc
     patron (0.13.3)
     pg (1.5.9)
+    prism (1.9.0)
     public_suffix (7.0.5)
     puma (5.6.9)
       nio4r (~> 2.0)
@@ -761,7 +765,7 @@ GEM
     ya2yaml (0.31)
     yajl-ruby (1.4.3)
     yui-compressor (0.12.0)
-    zeitwerk (2.7.3)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   ruby

--- a/lib/darwin_core/archive.rb
+++ b/lib/darwin_core/archive.rb
@@ -820,20 +820,21 @@ module DarwinCore
 
     def upload_to_aws_s3
       return unless @opts[:aws_s3_path]
+
       s3_config = YAML.load_file( File.join( Rails.root, "config", "s3.yml" ) )
       client = ::Aws::S3::Client.new(
         access_key_id: s3_config["access_key_id"],
         secret_access_key: s3_config["secret_access_key"],
         region: CONFIG.s3_region
       )
-      resource = Aws::S3::Resource.new( client: client )
-      bucket = resource.bucket( CONFIG.s3_bucket )
-      object = bucket.object( @opts[:aws_s3_path] )
-      object.upload_file( @opts[:path], {
+      transfer_manager = ::Aws::S3::TransferManager.new( client: client )
+      transfer_manager.upload_file(
+        @opts[:path],
+        key: @opts[:aws_s3_path],
+        bucket: CONFIG.s3_bucket,
         acl: "public-read",
         content_encoding: "zip"
-      } )
+      )
     end
-
   end
 end


### PR DESCRIPTION
Some changes to address the deprecation of `upload_file` on `Aws::S3::Object` and using `Aws::S3::TransferManager#upload_file` instead as recommended. The `kt-paperclip` update merges in changes in that package to address the same