### PR TITLE
change "Visually similar / Expected nearby" to "Visually similar & Expected Nearby"

### DIFF
--- a/app/webpack/observations/identify/components/suggestion_row.jsx
+++ b/app/webpack/observations/identify/components/suggestion_row.jsx
@@ -109,7 +109,7 @@ const SuggestionRow = ( {
           { details && ( details.vision_score || details.frequency_score ) ? (
             <div className="quiet btn btn-label btn-xs">
               { details.vision_score ? I18n.t( "visually_similar" ) : null }
-              { details.vision_score && details.frequency_score ? <span> / </span> : null }
+              { details.vision_score && details.frequency_score ? <span> & </span> : null }
               { details.frequency_score ? I18n.t( "expected_nearby" ) : null }
             </div>
           ) : null }

--- a/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
@@ -117,7 +117,7 @@ class TaxonAutocomplete extends React.Component {
       if ( r.frequencyScore ) {
         subtitles.push( I18n.t( "expected_nearby" ) );
       }
-      extraSubtitle = ( <span className="subtitle vision">{ subtitles.join( " / " ) }</span> );
+      extraSubtitle = ( <span className="subtitle vision">{ subtitles.join( " & " ) }</span> );
     }
     return ReactDOMServer.renderToString(
       <div className={className} data-taxon-id={r.id}>


### PR DESCRIPTION
the latter is the correct semantic thing in current handling.

The OR came from before geomodel gating where suggestions were added outside of CV prior from geo range query. nearby injection in fifth image at https://forum.inaturalist.org/t/identification-quality-on-inaturalist/7507

But since current results are conditioned on CV prior in first place so it should be AND under new geomodel and current results handling