### PR TITLE
fix: Fix header overflow on smaller screens, WEB-1026

### DIFF
--- a/app/assets/stylesheets/_breakpoints.scss
+++ b/app/assets/stylesheets/_breakpoints.scss
@@ -1,5 +1,14 @@
-// Shared responsive breakpoints
-// Use $mobile-max  for max-width queries (mobile styles apply ≤ 767px)
-// Use $desktop-min for min-width queries (desktop styles apply ≥ 768px)
 $mobile-max:  767px;
 $desktop-min: 768px;
+
+$sm:  576px;
+$md:  768px;
+$lg:  992px;
+$xl:  1200px;
+$xxl: 1400px;
+
+$sm-max:  575.98px;
+$md-max:  767.98px;
+$lg-max:  991.98px;
+$xl-max:  1199.98px;
+$xxl-max: 1399.98px;

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -2527,6 +2527,9 @@ body:not(.responsive) {
 }
 
 @mixin header-narrow-menu {
+  .search {
+    flex: 1;
+  }
   #narrow-menu {
     display: flex;
     align-items: center;

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -2216,6 +2216,7 @@ $header-line-height: 34px;
   .search {
     margin-bottom: 0;
     margin-right: 10px;
+    min-width: 0;
     display: -webkit-box;
     display: -webkit-flex;
     display: -moz-box;
@@ -2569,7 +2570,7 @@ body:not(.responsive) {
   }
 }
 
-@media (min-width: $md) and (max-width: $xl-max) {
+@media (max-width: $xl-max) {
   body.responsive #header {
     @include header-narrow-menu;
     #mainnav {
@@ -2586,8 +2587,7 @@ body:not(.responsive) {
       margin-right: 15px;
     }
     #header {
-      @include header-narrow-menu;
-      #headersearch, #mainnav {
+      #headersearch {
         display: none;
       }
       #messagesnav, #updatesnav {

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -2144,21 +2144,10 @@ $header-line-height: 34px;
       }
     }
   }
-  @media (min-width: 992px) and (max-width: 1199.99px) {
+  @media (min-width: $lg) and (max-width: $xl-max) {
     .header-md { display: inline-block; }
     .dropdown-menu {
       .header-md { display: block; }
-    }
-    &.search-open {
-      .header-md { display: none; }
-      .header-xs { display: inline-block; }
-      .dropdown-menu {
-        .header-xs { display: block; }
-      }
-      .btn-focus {
-        font-size: 15px !important;
-        padding: 6px 7px !important;
-      }
     }
   }
   @media (min-width: 1200px) {
@@ -2537,6 +2526,55 @@ body:not(.responsive) {
   }
 }
 
+@mixin header-narrow-menu {
+  #narrow-menu {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    .dropdown .dropdown-toggle i {
+      font-size: 20px;
+    }
+    .submenu {
+      .submenu-toggle-indicator {
+        padding-left: 5px;
+        display: inline-block;
+      }
+      &.closed {
+        ul {
+          display: none;
+        }
+      }
+      ul {
+        display: block;
+        list-style: none;
+        padding-inline-start: 0px;
+      }
+      li {
+        a:focus, a:hover {
+          text-decoration: none;
+          background-color: #f5f5f5;
+        }
+        a {
+          display: block;
+          padding: 3px 20px;
+          clear: both;
+          line-height: 1.42857143;
+          padding-inline-start: 40px;
+        }
+      }
+    }
+  }
+}
+
+@media (min-width: $md) and (max-width: $xl-max) {
+  body.responsive #header {
+    @include header-narrow-menu;
+    #mainnav {
+      display: none;
+    }
+  }
+}
+
 @media (max-width: $mobile-max) {
   body.responsive {
     .container {
@@ -2545,43 +2583,7 @@ body:not(.responsive) {
       margin-right: 15px;
     }
     #header {
-      #narrow-menu {
-        display: flex;
-        align-items: center;
-        white-space: nowrap;
-        .dropdown .dropdown-toggle i {
-          font-size: 20px;
-        }
-        .submenu {
-          .submenu-toggle-indicator {
-            padding-left: 5px;
-            display: inline-block;
-          }
-          &.closed {
-            ul {
-              display: none;
-            }
-          }
-          ul {
-            display: block;
-            list-style: none;
-            padding-inline-start: 0px;
-          }
-          li {
-            a:focus, a:hover {
-              text-decoration: none;
-              background-color: #f5f5f5;
-            }
-            a {
-              display: block;
-              padding: 3px 20px;
-              clear: both;
-              line-height: 1.42857143;
-              padding-inline-start: 40px;
-            }
-          }
-        }
-      }
+      @include header-narrow-menu;
       #headersearch, #mainnav {
         display: none;
       }

--- a/app/assets/stylesheets/welcome_v2.scss
+++ b/app/assets/stylesheets/welcome_v2.scss
@@ -79,6 +79,21 @@ $letter-spacing-tight: -0.03em;
   }
 }
 
