### PR TITLE
Web 881 unknown taxa button sets identified=true

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -162,7 +162,8 @@ var SearchController = function (
   $scope.possibleSubviews = { observations: ["map", "grid", "table"] };
   $scope.possibleFields = ["iconic_taxa", "month", "swlat", "swlng",
     "nelat", "nelng", "place_id", "taxon_id", "page", "view", "subview",
-    "locale", "preferred_place_id", "ident_user_id", "spam", "test"];
+    "locale", "preferred_place_id", "ident_user_id", "spam", "test",
+    "identified"];
   $scope.defaultView = "observations";
   $scope.defaultSubview = "grid";
   $rootScope.mapType = "map";
@@ -201,6 +202,19 @@ var SearchController = function (
   };
   $scope.$watchGroup( ["mapType", "mapLabels", "mapTerrain"], function ( ) {
     $rootScope.$emit( "setMapType", $scope.mapType, $scope.mapLabels, $scope.mapTerrain );
+  } );
+  $scope.toggleUnknownFilter = function ( ) {
+    if ( $scope.params.identified === "false" ) {
+      delete $scope.params.identified;
+    } else {
+      $scope.params.iconic_taxa_hash = {};
+      $scope.params.identified = "false";
+    }
+  };
+  $scope.$watchCollection( "params.iconic_taxa_hash", function ( newVal ) {
+    if ( newVal && _.some( newVal, function ( v ) { return !!v; } ) ) {
+      delete $scope.params.identified;
+    }
   } );
   // this is the first block to run when the page loads
   $scope.preInitialize = function ( ) {

--- a/app/assets/javascripts/ang/templates/observation_search/filter_menu.html.haml
+++ b/app/assets/javascripts/ang/templates/observation_search/filter_menu.html.haml
@@ -80,7 +80,7 @@
                   }
                 %button{ button_attrs }
                   %i{ :class => "icon-iconic-#{t[0].downcase}" }
-              %button{ type: "button", :class => "btn btn-default iconic-taxon last", "uib-btn-checkbox" => true, "uib-btn-checkbox-true" => "unknown", "ng-model" => "params.iconic_taxa_hash.unknown", title: "{{ shared.t( 'unknown' ) }}", "ng-class" => "{ 'filter-changed': params.iconic_taxa_hash.unknown }" }
+              %button{ type: "button", :class => "btn btn-default iconic-taxon last", "ng-click" => "toggleUnknownFilter()", "ng-class" => "{ 'filter-changed active': params.identified === 'false' }", title: "{{ shared.t( 'unknown' ) }}" }
                 %i{ :class => "icon-iconic-unknown" }
         .row
           .col-xs-12

--- a/app/webpack/observations/identify/components/filters_button.jsx
+++ b/app/webpack/observations/identify/components/filters_button.jsx
@@ -153,15 +153,18 @@ class FiltersButton extends React.Component {
           key={`btn-${t.name}`}
           onClick={( ) => {
             let newIconicTaxa;
+            const newParams = {};
             if ( _.includes( params.iconic_taxa, t.name ) ) {
               newIconicTaxa = _.without( params.iconic_taxa, t.name );
             } else {
               newIconicTaxa = params.iconic_taxa.map( n => n );
               newIconicTaxa.push( t.name );
             }
-            updateSearchParams( {
-              iconic_taxa: newIconicTaxa
-            } );
+            newParams.iconic_taxa = newIconicTaxa;
+            if ( params.identified === false ) {
+              newParams.identified = null;
+            }
+            updateSearchParams( newParams );
           }}
         >
           <i className={`icon-iconic-${t.name.toLowerCase( )}`} />
@@ -321,9 +324,22 @@ class FiltersButton extends React.Component {
                 { name: "Insecta", label: "insects" },
                 { name: "Plantae", label: "plants" },
                 { name: "Fungi", label: "fungi" },
-                { name: "Protozoa", label: "protozoans" },
-                { name: "unknown", label: "unknown" }
+                { name: "Protozoa", label: "protozoans" }
               ].map( iconicTaxonButton ) }
