### PR TITLE
fix: Add search to header menu at any size, WEB-1004

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -112,7 +112,7 @@
           %i.fa.fa-angle-down
         %ul.dropdown-menu{ aria: { labelledby: "header-more-dropdown-toggle" } }
           - if @skip_external_connections
-            %li.header-md.header-lg= link_to t( :search ), search_path
+            %li= link_to t( :search ), search_path
           - if logged_in?
             %li.header-xs.header-sm= link_to t( :identify ), identify_observations_path
           %li= link_to t( :taxa_info ), taxa_path


### PR DESCRIPTION
Search was previously not displaying in the More menu at window sizes < 992px because of the `header-md` class. This class was added by mistake, there's no benefit to using it. Removing it shows the search item whenever the More dropdown is displayed.