### PR TITLE
Improve localized Wikipedia summary parsing and URL lookup

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1518,6 +1518,22 @@ class Taxon < ApplicationRecord
     nil
   end
 
+  def wikipedia_url( options = {} )
+    return unless shows_wikipedia?
+
+    locale = options[:locale] || I18n.locale
+    locale_lang = Regexp.escape( locale.to_s.split( "-" ).first )
+    wikipedia_descriptions = taxon_descriptions.select do | desc |
+      desc.provider == "Wikipedia"
+    end
+    td = wikipedia_descriptions.detect {| desc | desc.locale.to_s == locale.to_s && !desc.url.blank? }
+    td ||= wikipedia_descriptions.detect do | desc |
+      desc.locale.to_s =~ /^#{locale_lang}(-|$)/ && !desc.url.blank?
+    end
+    td ||= wikipedia_descriptions.detect {| desc | desc.locale.to_s =~ /^en(-|$)/ && !desc.url.blank? }
+    td&.url
+  end
+
   def set_wikipedia_summary( options = {} )
     unless shows_wikipedia?
       update( wikipedia_summary: false )
@@ -1532,7 +1548,7 @@ class Taxon < ApplicationRecord
     if ( details = w.page_details( wname, options ) )
       pre_trunc = details[:summary]
       details[:summary] = details[:summary].split[0..75].join( " " )
-      details[:summary] += "..." if pre_trunc > details[:summary]
+      details[:summary] += "..." if pre_trunc.to_s.split.size > details[:summary].to_s.split.size
       provider = "Wikipedia"
     end
 

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -55,13 +55,18 @@ class WikipediaService < MetaService
 
   def summary_from_parsed( parsed )
     hxml = Nokogiri::HTML( HTMLEntities.new.decode( parsed.at( "text" ).try( :inner_text ) ) )
-    hxml.search( "table" ).remove
+    %w[
+      style link script noscript table
+      .hatnote .ambox .mbox .tmbox .ombox .cmbox .fmbox
+      .dablink .rellink .navbox .vertical-navbox .metadata
+      .noprint .infobox .sidebar .mw-editsection .navbar
+      .taxobox .taxobox_v3 table.infobox
+    ].each {| selector | hxml.search( selector ).remove }
     hxml.search( "//comment()" ).remove
     # Remove all elements that aren't displayed
     hxml.search( "//*[contains(@style,'display:none')]/text()" ).remove
-    summary = ( hxml.search( "//p" ).detect do | node |
-      !node.inner_html.strip.blank?
-    end || hxml ).inner_html.to_s.strip
+    summary_node = hxml.search( "//p" ).detect {| node | lead_paragraph?( node ) }
+    summary = ( summary_node || hxml ).inner_html.to_s.strip
     summary = sanitizer.sanitize( summary, tags: %w(p i em b strong) )
     summary.gsub! /\[.*?\]/, ""
     summary
@@ -76,5 +81,22 @@ class WikipediaService < MetaService
 
   def sanitizer
     @sanitizer ||= Rails::Html::SafeListSanitizer.new