+// Between md and xl: keep mainnav visible and hide the hamburger menu
+@media (min-width: $md) and (max-width: $xl-max) {
+  body.responsive #header {
+    #mainnav { display: flex; }
+    #narrow-menu { display: none; }
+  }
+}
+
+// Below md: logonav fills remaining space (mirrors the global mobile rule)
+@media (max-width: $md-max) {
+  body.responsive #header {
+    #logonav { flex: 1; }
+  }
+}
+
 // ── All component rules scoped under .wv2 to beat .bootstrap p specificity ───
 
 .wv2 {

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -43,6 +43,7 @@
               %li= link_to t( :video_tutorials ), @site.video_tutorials_url
             - if !@site&.curator_guide_url.blank?
               %li= link_to t( :curator_guide ), @site.curator_guide_url
+            %li= link_to t( :donate_ ), donate_url( utm_content: "header-more" )
 
   #logonav.navtabs
     - if site && !site.custom_logo.blank?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,16 @@ Rails.application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
-  config.eager_load = false
+  # Normally the test env autoloads lazily (false) for fast RSpec boots. But the
+  # e2e suite boots a live, multi-threaded Puma (`rails server -e test`), and this
+  # app still uses the classic autoloader (`config.load_defaults 5.0`), which is
+  # NOT thread-safe. Concurrent requests then race while synthesizing implicit
+  # namespace modules like `Users` (which spans app/controllers/users,
+  # app/webpack/users, ...), producing "already initialized constant Users" and
+  # "Unable to autoload constant Users::SessionsController" LoadErrors. Eager
+  # loading at boot (single-threaded) loads every constant before any request, so
+  # no thread ever autoloads at request time. Enabled only for the e2e server.
+  config.eager_load = ENV["E2E_EAGER_LOAD"] == "true"
 
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true

--- a/spec/e2e/app_commands/add_test_group.rb
+++ b/spec/e2e/app_commands/add_test_group.rb
@@ -1,0 +1,9 @@
+# Adds a user to one or more test groups, bypassing model validations (some
+# groups, e.g. "responsive-header", are admin-only and can't be set on a plain
+# factory user). Used by e2e specs that exercise gated features.
+#
+#   app( "add_test_group", { user_id: 1, test_groups: "responsive-header" } )
+user = User.find( command_options["user_id"] )
+groups = ( user.test_groups.to_s.split( "|" ) + Array( command_options["test_groups"] ) ).uniq
+user.update_column( :test_groups, groups.join( "|" ) )
+[user.test_groups]

--- a/spec/e2e/playwright/helpers/overflow.helper.ts
+++ b/spec/e2e/playwright/helpers/overflow.helper.ts
@@ -1,0 +1,58 @@
+import { test, expect, Page } from "@playwright/test";
+import { BREAKPOINTS, BreakpointName, VIEWPORTS } from "../../shared/breakpoints";
+
+/**
+ * Measure how far the document body extends horizontally versus the active
+ * browser viewport. `bodyWidth` uses `scrollWidth` so content that spills past
+ * the body's own box (the signature of horizontal overflow) is counted, and is
+ * compared against `window.innerWidth` — the viewport width the user actually
+ * sees, scrollbar excluded.
+ */
+async function measureHorizontalOverflow(
+  page: Page
+): Promise<{ bodyWidth: number; viewportWidth: number }> {
+  return page.evaluate( () => ( {
+    bodyWidth: document.body.scrollWidth,
+    viewportWidth: window.innerWidth
+  } ) );
+}
+
+/**
+ * Assert that the document body does not overflow the viewport horizontally at
+ * every responsive breakpoint. For each tier this sets the representative
+ * viewport, (re)loads `path`, and checks that the body is no wider than the
+ * viewport. A 1px tolerance absorbs sub-pixel rounding.
+ *
+ * Use this in a spec's top level (it registers one `test` per breakpoint):
+ *
+ *   import { expectNoHorizontalOverflowAtEveryBreakpoint } from "../../helpers/overflow.helper";
+ *   expectNoHorizontalOverflowAtEveryBreakpoint( "/" );
+ */
+export function expectNoHorizontalOverflowAtEveryBreakpoint(
+  path = "/",
+  options: { waitForSelector?: string } = {}
+): void {
+  test.describe( "no horizontal overflow", () => {
+    for ( const name of Object.keys( VIEWPORTS ) as BreakpointName[] ) {
+      const viewport = VIEWPORTS[name];
+
+      test( `the document body does not overflow the viewport at the ${name} breakpoint (${viewport.width}px)`, async ( { page } ) => {
+        await page.setViewportSize( viewport );
+        await page.goto( path );
+        await page.locator( options.waitForSelector || "#header" ).waitFor();
+
+        const { bodyWidth, viewportWidth } = await measureHorizontalOverflow( page );
+
+        // Sanity-check the viewport actually matches the tier we set, so a
+        // failure points at overflow rather than a missized window.
+        expect( viewportWidth ).toBeGreaterThanOrEqual( BREAKPOINTS[name].minWidth );
+
+        // Allow 1px for sub-pixel rounding.
+        expect(
+          bodyWidth,
+          `body (${bodyWidth}px) overflows the ${name} viewport (${viewportWidth}px)`
+        ).toBeLessThanOrEqual( viewportWidth + 1 );
+      } );
+    }
+  } );
+}

--- a/spec/e2e/playwright/helpers/overflow.helper.ts
+++ b/spec/e2e/playwright/helpers/overflow.helper.ts
@@ -1,13 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { BREAKPOINTS, BreakpointName, VIEWPORTS } from "../../shared/breakpoints";
 
-/**
- * Measure how far the document body extends horizontally versus the active
- * browser viewport. `bodyWidth` uses `scrollWidth` so content that spills past
- * the body's own box (the signature of horizontal overflow) is counted, and is
- * compared against `window.innerWidth` — the viewport width the user actually
- * sees, scrollbar excluded.
- */
 async function measureHorizontalOverflow(
   page: Page
 ): Promise<{ bodyWidth: number; viewportWidth: number }> {
@@ -17,18 +10,7 @@ async function measureHorizontalOverflow(
   } ) );
 }
 
