### PR TITLE
Update issue forms and guidance, LEAD-26

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,27 @@
+# Place this file at .github/ISSUE_TEMPLATE/config.yml so that Github 
+# will present these links to users and direct traffic to the forum.
+
+contact_links:
+  - name: 🐛 Report a bug
+    url: https://forum.inaturalist.org/c/bug-reports
+    about: >
+      Please report bugs on the iNaturalist Forum. You're more likely to get
+      a response there, and other users can confirm or add context to your report.
+
+  - name: 💡 Request a feature
+    url: https://forum.inaturalist.org/c/feature-requests
+    about: >
+      Please post feature requests on the iNaturalist Forum, where the
+      community can discuss and staff can weigh in on feasibility.
+
+  - name: 💬 Ask a technical question about the code
+    url: https://github.com/inaturalist/inaturalist/discussions
+    about: >
+      If you have a question about how the code works, or you're building
+      an integration, open a GitHub Discussion instead of an issue.
+
+  - name: 🔒 Report a security vulnerability
+    url: mailto:help+security@inaturalist.org
+    about: >
+      For security issues requiring confidential communication,
+      please email us directly rather than filing a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,9 @@
-# Place this file at .github/ISSUE_TEMPLATE/config.yml so that Github 
-# will present these links to users and direct traffic to the forum.
+# This file disables blank issue creation and replaces the issue form with
+# links that redirect users to the appropriate channels.
+#
+# Place this file at .github/ISSUE_TEMPLATE/config.yml in each repo.
+
+blank_issues_enabled: false
 
 contact_links:
   - name: 🐛 Report a bug

--- a/.github/ISSUE_TEMPLATE/technical_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/technical_bug_report.md
@@ -1,13 +1,13 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Technical bug report
+about: Create a report to help us improve, with code-level/engineering specific concerns
 title: ''
 type: Bug
 assignees: ''
 
 ---
 
-[//]: # (For feature requests and bug reports not specifically concerning code, please use https://forum.inaturalist.org/c/feature-requests/16. iNat staff will make github issues if/when an actionable solution emerges)
+[//]: # (For feature requests and bug reports not specifically concerning code, please use https://forum.inaturalist.org/c/bug-reports. To request a feature, use https://forum.inaturalist.org/c/feature-requests. To ask a technical question, use https://github.com/inaturalist/inaturalist/discussions. To report a secutrity vulnerability, email help+security@inaturalist.org)
 
 **Describe the bug**
 A clear and concise description of what the bug is, preferably with citations to the relevant code in this github repo.

--- a/.github/ISSUE_TEMPLATE/technical_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/technical_bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-[//]: # (For feature requests and bug reports not specifically concerning code, please use https://forum.inaturalist.org/c/bug-reports. To request a feature, use https://forum.inaturalist.org/c/feature-requests. To ask a technical question, use https://github.com/inaturalist/inaturalist/discussions. To report a secutrity vulnerability, email help+security@inaturalist.org)
+[//]: # (For feature requests and bug reports not specifically concerning code, please use https://forum.inaturalist.org/c/bug-reports. To request a feature, use https://forum.inaturalist.org/c/feature-requests. To ask a technical question, use https://github.com/inaturalist/inaturalist/discussions. To report a security vulnerability, email help+security@inaturalist.org)
 
 **Describe the bug**
 A clear and concise description of what the bug is, preferably with citations to the relevant code in this github repo.

--- a/.github/ISSUE_TEMPLATE/technical_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/technical_bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Technical bug report
+name: Report a code-level technical issue
 about: Create a report to help us improve, with code-level/engineering specific concerns
 title: ''
 type: Bug


### PR DESCRIPTION
Working on improving guidance for OS contributors, esp on filing issues. NOTE: Rendering of these files is impossible to test locally. We'll see how it looks in the PR.