+  end
+
+  private
+
+  def lead_paragraph?( node )
+    classes = node["class"].to_s.split
+    return false if classes.intersect?( %w(noexcerpt mw-empty-elt) )
+
+    text = node.text.to_s.squish
+    return false if text.blank?
+    return false if css_fragment?( text )
+
+    true
+  end
+
+  def css_fragment?( text )
+    text.match?( /\A[.#][\w-]+/ ) || ( text.include?( "{" ) && text.include?( "}" ) )
   end
 end

--- a/spec/lib/wikipedia_service.rb
+++ b/spec/lib/wikipedia_service.rb
@@ -46,4 +46,39 @@ describe WikipediaService do
       expect( api_endpoint.cache_hours ).to eq WikipediaService::CACHE_HOURS
     end
   end
+
+  describe "summary_from_parsed" do
+    let( :service ) { WikipediaService.new( locale: "fr" ) }
+
+    def parsed_doc_for( html )
+      Nokogiri::XML( "<api><parse><text>#{ERB::Util.h( html )}</text></parse></api>" )
+    end
+
+    it "ignores subtitle and style noise before the lead paragraph" do
+      html = <<~HTML
+        <div class="mw-parser-output">
+          <p id="sous_titre_h1" class="noexcerpt"><i>Cacatua galerita</i></p>
+          <style>.mw-parser-output h1 #sous_titre_h1{display:block}</style>
+          <p><b>Cacatua galerita</b> est une espece d'oiseau de la famille des Cacatuidae.</p>
+        </div>
+      HTML
+      summary = service.summary_from_parsed( parsed_doc_for( html ) )
+      expect( summary ).to include( "Cacatua galerita" )
+      expect( summary ).not_to match( /\.mw-parser-output/ )
+    end
+
+    it "ignores banner paragraphs and returns the descriptive lead paragraph" do
+      html = <<~HTML
+        <div class="mw-parser-output">
+          <div class="bandeau-container metadata hatnote">
+            <p>Vous lisez un bon article labellise en 2008.</p>
+          </div>
+          <p><b>Psittaciformes</b> est un ordre d'oiseaux comprenant les perroquets.</p>
+        </div>
+      HTML
+      summary = service.summary_from_parsed( parsed_doc_for( html ) )
+      expect( summary ).to include( "Psittaciformes" )
+      expect( summary ).not_to include( "bon article" )
+    end
+  end
 end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -390,6 +390,55 @@ describe Taxon, "updating" do
     end
   end
 
+  describe "wikipedia_url" do
+    let( :taxon ) { Taxon.make! }
+
+    it "returns the URL for the requested locale" do
+      create :taxon_description,
+        taxon: taxon,
+        provider: "Wikipedia",
+        locale: "fr",
+        url: "https://fr.wikipedia.org/wiki/Merle_noir"
+      create :taxon_description,
+        taxon: taxon,
+        provider: "Wikipedia",
+        locale: "en",
+        url: "https://en.wikipedia.org/wiki/Common_blackbird"
+
+      expect( taxon.wikipedia_url( locale: "fr" ) ).to eq "https://fr.wikipedia.org/wiki/Merle_noir"
+    end
+
+    it "falls back to a matching language variant" do
+      create :taxon_description,
+        taxon: taxon,
+        provider: "Wikipedia",
+        locale: "pt",
+        url: "https://pt.wikipedia.org/wiki/Melro-preto"
+
+      expect( taxon.wikipedia_url( locale: "pt" ) ).to eq "https://pt.wikipedia.org/wiki/Melro-preto"
+    end
+
+    it "falls back to an English Wikipedia URL" do
+      create :taxon_description,
+        taxon: taxon,
+        provider: "Wikipedia",
+        locale: "en",
+        url: "https://en.wikipedia.org/wiki/Common_blackbird"
+
+      expect( taxon.wikipedia_url( locale: "fr" ) ).to eq "https://en.wikipedia.org/wiki/Common_blackbird"
+    end
+
+    it "does not return a guessed URL when no stored Wikipedia URL exists" do
+      create :taxon_description,
+        taxon: taxon,
+        provider: "Wikipedia",
+        locale: "fr",
+        url: nil
+
+      expect( taxon.wikipedia_url( locale: "fr" ) ).to be_nil
+    end
+  end
+
   it "should assign the updater if explicitly assigned" do
     creator = make_curator
     updater = make_curator


### PR DESCRIPTION
# Summary

This PR fixes two related issues with localized Wikipedia content on taxa:

1. **Wikipedia summary extraction** — On some Wikipedia articles, the first non-empty `<p>` is not the lead paragraph. Subtitles, CSS, and quality banners were being saved as the taxon summary.
2. **Wikipedia URLs** — Adds `Taxon#wikipedia_url` so callers can resolve a stored Wikipedia link for the user’s locale (mirroring how localized summaries are already stored on `TaxonDescription`).

# Examples of malformed summaries

**[*Cacatua galerita*](https://fr.wikipedia.org/wiki/Cacatua_galerita)**

The page starts with a subtitle line and inline CSS before the real lead:

```html
<p id="sous_titre_h1" class="noexcerpt"><i>Cacatua galerita</i></p>
<style>.mw-parser-output h1 #sous_titre_h1{display:block}</style>
<p><b>Cacatua galerita</b> est une espèce d'oiseau de la famille des Cacatuidae.</p>
```

```sh
curl -s "https://api.inaturalist.org/v1/taxa/116834?locale=fr" | jq '.results[0] | {id, name, preferred_common_name, rank, wikipedia_url, wikipedia_summary}'
```

**[*Psittaciformes*](https://fr.wikipedia.org/wiki/Psittaciformes)**

A “good article” banner appears before the lead:

```html
<div class="bandeau-container metadata hatnote">
  <p>Vous lisez un « bon article » labellisé en 2008.</p>
</div>
<p><b>Psittaciformes</b> est un ordre d'oiseaux comprenant les perroquets.</p>
```

```sh
curl -s "https://api.inaturalist.org/v1/taxa/18874?locale=fr" | jq '.results[0] | {id, name, preferred_common_name, rank, wikipedia_url, wikipedia_summary}'
```

**[*Strigops habroptilus*](https://en.wikipedia.org/wiki/Kakapo)**

The stored English summary includes inline CSS from Wikipedia pronunciation markup instead of readable lead text:

```sh
curl -s "https://api.inaturalist.org/v1/taxa/1584019?locale=en" | jq '.results[0] | {id, name, preferred_common_name, rank, wikipedia_url, wikipedia_summary}'
```

With `locale=fr`, the same taxon returns only a short italic scientific name as the summary (no real lead paragraph):

# Localized Wikipedia URLs

When a user’s locale is not English, the Wikipedia link for a taxon is often missing, even when a localized summary exists:

- `Taxon#set_wikipedia_summary` can store a localized summary and URL on a `TaxonDescription` for that locale (e.g. French).
- `Taxon#wikipedia_summary(locale:)` already reads that localized body with locale/language fallback.
- There is no equivalent helper for the URL. Callers that need a link typically rely on the English association (`en_wikipedia_description`) or the English-only `wikipedia_url` field in the search index.

# Changes

- **`WikipediaService#summary_from_parsed`**: remove common non-lead Wikipedia markup (hatnotes, amboxes, infoboxes, navboxes, etc.), skip `noexcerpt` paragraphs, and pick the first suitable lead `<p>`.
- **`Taxon#set_wikipedia_summary`**: compare word counts when appending `...` after truncation (fixes incorrect ellipsis when the pre-truncated summary was not a string).
- **`Taxon#wikipedia_url`**: new helper with the same resolution order as `wikipedia_summary` (exact locale, then language variant, then English), returning URLs from stored Wikipedia `TaxonDescription` records.
- **Specs** for summary extraction and `wikipedia_url` fallback behavior.