-/**
- * Assert that the document body does not overflow the viewport horizontally at
- * every responsive breakpoint. For each tier this sets the representative
- * viewport, (re)loads `path`, and checks that the body is no wider than the
- * viewport. A 1px tolerance absorbs sub-pixel rounding.
- *
- * Use this in a spec's top level (it registers one `test` per breakpoint):
- *
- *   import { expectNoHorizontalOverflowAtEveryBreakpoint } from "../../helpers/overflow.helper";
- *   expectNoHorizontalOverflowAtEveryBreakpoint( "/" );
- */
-export function expectNoHorizontalOverflowAtEveryBreakpoint(
+export function expectNoHorizontalOverflow(
   path = "/",
   options: { waitForSelector?: string } = {}
 ): void {
@@ -43,11 +25,8 @@ export function expectNoHorizontalOverflowAtEveryBreakpoint(
 
         const { bodyWidth, viewportWidth } = await measureHorizontalOverflow( page );
 
-        // Sanity-check the viewport actually matches the tier we set, so a
-        // failure points at overflow rather than a missized window.
         expect( viewportWidth ).toBeGreaterThanOrEqual( BREAKPOINTS[name].minWidth );
 
-        // Allow 1px for sub-pixel rounding.
         expect(
           bodyWidth,
           `body (${bodyWidth}px) overflows the ${name} viewport (${viewportWidth}px)`

--- a/spec/e2e/playwright/playwright.config.ts
+++ b/spec/e2e/playwright/playwright.config.ts
@@ -11,14 +11,15 @@ export default defineConfig( {
     url: "http://localhost:3001/ping",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
-    env: { RAILS_ENV: "test" },
+    // Eager-load the app: the classic autoloader is not thread-safe, and the
+    // live multi-threaded Puma races on lazy autoloads otherwise. See test.rb.
+    env: { RAILS_ENV: "test", E2E_EAGER_LOAD: "true" },
     cwd: path.resolve( __dirname, "../../.." )
   },
   testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
   reporter: process.env.CI ? "html" : "list",
   timeout: 30_000,
   expect: {

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from "@playwright/test";
 import { login } from "../../helpers/auth.helper";
 import { app, appMake } from "../../support/on-rails";
 import { VIEWPORTS } from "../../../shared/breakpoints";
-import { expectNoHorizontalOverflowAtEveryBreakpoint } from "../../helpers/overflow.helper";
+import { expectNoHorizontalOverflow } from "../../helpers/overflow.helper";
 
 const TEST_PASSWORD = "TestPass123!";
 
@@ -103,7 +103,19 @@ test.describe( "Header navigation parity (desktop)", () => {
   } );
 } );
 
-expectNoHorizontalOverflowAtEveryBreakpoint( "/" );
+expectNoHorizontalOverflow( "/" );
+
+test.describe( "Header at the sm breakpoint (logged in)", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.sm );
+    await page.goto( "/" );
+    await page.locator( "#header .add-obs" ).waitFor();
+  } );
+
+  test( "upload button text is not visible", async ( { page } ) => {
+    await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeHidden();
+  } );
+} );
 
 test.describe( "Header at the md breakpoint (logged in)", () => {
   test.beforeEach( async ( { page } ) => {
@@ -131,17 +143,5 @@ test.describe( "Header at the lg breakpoint (logged in)", () => {
 
   test( "upload button text is visible", async ( { page } ) => {
     await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeVisible();
-  } );
-} );
-
-test.describe( "Header at the sm breakpoint (logged in)", () => {
-  test.beforeEach( async ( { page } ) => {
-    await page.setViewportSize( VIEWPORTS.sm );
-    await page.goto( "/" );
-    await page.locator( "#header .add-obs" ).waitFor();
-  } );
-
-  test( "upload button text is not visible", async ( { page } ) => {
-    await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeHidden();
   } );
 } );

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -11,21 +11,6 @@ const TEST_PASSWORD = "TestPass123!";
 // user is added to it (which also makes pages render with body.responsive).
 let testEmail: string;
 
-test.beforeAll( async () => {
-  const user = await appMake( "create", "user", { password: TEST_PASSWORD } );
-  testEmail = user.email as string;
-  await app( "add_test_group", { user_id: user.id, test_groups: "responsive-header" } );
-} );
-
-test.beforeEach( async ( { page } ) => {
-  await login( page, testEmail, TEST_PASSWORD );
-} );
-
-/**
- * Top-level menu labels for #mainnav and the #narrow-menu (hamburger). For a
- * dropdown tab (Community, More) the label is the toggle/anchor text only,
- * not the nested submenu items.
- */
 async function menuLabels( page: Page ): Promise<{ mainnav: string[]; hamburger: string[] }> {
   return page.evaluate( () => {
     const norm = ( s: string | null ) => ( s || "" ).replace( /\s+/g, " " ).trim();
@@ -47,6 +32,16 @@ async function menuLabels( page: Page ): Promise<{ mainnav: string[]; hamburger:
     return { mainnav, hamburger };
   } );
 }
+
+test.beforeAll( async () => {
+  const user = await appMake( "create", "user", { password: TEST_PASSWORD } );
+  testEmail = user.email as string;
+  await app( "add_test_group", { user_id: user.id, test_groups: "responsive-header" } );
+} );
+
+test.beforeEach( async ( { page } ) => {
+  await login( page, testEmail, TEST_PASSWORD );
+} );
 
 test.describe( "Header search bar (desktop)", () => {
   test.beforeEach( async ( { page } ) => {
@@ -95,10 +90,19 @@ test.describe( "Header navigation parity (desktop)", () => {
         `"${label}" from #mainnav should also appear in the #narrow-menu hamburger menu`
       ).toContain( label );
     }
+
+    for ( const label of hamburger ) {
+      // Search is not in the mainnav when search bar active
+      if ( label !== "Search" ) {
+      expect(
+          mainnav,
+          `"${label}" from #narrow-menu hamburger menu should also appear in the #mainnav`
+        ).toContain( label );
+      }
+    }
   } );
 } );
 
-// EXPECTED TO FAIL until the WEB-1026 header-overflow fix lands.
 expectNoHorizontalOverflowAtEveryBreakpoint( "/" );
 
 test.describe( "Header at the md breakpoint (logged in)", () => {
@@ -125,7 +129,6 @@ test.describe( "Header at the lg breakpoint (logged in)", () => {
     await page.locator( "#header .add-obs" ).waitFor();
   } );
 
-  // EXPECTED TO FAIL until the WEB-1026 header-overflow fix lands.
   test( "upload button text is visible", async ( { page } ) => {
     await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeVisible();
   } );

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, Page } from "@playwright/test";
+import { login } from "../../helpers/auth.helper";
+import { app, appMake } from "../../support/on-rails";
+import { VIEWPORTS } from "../../../shared/breakpoints";
+import { expectNoHorizontalOverflowAtEveryBreakpoint } from "../../helpers/overflow.helper";
+
+const TEST_PASSWORD = "TestPass123!";
+
+// One test user for the whole file; every test logs in as this user. The
+// responsive header is gated behind the "responsive-header" test group, so the
+// user is added to it (which also makes pages render with body.responsive).
+let testEmail: string;
+
+test.beforeAll( async () => {
+  const user = await appMake( "create", "user", { password: TEST_PASSWORD } );
+  testEmail = user.email as string;
+  await app( "add_test_group", { user_id: user.id, test_groups: "responsive-header" } );
+} );
+
+test.beforeEach( async ( { page } ) => {
+  await login( page, testEmail, TEST_PASSWORD );
+} );
+
+/**
+ * Top-level menu labels for #mainnav and the #narrow-menu (hamburger). For a
+ * dropdown tab (Community, More) the label is the toggle/anchor text only,
+ * not the nested submenu items.
+ */
+async function menuLabels( page: Page ): Promise<{ mainnav: string[]; hamburger: string[] }> {
+  return page.evaluate( () => {
+    const norm = ( s: string | null ) => ( s || "" ).replace( /\s+/g, " " ).trim();
+
+    const mainnav = Array.from(
+      document.querySelectorAll( "#mainnav > li.navtab" )
+    ).map( li => {
+      const toggle = li.querySelector( ":scope > .dropdown > .dropdown-toggle" );
+      return norm( ( toggle || li ).textContent );
+    } ).filter( Boolean );
+
+    const hamburger = Array.from(
+      document.querySelectorAll( "#narrow-menu .dropdown-menu > li" )
+    ).map( li => {
+      const submenuAnchor = li.matches( ".submenu" ) ? li.querySelector( ":scope > a" ) : null;
+      return norm( ( submenuAnchor || li ).textContent );
+    } ).filter( Boolean );
+
+    return { mainnav, hamburger };
+  } );
+}
+
+test.describe( "Header search bar (desktop)", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.xl );
+    await page.goto( "/" );
+    await page.locator( "#headersearch" ).waitFor();
+  } );
+
+  test( "opens and closes via the show/hide buttons", async ( { page } ) => {
+    const search = page.locator( "#headersearch" );
+    const header = page.locator( "#header" );
+
+    // Normalize to the closed state regardless of the session default.
+    if ( await search.evaluate( el => el.classList.contains( "open" ) ) ) {
+      await page.locator( "#header .hide-btn" ).click();
+    }
+    await expect( search ).not.toHaveClass( /\bopen\b/ );
+
+    // Open
+    await page.locator( "#header .show-btn" ).click();
+    await expect( search ).toHaveClass( /\bopen\b/ );
+    await expect( header ).toHaveClass( /\bsearch-open\b/ );
+    await expect( page.locator( "#headersearch input" ) ).toBeFocused();
+
+    // Close
+    await page.locator( "#header .hide-btn" ).click();
+    await expect( search ).not.toHaveClass( /\bopen\b/ );
+    await expect( header ).not.toHaveClass( /\bsearch-open\b/ );
+  } );
+} );
+
+test.describe( "Header navigation parity (desktop)", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.xl );
+    await page.goto( "/" );
+    await page.locator( "#mainnav" ).waitFor();
+  } );
+
+  test( "every #mainnav item also exists in the hamburger menu", async ( { page } ) => {
+    const { mainnav, hamburger } = await menuLabels( page );
+
+    expect( mainnav.length ).toBeGreaterThan( 0 );
+    for ( const label of mainnav ) {
+      expect(
+        hamburger,
+        `"${label}" from #mainnav should also appear in the #narrow-menu hamburger menu`
+      ).toContain( label );
+    }
+  } );
+} );
+
+// EXPECTED TO FAIL until the WEB-1026 header-overflow fix lands.
+expectNoHorizontalOverflowAtEveryBreakpoint( "/" );
+
+test.describe( "Header at the md breakpoint (logged in)", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.md );
+    await page.goto( "/" );
+    await page.locator( "#header" ).waitFor();
+  } );
+
+  test( "the navtabs collapse into the hamburger menu while the search bar stays", async ( { page } ) => {
+    // The desktop navtabs collapse into the hamburger menu...
+    await expect( page.locator( "#mainnav" ) ).toBeHidden();
+    await expect( page.locator( "#narrow-menu" ) ).toBeVisible();
+
+    // ...but the search bar still displays in the header.
+    await expect( page.locator( "#headersearch" ) ).toBeVisible();
+  } );
+} );
+
+test.describe( "Header at the lg breakpoint (logged in)", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.lg );
+    await page.goto( "/" );
+    await page.locator( "#header .add-obs" ).waitFor();
+  } );
+
+  // EXPECTED TO FAIL until the WEB-1026 header-overflow fix lands.
+  test( "upload button text is visible", async ( { page } ) => {
+    await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeVisible();
+  } );
+} );
+
+test.describe( "Header at the sm breakpoint (logged in)", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.sm );
+    await page.goto( "/" );
+    await page.locator( "#header .add-obs" ).waitFor();
+  } );
+
+  test( "upload button text is not visible", async ( { page } ) => {
+    await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeHidden();
+  } );
+} );

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -6,9 +6,6 @@ import { expectNoHorizontalOverflow } from "../../helpers/overflow.helper";
 
 const TEST_PASSWORD = "TestPass123!";
 
