### PR TITLE
Fix place match when searching in non english locale

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1345,8 +1345,10 @@ var SearchController = function (
   };
 
   $scope.geocodeSearchedPlaceID = function ( placeID ) {
-    var s = new google.maps.Geocoder( );
-    s.geocode( { placeId: placeID }, function ( results, status ) {
+    var geocoder = new google.maps.Geocoder( );
+    // language: "en" ensures address_components are in English for matching against
+    // iNat's English place database, regardless of the user's locale.
+    geocoder.geocode( { placeId: placeID, language: "en" }, function ( results, status ) {
       if ( status !== google.maps.GeocoderStatus.OK ) {
         return;
       }


### PR DESCRIPTION
Adds ` language: "en" ` to Google geocoder call to return result in english to match iNaturalist places API.