### PR TITLE
feat: more gracefully handle delayed job unique_hash race condition, WEB-1032

### DIFF
--- a/config/initializers/delayed_jobs_unique_hash.rb
+++ b/config/initializers/delayed_jobs_unique_hash.rb
@@ -23,7 +23,13 @@ module Delayed
         # before the job can be saved. Catch these unique_hash uniqueness errors
         # and add an error to the instance instead of raising an exception
         def save( *args, **kwargs, & )
-          super
+          # create a transaction, or savepoint within an open transaction, so
+          # that if a unique index violation occurs at the DB level an open
+          # transaction is not left in a fail state, causing subsequent queries
+          # to raise errors
+          self.class.transaction( requires_new: true ) do
+            super
+          end
         rescue ::ActiveRecord::RecordNotUnique, ::PG::UniqueViolation => e
           raise unless e.message.include?( "index_delayed_jobs_on_unique_hash" )
 

--- a/config/initializers/delayed_jobs_unique_hash.rb
+++ b/config/initializers/delayed_jobs_unique_hash.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 module Delayed
   module Backend
     module ActiveRecord
       class Job < ::ActiveRecord::Base
-
         # there is a migration to add a `unique_hash` column
         # to delayed_jobs. If we set that hash when creating
         # a job then the job will not be created if another
@@ -13,6 +14,27 @@ module Delayed
         #     refresh_listed_taxon(lt.id)
         validates_uniqueness_of :unique_hash, allow_blank: true
 
+        validate :unique_hash_not_known_to_be_taken
+        attr_accessor :unique_hash_taken
+
+        # Some Delayed Jobs are attempted to be queued very often,
+        # leading to race conditions when the above validates_uniqueness_of
+        # validation succeeds but a record with the same unique_hash is added
+        # before the job can be saved. Catch these unique_hash uniqueness errors
+        # and add an error to the instance instead of raising an exception
+        def save( *args, **kwargs, & )
+          super
+        rescue ::ActiveRecord::RecordNotUnique, ::PG::UniqueViolation => e
+          raise unless e.message.include?( "index_delayed_jobs_on_unique_hash" )
+
+          self.unique_hash_taken = true
+          errors.add( :unique_hash, :taken )
+          false
+        end
+
+        def unique_hash_not_known_to_be_taken
+          errors.add( :unique_hash, :taken ) if unique_hash_taken
+        end
       end
     end
   end

--- a/spec/initializers/delayed_jobs_unique_hash_spec.rb
+++ b/spec/initializers/delayed_jobs_unique_hash_spec.rb
@@ -47,4 +47,21 @@ describe "Delayed::Jobs::unique_hash" do
     expect( second_job.unique_hash_taken ).to be true
     expect( second_job.errors[:unique_hash] ).not_to be_empty
   end
+
+  it "does not leave open transactions in a failed state" do
+    User.delay( unique_hash: "first!" ).find( 1 )
+    second_job = Delayed::Job.new( unique_hash: "first!" )
+    # many jobs are enqueued from model callbacks, i.e. inside an open
+    # transaction. When an INSERT violates a unique index, Postgres aborts
+    # the entire transaction. This is checking that after hitting a DB
+    # unique index violation, the open transaction can still process
+    # queries, and does not raise a PG::InFailedSqlTransaction error
+    ActiveRecord::Base.transaction do
+      expect( second_job.save( validate: false ) ).to be false
+      expect( second_job.unique_hash_taken ).to be true
+      expect do
+        Delayed::Job.count
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/initializers/delayed_jobs_unique_hash_spec.rb
+++ b/spec/initializers/delayed_jobs_unique_hash_spec.rb
@@ -1,22 +1,50 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe "Delayed::Jobs::unique_hash" do
-
   it "allows a unique_hash to be set" do
     expect( Delayed::Job.count ).to eq 0
-    User.delay(unique_hash: "itworks").find(1)
+    User.delay( unique_hash: "itworks" ).find( 1 )
     expect( Delayed::Job.count ).to eq 1
     expect( Delayed::Job.first.unique_hash ).to eq "itworks"
   end
 
-  it "allows only one just unique_hash to be set" do
+  it "enforces unique_hash uniqueness" do
     expect( Delayed::Job.count ).to eq 0
-    User.delay(unique_hash: "first!").find(1)
-    User.delay(unique_hash: "first!").find(2)
-    User.delay(unique_hash: "third").find(3)
+    User.delay( unique_hash: "first!" ).find( 1 )
+    User.delay( unique_hash: "first!" ).find( 2 )
+    User.delay( unique_hash: "third" ).find( 3 )
     expect( Delayed::Job.count ).to eq 2
     expect( Delayed::Job.all[0].unique_hash ).to eq "first!"
     expect( Delayed::Job.all[1].unique_hash ).to eq "third"
   end
 
+  it "catches DB uniqueness validation failures and treats them as rails validation errors" do
+    expect( Delayed::Job.count ).to eq 0
+    User.delay( unique_hash: "first!" ).find( 1 )
+    expect( Delayed::Job.count ).to eq 1
+    expect( Delayed::Job.all[0].unique_hash ).to eq "first!"
+
+    # without the custom save and rescuing of UniqueViolation, this would
+    # raise an error becuase the DB would fail to save the record due to
+    # the uniqueness constraint on this column in the DB. We are rescuing
+    # that exception, and marking the instance as invalid - the same as if
+    # the rails `validates_uniqueness_of` validation were the one to catch
+    # the uniqueness failure
+    second_job = Delayed::Job.create( unique_hash: "first!" )
+    expect do
+      # skip validations to skip the `validates_uniqueness_of :unique_hash`
+      # validation - attempting to simulate a race condition where that
+      # validation passes, but another record is added to the DB before this
+      # one can be actually saved
+      second_job.save( validate: false )
+    end.not_to raise_error
+    expect( second_job ).not_to be_valid
+    # when the UniqueViolation is caught, an attribute `unique_hash_taken` is
+    # set so that if .valid? is called again on the instance, we will already
+    # know its unique_hash is not unique w/o needing to query the DB again
+    expect( second_job.unique_hash_taken ).to be true
+    expect( second_job.errors[:unique_hash] ).not_to be_empty
+  end
 end


### PR DESCRIPTION
Treat DB-level `PG::UniqueViolation` for the Delayed::Job `unique_hash` attribute as Rails `validates_uniqueness_of` validation errors, not uncaught exceptions