### PR TITLE
feat: change project edit date and time form fields, WEB-834

### DIFF
--- a/app/assets/stylesheets/projects/new2.scss
+++ b/app/assets/stylesheets/projects/new2.scss
@@ -188,10 +188,12 @@ body>div>.popover[role="tooltip"].popover-error {
     }
   }
   .row {
-    padding-bottom: 43px;
     &.text, &.separator-row {
       padding: 0;
     }
+  }
+  .row:not( :last-child ) {
+    padding-bottom: 43px;
   }
   label {
     font-weight: 600 !important;
@@ -358,23 +360,13 @@ body>div>.popover[role="tooltip"].popover-error {
       height: 20px;
     }
   }
-  .date-row {
+  .row.date-row {
     padding-bottom: 5px;
     & > div > div:not(.help-text) {
       display: inline-block;
       position: relative;
       vertical-align: middle;
       margin-left: 5px;
-    }
-    .input-group.date {
-      width: 190px;
-      .form-control:first-child {
-        border-top-right-radius: 2px;
-        border-bottom-right-radius: 2px;
-      }
-      .input-group-addon {
-        display: none
-      }
     }
     label[for="project-date-type-exact"] + div .input-group.date {
       width: 120px;
@@ -389,6 +381,43 @@ body>div>.popover[role="tooltip"].popover-error {
     margin-top: 15px;
     button + button {
       margin-left: 10px;
+    }
+  }
+  .date-pickers {
+    .datetime-wrapper {
+      display: inline-block;
+      position: relative;
+      vertical-align: middle;
+      margin-left: 5px;
+    }
+    .input-group.date {
+      width: 150px;
+      input {
+        width: 145px;
+      }
+      .input-group-addon {
+        display: none
+      }
+      .form-control:first-child {
+        border-top-right-radius: 2px;
+        border-bottom-right-radius: 2px;
+      }
+    }
+    .times {
+      display: inline-block;
+    }
+    .datetime-wrapper.datetimepicker-pull-left {
+      .bootstrap-datetimepicker-widget.dropdown-menu {
+        right: auto !important;
+        &:before {
+          left: 7px;
+          right: auto;
+        }
+        &:after {
+          left: 8px;
+          right: auto;
+        }
+      }
     }
   }
 }
@@ -522,4 +551,11 @@ body>div>.popover[role="tooltip"].popover-error {
   border: 1px solid $border-grey;
   padding: 15px;
   background: white;
+}
+
+.bootstrap .dropdown-menu.bootstrap-datetimepicker-widget {
+  padding: 4px;
+  td span {
+    line-height: 54px;
+  }
 }

--- a/app/webpack/observations/identify/components/jquery_ui_multiselect.jsx
+++ b/app/webpack/observations/identify/components/jquery_ui_multiselect.jsx
@@ -5,11 +5,12 @@ import _ from "lodash";
 
 class JQueryUIMultiselect extends React.Component {
   componentDidMount( ) {
-    const { onOpen, onChange } = this.props;
+    const { onOpen, onChange, noneSelectedText } = this.props;
     const domNode = ReactDOM.findDOMNode( this );
     const opts = {
       checkAllText: I18n.t( "all" ),
-      uncheckAllText: I18n.t( "none" )
+      uncheckAllText: I18n.t( "none" ),
+      noneSelectedText
     };
     if ( typeof ( onOpen ) === "function" ) {
       opts.open = onOpen;
@@ -52,6 +53,7 @@ JQueryUIMultiselect.propTypes = {
   onChange: PropTypes.func,
   onOpen: PropTypes.func,
   id: PropTypes.string,
+  noneSelectedText: PropTypes.string,
   data: PropTypes.array,
   defaultValue: PropTypes.array
 };

--- a/app/webpack/projects/form/components/regular_form.jsx
+++ b/app/webpack/projects/form/components/regular_form.jsx
@@ -13,6 +13,9 @@ import TaxonSelector from "./taxon_selector";
 import PlaceSelector from "./place_selector";
 import UserSelector from "./user_selector";
 
+const MonthNames = ( "january february march april may june july august "
+  + "september october november december" ).split( " " );
+
 class RegularForm extends React.Component {
   constructor( props ) {
     super( props );
@@ -136,27 +139,25 @@ class RegularForm extends React.Component {
     const { project, updateProject } = this.props;
     const key = `time-checkbox-${_.kebabCase( fieldName )}`;
     return (
-      <div>
-        <div className="checkbox">
-          <label>
-            <input
-              type="checkbox"
-              key={key}
-              id={key}
-              defaultChecked={project[fieldName]}
-              onChange={e => {
-                const updates = {
-                  [fieldName]: e.target.checked || null
-                };
-                if ( !e.target.checked ) {
-                  Object.assign( updates, resetUpdates );
-                }
-                updateProject( updates );
-              }}
-            />
-            { I18n.t( "views.projects.new.date_pickers.include_times" ) }
-          </label>
-        </div>
+      <div className="checkbox">
+        <label>
+          <input
+            type="checkbox"
+            key={key}
+            id={key}
+            defaultChecked={project[fieldName]}
+            onChange={e => {
+              const updates = {
+                [fieldName]: e.target.checked || null
+              };
+              if ( !e.target.checked ) {
+                Object.assign( updates, resetUpdates );
+              }
+              updateProject( updates );
+            }}
+          />
+          { I18n.t( "views.projects.new.date_pickers.include_times" ) }
+        </label>
       </div>
     );
   }
@@ -264,8 +265,6 @@ class RegularForm extends React.Component {
       project,
       setRulePreference
     } = this.props;
-    const monthNames = ( "january february march april may june july august "
-      + "september october november december" ).split( " " );
     return (
       <div
         style={{ position: "relative" }}
@@ -277,7 +276,7 @@ class RegularForm extends React.Component {
           defaultValue={project.rule_month ? project.rule_month.split( "," ) : []}
           noneSelectedText={I18n.t( "views.projects.new.date_pickers.select_months" )}
           data={
-            _.map( monthNames, ( month, i ) => (
+            _.map( MonthNames, ( month, i ) => (
               {
                 value: i + 1,
                 label: I18n.t( `date_format.month.${month}` )

--- a/app/webpack/projects/form/components/regular_form.jsx
+++ b/app/webpack/projects/form/components/regular_form.jsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom";
 import {
   Grid, Row, Col, Panel, Overlay, Popover
 } from "react-bootstrap";
+import moment from "moment-timezone";
 import DateTimeFieldWrapper from
   "../../../observations/uploader/components/date_time_field_wrapper";
 import JQueryUIMultiselect from "../../../observations/identify/components/jquery_ui_multiselect";
@@ -15,9 +16,13 @@ import UserSelector from "./user_selector";
 class RegularForm extends React.Component {
   constructor( props ) {
     super( props );
-    this.observedOnInput = React.createRef( );
-    this.dateRangeD1Input = React.createRef( );
-    this.dateRangeD2Input = React.createRef( );
+    this.exactDateInput = React.createRef( );
+    this.exactDateStartTimeInput = React.createRef( );
+    this.exactDateEndTimeInput = React.createRef( );
+    this.rangeStartDateInput = React.createRef( );
+    this.rangeStartTimeInput = React.createRef( );
+    this.rangeEndDateInput = React.createRef( );
+    this.rangeEndTimeInput = React.createRef( );
     this.state = {
       inverseFiltersOpen: null
     };
@@ -28,6 +33,279 @@ class RegularForm extends React.Component {
     return _.map( checkedInputs, a => a.value ).join( "," ) || null;
   }
 
+  errorOverlay( fieldName, target, errorKeyAlt = null ) {
+    const { project } = this.props;
+    const error = project.errors[fieldName];
+    const id = `popover-${_.kebabCase( fieldName )}`;
+    // some factors shift the elements the overlays are intended to be displayed
+    // on top of. Allow the key to be modified so the overlay re-renders
+    // over the element if its placement changes
+    const overlayKey = `overlay-${_.kebabCase( fieldName )}${errorKeyAlt ? "-alt" : ""}`;
+    return error && (
+      <Overlay
+        show
+        placement="top"
+        target={( ) => target}
+        key={overlayKey}
+      >
+        <Popover
+          id={id}
+          className="popover-error"
+        >
+          { error }
+        </Popover>
+      </Overlay>
+    );
+  }
+
+  dateField( fieldName, ref, options = { } ) {
+    const { project, updateProject } = this.props;
+    const error = project.errors[fieldName];
+    const divKey = `date-${_.kebabCase( fieldName )}`;
+    let className = "datetime-wrapper";
+    if ( options.pullLeft ) {
+      className += " datetimepicker-pull-left";
+    }
+    if ( error ) {
+      className += " has-error";
+    }
+    return (
+      <>
+        <div
+          className={className}
+          key={divKey}
+        >
+          <DateTimeFieldWrapper
+            className="datefield"
+            mode="date"
+            ref={ref}
+            inputFormat="YYYY-MM-DD"
+            defaultText={project[fieldName]}
+            onChange={date => updateProject( { [fieldName]: date } )}
+            allowFutureDates
+            inputProps={{
+              className: "form-control",
+              placeholder: "YYYY-MM-DD",
+              onClick: ( ) => ref.current.onClick( )
+            }}
+          />
+        </div>
+        { this.errorOverlay( fieldName, ref.current, options.errorKeyAlt ) }
+      </>
+    );
+  }
+
+  timeField( fieldName, fieldMoment, updatedAt, ref, options = { } ) {
+    const { project, updateProject } = this.props;
+    const error = project.errors[fieldName];
+    const divKey = `time-${_.kebabCase( fieldName )}-${updatedAt}`;
+    let className = "datetime-wrapper";
+    if ( options.pullLeft ) {
+      className += " datetimepicker-pull-left";
+    }
+    if ( error ) {
+      className += " has-error";
+    }
+    return (
+      <>
+        <div
+          className={className}
+          key={divKey}
+        >
+          <DateTimeFieldWrapper
+            className="datefield"
+            mode="time"
+            ref={ref}
+            inputFormat="HH:mm UTCZ"
+            defaultText={project[fieldName]}
+            dateTime={fieldMoment ? fieldMoment.format( "x" ) : moment().format( "x" )}
+            onChange={date => updateProject( { [fieldName]: date } )}
+            allowFutureDates
+            inputProps={{
+              className: "form-control",
+              onClick: ( ) => ref.current.onClick( )
+            }}
+          />
+        </div>
+        { this.errorOverlay( fieldName, ref.current, options.errorKeyAlt ) }
+      </>
+    );
+  }
+
+  includeTimesCheckbox( fieldName, resetUpdates = { } ) {
+    const { project, updateProject } = this.props;
+    const key = `time-checkbox-${_.kebabCase( fieldName )}`;
+    return (
+      <div>
+        <div className="checkbox">
+          <label>
+            <input
+              type="checkbox"
+              key={key}
+              id={key}
+              defaultChecked={project[fieldName]}
+              onChange={e => {
+                const updates = {
+                  [fieldName]: e.target.checked || null
+                };
+                if ( !e.target.checked ) {
+                  Object.assign( updates, resetUpdates );
+                }
+                updateProject( updates );
+              }}
+            />
+            { I18n.t( "views.projects.new.date_pickers.include_times" ) }
+          </label>
+        </div>
+      </div>
+    );
+  }
+
+  exactDatePickers( ) {
+    const { project } = this.props;
+    let timesDisabled = false;
+    if ( !project.exactDate || project.errors.exactDate ) {
+      timesDisabled = true;
+    }
+    return (
+      <>
+        <div className="date-pickers">
+          <label>
+            { I18n.t( "views.projects.new.date_pickers.date" ) }
+          </label>
+          { this.dateField( "exactDate", this.exactDateInput, { pullLeft: true } ) }
+          { project.includeExactTimes && (
+            <div className={`times${timesDisabled ? " disabled" : ""}`}>
+              <label>
+                { I18n.t( "views.projects.new.date_pickers.start_time" ) }
+              </label>
+              { this.timeField(
+                "exactDateD1",
+                project.exactDateD1Moment,
+                project.exactDateD1UpdatedAt,
+                this.exactDateStartTimeInput
+              ) }
+              <label>
+                { I18n.t( "views.projects.new.date_pickers.end_time" ) }
+              </label>
+              { this.timeField(
+                "exactDateD2",
+                project.exactDateD2Moment,
+                project.exactDateD2UpdatedAt,
+                this.exactDateEndTimeInput
+              ) }
+            </div>
+          ) }
+        </div>
+        { this.includeTimesCheckbox( "includeExactTimes", {
+          exactDateD1: null,
+          exactDateD2: null
+        } )}
+      </>
+    );
+  }
+
+  rangeDatePickers( ) {
+    const { project } = this.props;
+    let rangeStartTimeDisabled = false;
+    let rangeEndTimeDisabled = false;
+    if ( !project.rangeStartDate || project.errors.rangeStartDate ) {
+      rangeStartTimeDisabled = true;
+    }
+    if ( !project.rangeEndDate || project.errors.rangeEndDate ) {
+      rangeEndTimeDisabled = true;
+    }
+    return (
+      <>
+        <div className="date-pickers">
+          <label>
+            { I18n.t( "views.projects.new.date_pickers.start_date" ) }
+          </label>
+          { this.dateField( "rangeStartDate", this.rangeStartDateInput, { pullLeft: true } ) }
+          { project.includeRangeTimes && (
+            <div className={`times${rangeStartTimeDisabled ? " disabled" : ""}`}>
+              { this.timeField(
+                "rangeStartTime",
+                project.rangeStartTimeMoment,
+                project.rangeStartTimeUpdatedAt,
+                this.rangeStartTimeInput
+              ) }
+            </div>
+          ) }
+          <label>
+            { I18n.t( "views.projects.new.date_pickers.end_date" ) }
+          </label>
+          { this.dateField(
+            "rangeEndDate",
+            this.rangeEndDateInput,
+            { errorKeyAlt: project.includeRangeTimes }
+          ) }
+          { project.includeRangeTimes && (
+            <div className={`times${rangeEndTimeDisabled ? " disabled" : ""}`}>
+              { this.timeField(
+                "rangeEndTime",
+                project.rangeEndTimeMoment,
+                project.rangeEndTimeUpdatedAt,
+                this.rangeEndTimeInput
+              ) }
+            </div>
+          ) }
+        </div>
+        { this.includeTimesCheckbox( "includeRangeTimes", {
+          rangeStartTime: null,
+          rangeEndTime: null
+        } )}
+      </>
+    );
+  }
+
+  monthDatePickers( ) {
+    const {
+      project,
+      setRulePreference
+    } = this.props;
+    const monthNames = ( "january february march april may june july august "
+      + "september october november december" ).split( " " );
+    return (
+      <div
+        style={{ position: "relative" }}
+      >
+        <JQueryUIMultiselect
+          className="form-control input-sm"
+          id="filters-dates-month"
+          onChange={values => setRulePreference( "month", values ? values.join( "," ) : null )}
+          defaultValue={project.rule_month ? project.rule_month.split( "," ) : []}
+          noneSelectedText={I18n.t( "views.projects.new.date_pickers.select_months" )}
+          data={
+            _.map( monthNames, ( month, i ) => (
+              {
+                value: i + 1,
+                label: I18n.t( `date_format.month.${month}` )
+              }
+            ) )
+          }
+        />
+      </div>
+    );
+  }
+
+  datePickers( ) {
+    const { project } = this.props;
+    switch ( project.date_type ) {
+      case "exact": {
+        return this.exactDatePickers( );
+      }
+      case "range": {
+        return this.rangeDatePickers( );
+      }
+      case "months": {
+        return this.monthDatePickers( );
+      }
+      default:
+    }
+    return null;
+  }
+
   render( ) {
     const {
       project,
@@ -36,8 +314,6 @@ class RegularForm extends React.Component {
       allControlledTerms
     } = this.props;
     let { inverseFiltersOpen } = this.state;
-    const monthNames = ( "january february march april may june july august "
-      + "september october november december" ).split( " " );
     const inverseFilterCount = _.size( project.notTaxonRules )
       + _.size( project.notPlaceRules ) + _.size( project.notUserRules );
     if ( inverseFiltersOpen === null && inverseFilterCount > 0 ) {
@@ -377,19 +653,19 @@ class RegularForm extends React.Component {
               </label>
             </Col>
           </Row>
-          <Row className="date-row">
-            <Col xs={12} className={`members-only${usingDelegation ? " disabled" : ""}`}>
+          <Row>
+            <Col xs={12} className={usingDelegation ? " disabled" : null}>
               <label>{ I18n.t( "date_observed_" ) }</label>
               <div className="help-text">
                 { I18n.t( "views.projects.new.use_this_for_a_time_limited_event" ) }
               </div>
+              <input
+                type="radio"
+                id="project-date-type-any"
+                checked={project.date_type === "any"}
+                onChange={( ) => updateProject( { date_type: "any" } )}
+              />
               <label className="inline checkboxradio" htmlFor="project-date-type-any">
-                <input
-                  type="radio"
-                  id="project-date-type-any"
-                  checked={project.date_type === "any"}
-                  onChange={( ) => updateProject( { date_type: "any" } )}
-                />
                 { I18n.t( "any_date" ) }
               </label>
               <input
@@ -398,117 +674,18 @@ class RegularForm extends React.Component {
                 checked={project.date_type === "exact"}
                 onChange={( ) => updateProject( { date_type: "exact" } )}
               />
-              <label className="inline" htmlFor="project-date-type-exact">
-                { I18n.t( "exact" ) }
+              <label className="inline checkboxradio" htmlFor="project-date-type-exact">
+                { I18n.t( "exact_date" ) }
               </label>
-              <div className={`datetime-wrapper ${project.errors.observed_on && "has-error"}`}>
-                <DateTimeFieldWrapper
-                  className="datefield"
-                  mode="date"
-                  ref={this.observedOnInput}
-                  inputFormat="YYYY-MM-DD"
-                  defaultText={project.rule_observed_on}
-                  onChange={date => setRulePreference( "observed_on", date )}
-                  allowFutureDates
-                  inputProps={{
-                    className: "form-control",
-                    placeholder: "YYYY-MM-DD",
-                    onClick: ( ) => this.observedOnInput.current.onClick( )
-                  }}
-                />
-              </div>
-              { project.errors.observed_on && (
-                <Overlay
-                  show
-                  placement="top"
-                  target={( ) => this.observedOnInput.current}
-                >
-                  <Popover
-                    id="popover-observed-on"
-                    className="popover-error"
-                  >
-                    { project.errors.observed_on }
-                  </Popover>
-                </Overlay>
-              ) }
-            </Col>
-          </Row>
-          <Row className="date-row">
-            <Col xs={12} className={`date-range-col members-only${usingDelegation ? " disabled" : ""}`}>
               <input
                 type="radio"
                 id="project-date-type-range"
                 checked={project.date_type === "range"}
                 onChange={( ) => updateProject( { date_type: "range" } )}
               />
-              <label className="inline" htmlFor="project-date-type-range">
-                { I18n.t( "date_picker.range" ) }
+              <label className="inline checkboxradio" htmlFor="project-date-type-range">
+                { I18n.t( "date_range" ) }
               </label>
-              <div className={`datetime-wrapper ${project.errors.d1 && "has-error"}`}>
-                <DateTimeFieldWrapper
-                  mode="datetime"
-                  ref={this.dateRangeD1Input}
-                  inputFormat="YYYY-MM-DD HH:mm Z"
-                  defaultText={project.rule_d1}
-                  onChange={date => setRulePreference( "d1", date )}
-                  allowFutureDates
-                  inputProps={{
-                    className: "form-control",
-                    placeholder: I18n.t( "start_date_time" ),
-                    onClick: ( ) => this.dateRangeD1Input.current.onClick( )
-                  }}
-                />
-              </div>
-              { project.errors.d1 && (
-                <Overlay
-                  show
-                  placement="top"
-                  target={( ) => this.dateRangeD1Input.current}
-                >
-                  <Popover
-                    id="popover-d1"
-                    className="popover-error"
-                  >
-                    { project.errors.d1 }
-                  </Popover>
-                </Overlay>
-              ) }
-              <div className={`datetime-wrapper ${project.errors.d2 && "has-error"}`}>
-                <DateTimeFieldWrapper
-                  mode="datetime"
-                  ref={this.dateRangeD2Input}
-                  inputFormat="YYYY-MM-DD HH:mm Z"
-                  defaultText={project.rule_d2}
-                  onChange={date => setRulePreference( "d2", date )}
-                  allowFutureDates
-                  inputProps={{
-                    className: "form-control",
-                    placeholder: I18n.t( "end_date_time" ),
-                    onClick: ( ) => this.dateRangeD2Input.current.onClick( )
-                  }}
-                />
-              </div>
-              { project.errors.d2 && (
-                <Overlay
-                  show
-                  placement="top"
-                  target={( ) => this.dateRangeD2Input.current}
-                >
-                  <Popover
-                    id="popover-d2"
-                    className="popover-error"
-                  >
-                    { project.errors.d2 }
-                  </Popover>
-                </Overlay>
-              ) }
-              <div className="help-text">
-                { I18n.t( "views.projects.new.note_you_can_delete_the_time" ) }
-              </div>
-            </Col>
-          </Row>
-          <Row className="date-row">
-            <Col xs={12} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <input
                 type="radio"
                 id="project-date-type-months"
@@ -518,26 +695,7 @@ class RegularForm extends React.Component {
               <label className="inline" htmlFor="project-date-type-months">
                 { I18n.t( "months" ) }
               </label>
-              <div
-                style={{ position: "relative" }}
-              >
-                <JQueryUIMultiselect
-                  className="form-control input-sm"
-                  id="filters-dates-month"
-                  onChange={values => setRulePreference(
-                    "month", values ? values.join( "," ) : null
-                  )}
-                  defaultValue={project.rule_month ? project.rule_month.split( "," ) : []}
-                  data={
-                    _.map( monthNames, ( month, i ) => (
-                      {
-                        value: i + 1,
-                        label: I18n.t( `date_format.month.${month}` )
-                      }
-                    ) )
-                  }
-                />
-              </div>
+              { this.datePickers( ) }
             </Col>
           </Row>
         </Grid>

--- a/app/webpack/projects/form/form_reducer.js
+++ b/app/webpack/projects/form/form_reducer.js
@@ -31,6 +31,7 @@ export function removeProject( ) {
 export function setProject( p ) {
   p.initialSubprojectCount = _.isEmpty( p.project_observation_rules ) ? 0
     : _.filter( p.project_observation_rules, rule => rule.operand_type === "Project" ).length;
+  p.editing = true;
   const project = new Project( p );
   return setAttributes( { project, initialProject: _.cloneDeep( project ) } );
 }
@@ -402,13 +403,13 @@ export function submitProject( ) {
           ( _.isEmpty( project.rule_term_value_id ) || _.isEmpty( project.rule_term_id ) )
             ? "" : project.rule_term_value_id,
         prefers_rule_observed_on:
-          ( project.date_type !== "exact" || _.isEmpty( project.rule_observed_on ) )
+          ( project.date_type === "months" || _.isEmpty( project.rule_observed_on ) )
             ? "" : project.rule_observed_on.trim( ),
-        prefers_rule_d1: project.date_type !== "range" || _.isEmpty( project.rule_d1 )
+        prefers_rule_d1: ( project.date_type === "months" || _.isEmpty( project.rule_d1 ) )
           ? "" : project.rule_d1.trim( ),
-        prefers_rule_d2: project.date_type !== "range" || _.isEmpty( project.rule_d2 )
+        prefers_rule_d2: ( project.date_type === "months" || _.isEmpty( project.rule_d2 ) )
           ? "" : project.rule_d2.trim( ),
-        prefers_rule_month: project.date_type !== "months" || _.isEmpty( project.rule_month )
+        prefers_rule_month: ( project.date_type !== "months" || _.isEmpty( project.rule_month ) )
           || project.rule_month === _.range( 1, 13 ).join( "," ) ? "" : project.rule_month,
         prefers_rule_native: _.isEmpty( project.rule_native ) ? "" : project.rule_native,
         prefers_rule_introduced: _.isEmpty( project.rule_introduced ) ? "" : project.rule_introduced,

--- a/app/webpack/projects/shared/models/project.js
+++ b/app/webpack/projects/shared/models/project.js
@@ -44,13 +44,14 @@ const Project = class Project extends inatjs.Project {
       this.search_params.collection_preview = true;
     }
     Object.assign( this.search_params, additionalSearchParams );
-    this.setPreviewSearchParams( );
     const start = this.rule_observed_on || this.rule_d1;
     const end = this.rule_observed_on || this.rule_d2;
+    this.ruleD1Moment = util.momentDateFromString( this.rule_d1 );
+    this.ruleD2Moment = util.momentDateFromString( this.rule_d2 );
     this.startDate = util.momentDateFromString( start );
-    this.startDateIncludesTime = !util.isDate( start );
+    this.startDateIncludesTime = this.startDate && !util.isDate( start );
     this.endDate = util.momentDateFromString( end );
-    this.endDateIncludesTime = !util.isDate( end );
+    this.endDateIncludesTime = this.endDate && !util.isDate( end );
     this.started = false;
     this.ended = false;
     this.durationToEvent = null;
@@ -73,39 +74,225 @@ const Project = class Project extends inatjs.Project {
     this.undestroyedAdmins = _.filter( this.admins, a => !a._destroy );
     // TODO don't hardcode default color
     this.banner_color = this.banner_color || "#74ac00";
+    if ( !this.editing ) {
+      return;
+    }
+
+    this.mapAttributesToFormDates( );
     this.errors = this.errors || { };
-    this.validateDates( );
+    this.validateNewDates( );
+    this.setPreviewSearchParams( );
   }
 
-  validateDates( ) {
-    if ( this.date_type === "range" ) {
-      _.each( ["d1", "d2"], dateField => {
-        const ruleName = `rule_${dateField}`;
-        if ( this[ruleName] && !(
-          moment( this[ruleName].trim( ), "YYYY-MM-DD HH:mm Z", true ).isValid( )
-            || moment( this[ruleName].trim( ), "YYYY-MM-DD", true ).isValid( )
-        ) ) {
-          this.errors[dateField] = I18n.t( "invalid_date" );
-        } else {
-          delete this.errors[dateField];
+  mapAttributesToFormDates( ) {
+    // when projects are loaded from an API response, the way the form dates
+    // should be set up depeneds on the nature of the response, particularly
+    // when it comes to d1 and d2. Projects using d1 and d2 may use the
+    // "exact" date type if they are the same day relative to the viewwer,
+    // or they may use the "range" date type of they are different days
+    if ( !this.date_type ) {
+      if ( ( this.rule_d1 && this.startDate ) || ( this.rule_d2 && this.endDate ) ) {
+        const startDay = this.startDate?.format( "YYYY-MM-DD" );
+        const endDay = this.endDate?.format( "YYYY-MM-DD" );
+        if ( startDay === endDay ) {
+          this.date_type = "exact";
+          this.includeExactTimes = true;
+          this.exactDate = this.startDate.format( "YYYY-MM-DD" );
+          this.exactDateD1 = this.startDate.format( "HH:mm UTCZ" );
+          this.exactDateD2 = this.endDate.format( "HH:mm UTCZ" );
+          return;
         }
-      } );
-    } else {
-      delete this.errors.d1;
-      delete this.errors.d2;
+        this.rangeStartDate = this.startDate?.format( "YYYY-MM-DD" );
+        if ( this.startDateIncludesTime ) {
+          this.rangeStartTime = this.startDate.format( "HH:mm UTCZ" );
+          this.includeRangeTimes = true;
+        }
+        this.rangeEndDate = this.endDate?.format( "YYYY-MM-DD" );
+        if ( this.endDateIncludesTime ) {
+          this.rangeEndTime = this.endDate.format( "HH:mm UTCZ" );
+          this.includeRangeTimes = true;
+        }
+        this.date_type = "range";
+      } else if ( this.rule_observed_on ) {
+        this.date_type = "exact";
+        this.exactDate = this.rule_observed_on;
+      } else if ( this.rule_month ) {
+        this.date_type = "months";
+      } else {
+        this.date_type = "any";
+      }
+    }
+  }
+
+  validateExactTime( index ) {
+    const exactAttribute = `exactDateD${index}`;
+    const exactMomentAttribute = `exactDateD${index}Moment`;
+    delete this.errors[exactAttribute];
+    delete this[exactMomentAttribute];
+
+    if ( _.isEmpty( this[exactAttribute] ) ) {
+      return;
     }
 
-    if ( this.date_type === "exact" ) {
-      if ( this.rule_observed_on
-        && !moment( this.rule_observed_on.trim( ), "YYYY-MM-DD", true ).isValid( )
-      ) {
-        this.errors.observed_on = I18n.t( "invalid_date" );
-      } else {
-        delete this.errors.observed_on;
-      }
-    } else {
-      delete this.errors.observed_on;
+    // combine the date and time and validate the resulting datetime
+    const strippedTime = this[exactAttribute].replace( " UTC", "" );
+    this[exactMomentAttribute] = moment(
+      `${this.exactDate}T${strippedTime}`,
+      "YYYY-MM-DDTHH:mmZ",
+      true
+    );
+    if ( !this[exactMomentAttribute].isValid( ) ) {
+      this.errors[exactAttribute] = I18n.t( "invalid_time" );
+      return;
     }
+
+    // if one time is set and the other is not, set it accordingly. Also mark it as being updated -
+    // the datetimepicker will not recognize the updated time unless it is re-renderd, which we
+    // only want to do when the time is force-updated
+    let altIndex;
+    let altMomentMethod;
+    if ( index === 1 ) {
+      altIndex = 2;
+      altMomentMethod = "endOf";
+    } else {
+      altIndex = 1;
+      altMomentMethod = "startOf";
+    }
+    const altExactAttribute = `exactDateD${altIndex}`;
+    const altExactAttributeUpdatedAt = `exactDateD${altIndex}UpdatedAt`;
+    const altExactMomentAttribute = `exactDateD${altIndex}Moment`;
+    if ( _.isEmpty( this[altExactAttribute] ) ) {
+      this[altExactMomentAttribute] = this[exactMomentAttribute].clone( )[altMomentMethod]( "day" );
+      this[altExactAttribute] = this[altExactMomentAttribute].format( "HH:mm UTCZ" );
+      this[altExactAttributeUpdatedAt] = Date.now( );
+    }
+  }
+
+  validateExactDates( ) {
+    if ( this.date_type !== "exact" ) {
+      return;
+    }
+
+    if ( _.isEmpty( this.exactDate ) ) {
+      delete this.exactDateD1;
+      delete this.exactDateD2;
+      this.exactDateD1UpdatedAt = Date.now( );
+      this.exactDateD2UpdatedAt = Date.now( );
+      return;
+    }
+
+    delete this.errors.exactDate;
+    if ( !moment( this.exactDate.trim( ), "YYYY-MM-DD", true ).isValid( ) ) {
+      this.errors.exactDate = I18n.t( "invalid_date" );
+      return;
+    }
+
+    // validate the values in the time fields
+    this.validateExactTime( 1 );
+    this.validateExactTime( 2 );
+
+    if ( this.exactDateD1 && this.exactDateD2
+      && !this.errors.exactDateD1 && !this.errors.exactDateD2
+    ) {
+      if ( this.exactDateD2Moment.isSameOrBefore( this.exactDateD1Moment ) ) {
+        this.errors.exactDateD2 = I18n.t( "views.projects.new.end_time_must_be_after_start_time" );
+        return;
+      }
+      // if both times are valid, set tentative date range rules
+      this.rule_d1 = this.exactDateD1Moment.format( "YYYY-MM-DD HH:mm UTCZ" );
+      this.rule_d2 = this.exactDateD2Moment.format( "YYYY-MM-DD HH:mm UTCZ" );
+      return;
+    }
+
+    // if both times aren't valid, only apply the date as a tentative rule
+    this.rule_observed_on = this.exactDate;
+  }
+
+  validateRangeTime( type ) {
+    const rangeTimeAttribute = `range${type}Time`;
+    const rangeDateAttribute = `range${type}Date`;
+    const rangeTimeMomentAttribute = `range${type}TimeMoment`;
+    delete this.errors[rangeTimeAttribute];
+    delete this[rangeTimeMomentAttribute];
+
+    if ( _.isEmpty( this[rangeTimeAttribute] ) ) {
+      return;
+    }
+
+    // combine the date and time and validate the resulting datetime
+    const strippedTime = this[rangeTimeAttribute].replace( " UTC", "" );
+    this[rangeTimeMomentAttribute] = moment(
+      `${this[rangeDateAttribute]}T${strippedTime}`,
+      "YYYY-MM-DDTHH:mmZ",
+      true
+    );
+    if ( !this[rangeTimeMomentAttribute].isValid( ) ) {
+      this.errors[rangeTimeAttribute] = I18n.t( "invalid_time" );
+    }
+  }
+
+  validateRangeDates( ) {
+    if ( this.date_type !== "range" ) {
+      return;
+    }
+
+    delete this.errors.rangeStartDate;
+    let rangeStartDateMoment;
+    if ( _.isEmpty( this.rangeStartDate ) ) {
+      delete this.rangeStartTime;
+      this.rangeStartTimeUpdatedAt = Date.now( );
+    } else {
+      rangeStartDateMoment = moment( this.rangeStartDate.trim( ), "YYYY-MM-DD", true );
+      if ( !rangeStartDateMoment.isValid( ) ) {
+        this.errors.rangeStartDate = I18n.t( "invalid_date" );
+      } else {
+        this.validateRangeTime( "Start" );
+      }
+    }
+
+    delete this.errors.rangeEndDate;
+    let rangeEndDateMoment;
+    if ( _.isEmpty( this.rangeEndDate ) ) {
+      delete this.rangeEndTime;
+      this.rangeEndTimeUpdatedAt = Date.now( );
+    } else {
+      rangeEndDateMoment = moment( this.rangeEndDate.trim( ), "YYYY-MM-DD", true );
+      if ( !rangeEndDateMoment.isValid( ) ) {
+        this.errors.rangeEndDate = I18n.t( "invalid_date" );
+      } else {
+        this.validateRangeTime( "End" );
+      }
+    }
+
+    // validate the end date is after the start date
+    if ( rangeEndDateMoment && rangeStartDateMoment
+      && rangeEndDateMoment.isSameOrBefore( rangeStartDateMoment ) ) {
+      this.errors.rangeEndDate = I18n.t( "views.projects.new.end_date_must_be_after_start_date" );
+      return;
+    }
+
+    if ( this.rangeStartDate && !this.errors.rangeStartDate ) {
+      if ( this.rangeStartTime && !this.errors.rangeStartTime ) {
+        this.rule_d1 = this.rangeStartTimeMoment.format( "YYYY-MM-DD HH:mm Z" );
+      } else {
+        this.rule_d1 = this.rangeStartDate;
+      }
+    }
+    if ( this.rangeEndDate && !this.errors.rangeEndDate ) {
+      if ( this.rangeEndTime && !this.errors.rangeEndTime ) {
+        this.rule_d2 = this.rangeEndTimeMoment.format( "YYYY-MM-DD HH:mm Z" );
+      } else {
+        this.rule_d2 = this.rangeEndDate;
+      }
+    }
+  }
+
+  validateNewDates( ) {
+    delete this.rule_d1;
+    delete this.rule_d2;
+    delete this.rule_observed_on;
+    this.validateExactDates( );
+    this.validateRangeDates( );
   }
 
   hasInsufficientRequirements( ) {
@@ -113,9 +300,11 @@ const Project = class Project extends inatjs.Project {
     const dateType = this.date_type;
     if ( !_.isEmpty( this.rule_term_id ) ) { empty = false; }
     if ( !_.isEmpty( this.rule_term_value_id ) ) { empty = false; }
-    if ( dateType === "exact" && !_.isEmpty( this.rule_observed_on ) ) { empty = false; }
-    if ( dateType === "range" && !_.isEmpty( this.rule_d1 ) ) { empty = false; }
-    if ( dateType === "range" && !_.isEmpty( this.rule_d2 ) ) { empty = false; }
+    if ( dateType !== "months" && (
+      !_.isEmpty( this.rule_observed_on )
+      || !_.isEmpty( this.rule_d1 )
+      || !_.isEmpty( this.rule_d2 )
+    ) ) { empty = false; }
     // there are months, but not ALL months
     if ( dateType === "months" && !_.isEmpty( this.rule_month )
       && this.rule_month !== _.range( 1, 13 ).join( "," ) ) {
@@ -227,7 +416,15 @@ const Project = class Project extends inatjs.Project {
     }
     if ( !this.is_umbrella || this.is_delegated_umbrella ) {
       this.previewSearchParamsObject = _.fromPairs(
-        _.map( _.filter( this.rule_preferences, p => p.value !== null ), p => [p.field, p.value] )
+        _.map(
+          _.filter( this.rule_preferences, p => {
+            if ( _.includes( ["d1", "d2", "observed_on", "month"], p.field ) ) {
+              return false;
+            }
+            return p.value !== null;
+          } ),
+          p => [p.field, p.value]
+        )
       );
       if ( !_.isEmpty( this.notTaxonRules ) ) {
         this.previewSearchParamsObject.without_taxon_id = _.map(
@@ -266,27 +463,6 @@ const Project = class Project extends inatjs.Project {
         ).join( "," );
       }
     }
-    if ( !this.date_type ) {
-      if ( this.previewSearchParamsObject.d1 || this.previewSearchParamsObject.d2 ) {
-        this.date_type = "range";
-      } else if ( this.previewSearchParamsObject.observed_on ) {
-        this.date_type = "exact";
-      } else if ( this.previewSearchParamsObject.month ) {
-        this.date_type = "months";
-      } else {
-        this.date_type = "any";
-      }
-    }
-    if ( this.date_type !== "range" ) {
-      delete this.previewSearchParamsObject.d1;
-      delete this.previewSearchParamsObject.d2;
-    }
-    if ( this.date_type !== "months" ) {
-      delete this.previewSearchParamsObject.month;
-    }
-    if ( this.date_type !== "exact" ) {
-      delete this.previewSearchParamsObject.observed_on;
-    }
     if ( this.previewSearchParamsObject.members_only ) {
       if ( this.id ) {
         this.previewSearchParamsObject.members_of_project = this.id;
@@ -306,13 +482,22 @@ const Project = class Project extends inatjs.Project {
     // using naming consistent with the web obs search form
     this.previewSearchParamsObject.verifiable = "any";
     this.previewSearchParamsObject.place_id = this.previewSearchParamsObject.place_id || "any";
-    // Convert dates into iso8601 strings
-    _.each( ["d1", "d2"], dateAttr => {
-      if ( this.previewSearchParamsObject[dateAttr] ) {
-        const d = moment( this.previewSearchParamsObject[dateAttr] );
-        this.previewSearchParamsObject[dateAttr] = d.format( );
+
+    // handle dates separately to avoid conflicts between the form data
+    // and existing rules returned from the project details API response
+    if ( this.rule_d1 ) {
+      this.previewSearchParamsObject.d1 = this.rule_d1;
+    }
+    if ( this.rule_d2 ) {
+      this.previewSearchParamsObject.d2 = this.rule_d2;
+    }
+    if ( !this.rule_d1 && !this.rule_d2 ) {
+      if ( this.rule_observed_on ) {
+        this.previewSearchParamsObject.on = this.rule_observed_on;
+      } else if ( this.rule_month ) {
+        this.previewSearchParamsObject.month = this.rule_month;
       }
-    } );
+    }
     this.previewSearchParamsString = $.param( this.previewSearchParamsObject );
   }
 };

--- a/app/webpack/projects/shared/models/project.js
+++ b/app/webpack/projects/shared/models/project.js
@@ -46,8 +46,6 @@ const Project = class Project extends inatjs.Project {
     Object.assign( this.search_params, additionalSearchParams );
     const start = this.rule_observed_on || this.rule_d1;
     const end = this.rule_observed_on || this.rule_d2;
-    this.ruleD1Moment = util.momentDateFromString( this.rule_d1 );
-    this.ruleD2Moment = util.momentDateFromString( this.rule_d2 );
     this.startDate = util.momentDateFromString( start );
     this.startDateIncludesTime = this.startDate && !util.isDate( start );
     this.endDate = util.momentDateFromString( end );
@@ -199,8 +197,8 @@ const Project = class Project extends inatjs.Project {
         return;
       }
       // if both times are valid, set tentative date range rules
-      this.rule_d1 = this.exactDateD1Moment.format( "YYYY-MM-DD HH:mm UTCZ" );
-      this.rule_d2 = this.exactDateD2Moment.format( "YYYY-MM-DD HH:mm UTCZ" );
+      this.rule_d1 = this.exactDateD1Moment.format( "YYYY-MM-DD HH:mm Z" );
+      this.rule_d2 = this.exactDateD2Moment.format( "YYYY-MM-DD HH:mm Z" );
       return;
     }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2805,6 +2805,8 @@ en:
   introduced_in_place: "Introduced in %{place}"
   # Error message shown when a date format is invalid
   invalid_date: Invalid date
+  # Error message shown when a time format is invalid
+  invalid_time: Invalid time
   invitation: Invitation
   invite: invite
   invite_people: Invite people
@@ -8851,12 +8853,31 @@ en:
         contain_entire_image_without_cropping: Contain entire image without cropping
         custom_banner_icon_and_project_description: Custom banner, icon, and project description
         data_visualizations: Data visualizations
+        date_pickers:
+          # Label for a form field for a project's exact date
+          date: Date
+          # Label for a form field for a project's starting date
+          start_date: Start Date
+          # Label for a form field for a project's end date
+          end_date: End Date
+          # Label for a form field for a project's starting time
+          start_time: Start Time
+          # Label for a form field for a project's end time
+          end_time: End Time
+          # Label for a form field allowing projects to specify start/end times in addition to dates
+          include_times: Include Times
+          # Label for a form select field allowing the editor to choose calendar months
+          select_months: Select Months
         delete_project: Delete Project
         display_project_name: Display project name
         do_you_need_features_from_traditional2: |
           Do you need features from traditional projects, such as custom observation fields,
           or adding individual observations that can’t be automatically filtered?
         duplicate_project: Duplicate Project
+        # validation error when a project's end date is earlier than its start date
+        end_date_must_be_after_start_date: End date must be after start date
+        # validation error when a project's end time is earlier than its start time
+        end_time_must_be_after_start_time: End time must be after start time
         include_annotated_observations: |
           Include only observations annotated with a particular attribute (e.g. life stage),
           or a particular attribute and value (e.g life stage = adult).


### PR DESCRIPTION
This PR updates how project date-related fields are edited. Some of the complication in code is a result of splitting up date from time into two separate form fields, so there is no longer a 1-1 mapping between form field and project rule.

There's an additional complication that the "Exact" date type can either result in an `observed_on` attribute, or a `d1` and `d2` attribute, depending on if a time range is included or not. Similarly, when loading a project, a project with `d1` and `d2` attributes may need to use the "Exact" or "Range" date type, depending on if they include times, and, depending on the viewers time zone, if those date/times are the same calendar day or not.

Various new validation is added as well, particularly checking to make sure end date/times are later than start/date times which is something we hadn't been doing before