-// One test user for the whole file; every test logs in as this user. The
-// responsive header is gated behind the "responsive-header" test group, so the
-// user is added to it (which also makes pages render with body.responsive).
 let testEmail: string;
 
 async function menuLabels( page: Page ): Promise<{ mainnav: string[]; hamburger: string[] }> {

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -40,6 +40,8 @@ test.beforeEach( async ( { page } ) => {
   await login( page, testEmail, TEST_PASSWORD );
 } );
 
+expectNoHorizontalOverflow( "/" );
+
 test.describe( "Header search bar (desktop)", () => {
   test.beforeEach( async ( { page } ) => {
     await page.setViewportSize( VIEWPORTS.xl );
@@ -99,8 +101,6 @@ test.describe( "Header navigation parity (desktop)", () => {
     }
   } );
 } );
-
-expectNoHorizontalOverflow( "/" );
 
 test.describe( "Header at the sm breakpoint (logged in)", () => {
   test.beforeEach( async ( { page } ) => {

--- a/spec/e2e/shared/breakpoints.ts
+++ b/spec/e2e/shared/breakpoints.ts
@@ -1,22 +1,3 @@
-/**
- * Responsive breakpoints, shared across all e2e tests.
- *
- * These mirror the Bootstrap 5 grid tiers:
- *
- *   Breakpoint    Infix    Dimensions
- *   Extra small   (none)   < 576px
- *   Small         sm       >= 576px
- *   Medium        md       >= 768px
- *   Large         lg       >= 992px
- *   Extra large   xl       >= 1200px
- *   XX-large      xxl      >= 1400px
- *
- * `minWidth` is the viewport width (px) at which a tier becomes active.
- * `VIEWPORTS` gives a representative viewport for each tier — the tier's
- * lower bound (with a sensible width for `xs`, which has no minimum) — so a
- * test can do `page.setViewportSize( VIEWPORTS.lg )`.
- */
-
 export type BreakpointName = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 
 export interface Breakpoint {

--- a/spec/e2e/shared/breakpoints.ts
+++ b/spec/e2e/shared/breakpoints.ts
@@ -1,0 +1,45 @@
+/**
+ * Responsive breakpoints, shared across all e2e tests.
+ *
+ * These mirror the Bootstrap 5 grid tiers:
+ *
+ *   Breakpoint    Infix    Dimensions
+ *   Extra small   (none)   < 576px
+ *   Small         sm       >= 576px
+ *   Medium        md       >= 768px
+ *   Large         lg       >= 992px
+ *   Extra large   xl       >= 1200px
+ *   XX-large      xxl      >= 1400px
+ *
+ * `minWidth` is the viewport width (px) at which a tier becomes active.
+ * `VIEWPORTS` gives a representative viewport for each tier — the tier's
+ * lower bound (with a sensible width for `xs`, which has no minimum) — so a
+ * test can do `page.setViewportSize( VIEWPORTS.lg )`.
+ */
+
+export type BreakpointName = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+
+export interface Breakpoint {
+  infix: string | null;
+  minWidth: number;
+}
+
+export const BREAKPOINTS: Record<BreakpointName, Breakpoint> = {
+  xs: { infix: null, minWidth: 0 },
+  sm: { infix: "sm", minWidth: 576 },
+  md: { infix: "md", minWidth: 768 },
+  lg: { infix: "lg", minWidth: 992 },
+  xl: { infix: "xl", minWidth: 1200 },
+  xxl: { infix: "xxl", minWidth: 1400 }
+};
+
+const VIEWPORT_HEIGHT = 900;
+
+export const VIEWPORTS: Record<BreakpointName, { width: number; height: number }> = {
+  xs: { width: 375, height: VIEWPORT_HEIGHT },
+  sm: { width: BREAKPOINTS.sm.minWidth, height: VIEWPORT_HEIGHT },
+  md: { width: BREAKPOINTS.md.minWidth, height: VIEWPORT_HEIGHT },
+  lg: { width: BREAKPOINTS.lg.minWidth, height: VIEWPORT_HEIGHT },
+  xl: { width: BREAKPOINTS.xl.minWidth, height: VIEWPORT_HEIGHT },
+  xxl: { width: BREAKPOINTS.xxl.minWidth, height: VIEWPORT_HEIGHT }
+};


### PR DESCRIPTION
https://linear.app/inaturalist/issue/WEB-1026/fix-header-overflow-on-smaller-screens

Hides header labels to prevent overflow. Extracts CSS that handled this for mobile size previously and made it a reusable mixin, which is used in both the tablet and mobile cases.

Added header-specific tests as well as a general horizontal overflow test that can be reused on any page.

**ALSO** allow E2E tests to run on as many works as it decides.

https://github.com/user-attachments/assets/37970b7a-a977-4d6e-8b44-d901faead84d
