### PR TITLE
maintain position of vernacular names in darwin export of taxonomy

### DIFF
--- a/lib/darwin_core/extensions/vernacular_names.rb
+++ b/lib/darwin_core/extensions/vernacular_names.rb
@@ -108,8 +108,8 @@ module DarwinCore
             base_scope.
               where( lexicon: lexicon ).
               includes( :taxon, :source, :creator, :updater, place_taxon_names: :place ).
-              order( "taxon_id" ).
-              find_each do | tn |
+              order( "taxon_id, position" ).
+              each do | tn |
               adapt( tn, core: options[:core] )
               csv << TERMS.map do | field, _uri, _default, method |
                 tn.send( method || field )


### PR DESCRIPTION
the ordering of the vernacular names on website is to be preserved back in the export using their "position", and since find_each ignores such order clause, switching it to each.

https://forum.inaturalist.org/t/taxonomy-download-with-synonyms/38699/11?u=einsum