+              <Button
+                className={`iconic-taxon last${params.identified === false ? " filter-changed active" : ""}`}
+                title={I18n.t( "unknown" )}
+                key="btn-unknown"
+                onClick={( ) => {
+                  if ( params.identified === false ) {
+                    updateSearchParams( { identified: null } );
+                  } else {
+                    updateSearchParams( { iconic_taxa: [], identified: false } );
+                  }
+                }}
+              >
+                <i className="icon-iconic-unknown" />
+              </Button>
             </div>
           </Col>
         </Row>

--- a/app/webpack/observations/identify/components/filters_button.jsx
+++ b/app/webpack/observations/identify/components/filters_button.jsx
@@ -139,11 +139,15 @@ class FiltersButton extends React.Component {
       params.observationFields && _.size( params.observationFields ) > 0
     );
     const iconicTaxonButton = ( t, i ) => {
+      const isUnknown = t.name === "unknown";
       let cssClass = "iconic-taxon";
       if ( ( i + 1 ) % 6 === 0 ) {
         cssClass += " last";
       }
-      if ( _.includes( params.iconic_taxa, t.name ) ) {
+      const isActive = isUnknown
+        ? params.identified === false
+        : _.includes( params.iconic_taxa, t.name );
+      if ( isActive ) {
         cssClass += " filter-changed active";
       }
       return (
@@ -152,19 +156,27 @@ class FiltersButton extends React.Component {
           title={I18n.t( `all_taxa.${t.label}`, { defaultValue: I18n.t( t.label ) } )}
           key={`btn-${t.name}`}
           onClick={( ) => {
-            let newIconicTaxa;
-            const newParams = {};
-            if ( _.includes( params.iconic_taxa, t.name ) ) {
-              newIconicTaxa = _.without( params.iconic_taxa, t.name );
+            if ( isUnknown ) {
+              if ( params.identified === false ) {
+                updateSearchParams( { identified: null } );
+              } else {
+                updateSearchParams( { iconic_taxa: [], identified: false } );
+              }
             } else {
-              newIconicTaxa = params.iconic_taxa.map( n => n );
-              newIconicTaxa.push( t.name );
+              let newIconicTaxa;
+              const newParams = {};
+              if ( _.includes( params.iconic_taxa, t.name ) ) {
+                newIconicTaxa = _.without( params.iconic_taxa, t.name );
+              } else {
+                newIconicTaxa = params.iconic_taxa.map( n => n );
+                newIconicTaxa.push( t.name );
+              }
+              newParams.iconic_taxa = newIconicTaxa;
+              if ( params.identified === false ) {
+                newParams.identified = null;
+              }
+              updateSearchParams( newParams );
             }
-            newParams.iconic_taxa = newIconicTaxa;
-            if ( params.identified === false ) {
-              newParams.identified = null;
-            }
-            updateSearchParams( newParams );
           }}
         >
           <i className={`icon-iconic-${t.name.toLowerCase( )}`} />
@@ -324,22 +336,9 @@ class FiltersButton extends React.Component {
                 { name: "Insecta", label: "insects" },
                 { name: "Plantae", label: "plants" },
                 { name: "Fungi", label: "fungi" },
-                { name: "Protozoa", label: "protozoans" }
+                { name: "Protozoa", label: "protozoans" },
+                { name: "unknown", label: "unknown" }
               ].map( iconicTaxonButton ) }
-              <Button
-                className={`iconic-taxon last${params.identified === false ? " filter-changed active" : ""}`}
-                title={I18n.t( "unknown" )}
-                key="btn-unknown"
-                onClick={( ) => {
-                  if ( params.identified === false ) {
-                    updateSearchParams( { identified: null } );
-                  } else {
-                    updateSearchParams( { iconic_taxa: [], identified: false } );
-                  }
-                }}
-              >
-                <i className="icon-iconic-unknown" />
-              </Button>
             </div>
           </Col>
         </Row>


### PR DESCRIPTION
This fixes a UX bug where selecting an "unknown" taxa on the discover or identify pages returned viruses and bacteria because they are not "iconic" tax. Now this button will return only observations with no identifications.