### PR TITLE
chore:web-1024: add two virtuous tags to UserVirtuousTag#POSSIBLE_TAGS

### DIFF
--- a/app/models/user_virtuous_tag.rb
+++ b/app/models/user_virtuous_tag.rb
@@ -11,5 +11,7 @@ class UserVirtuousTag < ApplicationRecord
     FoundationProspect
     FRU\ donors\ temporary
     Ambassador
+    Do\ Not\ Contact
+    Mid-Range\ Donors
   ).freeze
 end


### PR DESCRIPTION
- `Do Not Contact`
- `Mid-Range Donors`

Confirmed these displays in the announcement logged in user targeting UI:
<img width="484" height="180" alt="image" src="https://github.com/user-attachments/assets/543fd7d6-90b7-43e2-85cc-6a9477d5e795" />

Did not test tags w/ actual virtuous API Keys.
