### PR TITLE
make mappable decide on circle "diameter" check with square diagonal

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -3153,7 +3153,7 @@ class Observation < ApplicationRecord
 
   def calculate_mappable
     return false if latitude.blank? && longitude.blank?
-    return false if public_positional_accuracy && public_positional_accuracy.to_i > uncertainty_cell_diagonal_meters.to_i
+    return false if public_positional_accuracy && public_positional_accuracy.to_i * 2 > uncertainty_cell_diagonal_meters.to_i
     return false if inaccurate_location?
     return false unless passes_quality_metric?( QualityMetric::EVIDENCE )
     return false unless appropriate?


### PR DESCRIPTION
related bug on mobile app that is fixed recently by @jtklein  - https://github.com/inaturalist/iNaturalistReactNative/pull/3406

the positional accuracy is radius and comparing to diagonal of square is not the intended check here I guess, as such diagonal is a diameter of circle then