### PR TITLE
web 1014 timed suspension feedback

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,11 +5,11 @@
 module ApplicationHelper
   include Ambidextrous
 
-  def t_with_fallback( new_key, old_key )
+  def t_with_fallback( new_key, old_key, ** )
     if I18n.has_t?( old_key ) && !I18n.has_t?( new_key )
-      I18n.t( old_key )
+      I18n.t( old_key, ** )
     else
-      I18n.t( new_key )
+      I18n.t( new_key, ** )
     end
   end
 

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -5,6 +5,7 @@ class Emailer < ActionMailer::Base
   helper :observations
   helper :taxa
   helper :users
+  helper :format
 
   before_action :set_x_smtpapi_headers
 

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -141,9 +141,9 @@ class Emailer < ActionMailer::Base
     return if @user.prefers_no_email?
     return if @user.email_suppressed_in_group?( EmailSuppression::TRANSACTIONAL_EMAILS )
 
-    @reason = ModeratorAction.translate_reason( reason )
+    @reason = reason
     @indefinite = suspended_until.blank?
-    @suspension_duration = ApplicationController.helpers.time_until_in_words( suspended_until ) unless @indefinite
+    @suspended_until = suspended_until
     @site_name = site_name
     mail_with_defaults(
       to: @user.email,

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -126,6 +126,7 @@ class Emailer < ActionMailer::Base
 
     @reason = reason
     @site_name = site_name
+    @x_smtpapi_headers[:asm_group_id] = CONFIG.sendgrid&.asm_group_ids&.account
     mail_with_defaults(
       to: @user.email,
       subject: [:user_unsuspended_email_subject, { prefix: subject_prefix }]
@@ -142,6 +143,7 @@ class Emailer < ActionMailer::Base
     @indefinite = suspended_until.blank?
     @suspended_until = suspended_until
     @site_name = site_name
+    @x_smtpapi_headers[:asm_group_id] = CONFIG.sendgrid&.asm_group_ids&.account
     mail_with_defaults(
       to: @user.email,
       subject: [:user_suspended_email_subject, { prefix: subject_prefix }]

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -133,6 +133,24 @@ class Emailer < ActionMailer::Base
     )
   end
 
+  def user_suspended( user, reason, suspended_until )
+    return if user.blank?
+
+    @user = user
+    return if @user.email.blank?
+    return if @user.prefers_no_email?
+    return if @user.email_suppressed_in_group?( EmailSuppression::TRANSACTIONAL_EMAILS )
+
+    @reason = ModeratorAction.translate_reason( reason )
+    @indefinite = suspended_until.blank?
+    @suspension_duration = ApplicationController.helpers.time_until_in_words( suspended_until ) unless @indefinite
+    @site_name = site_name
+    mail_with_defaults(
+      to: @user.email,
+      subject: [:user_suspended_email_subject, { prefix: subject_prefix }]
+    )
+  end
+
   # Send the user an email saying the bulk observation import encountered
   # an error.
   def bulk_observation_error( user, filename, error_details )

--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -123,8 +123,6 @@ class Emailer < ActionMailer::Base
 
     @user = user
     return if @user.email.blank?
-    return if @user.prefers_no_email?
-    return if @user.email_suppressed_in_group?( EmailSuppression::TRANSACTIONAL_EMAILS )
 
     @reason = reason
     @site_name = site_name
@@ -139,8 +137,6 @@ class Emailer < ActionMailer::Base
 
     @user = user
     return if @user.email.blank?
-    return if @user.prefers_no_email?
-    return if @user.email_suppressed_in_group?( EmailSuppression::TRANSACTIONAL_EMAILS )
 
     @reason = reason
     @indefinite = suspended_until.blank?

--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -15,7 +15,7 @@ class ModeratorAction < ApplicationRecord
   ].freeze
   MINIMUM_REASON_LENGTH = 10
   MAXIMUM_REASON_LENGTH = 2048
-  MAXIMUM_SUSPEND_REASON_LENGTH = 100
+  MAXIMUM_SUSPEND_REASON_LENGTH = 250
 
   SUSPENSION_REASONS = {
     "insults_or_threats" => { default_duration: "1_day" },

--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -20,13 +20,13 @@ class ModeratorAction < ApplicationRecord
   SUSPENSION_REASONS = {
     "insults_or_threats" => { default_duration: "1_day" },
     "hate_speech" => { default_duration: "3_days" },
-    "sexually_explicit_content" => { default_duration: "indefinite" },
-    "sockpuppet_accounts" => { default_duration: "1_week" },
-    "false_ids_or_dqa_votes" => { default_duration: "1_day" },
-    "machine_generated_content" => { default_duration: "indefinite" },
-    "continued_copyright_infringement_after_warning" => { default_duration: "1_day" },
+    "posting_sexually_explicit_human_content" => { default_duration: "indefinite" },
+    "misusing_a_second_account" => { default_duration: "1_week" },
+    "intentionally_adding_false_data" => { default_duration: "1_day" },
+    "adding_machine_generated_content" => { default_duration: "indefinite" },
+    "continued_posting_media_without_owners_permission_after_warning" => { default_duration: "1_day" },
     "continued_posting_of_artificially_generated_media_after_warning" => { default_duration: "1_day" },
-    "continued_reduction_of_data_quality_after_warning" => { default_duration: "3_days" }
+    "continued_reduction_of_data_quality_such_as_incorrect_ids_after_warning" => { default_duration: "3_days" }
   }.freeze
 
   PRIVATE_MEDIA_RETENTION_TIME = 2.months

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1821,8 +1821,9 @@ class User < ApplicationRecord
         suspend!( moderator_action.reason )
       end
     elsif moderator_action.action == ModeratorAction::UNSUSPEND
+      email_reason = suspended_until.present? ? suspension_reason : moderator_action.reason
       unsuspend!
-      send_unsuspended_email( moderator_action.reason )
+      send_unsuspended_email( email_reason )
     elsif moderator_action.action == ModeratorAction::RENAME
       new_login = User.suggest_login( User::DEFAULT_LOGIN )
       self.login = new_login

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1585,6 +1585,10 @@ class User < ApplicationRecord
       resend_unsent_for_user( id )
   end
 
+  def send_suspended_email( reason, suspended_until )
+    Emailer.delay.user_suspended( self, reason, suspended_until )
+  end
+
   def send_unsuspended_email( reason = nil )
     Emailer.delay.user_unsuspended( self, reason )
   end
@@ -1820,6 +1824,7 @@ class User < ApplicationRecord
         self.suspended_by_user = moderator_action.user
         suspend!( moderator_action.reason )
       end
+      send_suspended_email( moderator_action.reason, moderator_action.suspended_until )
     elsif moderator_action.action == ModeratorAction::UNSUSPEND
       email_reason = suspended_until.present? ? suspension_reason : moderator_action.reason
       unsuspend!

--- a/app/views/emailer/user_suspended.html.haml
+++ b/app/views/emailer/user_suspended.html.haml
@@ -1,0 +1,18 @@
+%p<>
+  = succeed "," do
+    = t(:hi_user, user: @user.name.blank? ? @user.login : @user.name)
+- if @indefinite
+  %p<>
+    = t("views.emailer.user_suspended.message_indefinite", reason: @reason)
+- else
+  %p<>
+    = t("views.emailer.user_suspended.message_timed", reason: @reason, duration: @suspension_duration)
+%p<>
+  = t("views.emailer.user_suspended.appeal_html", |
+    contact_us_url: "https://help.inaturalist.org/support/tickets/new" |
+  ) |
+%p<>
+  = t("views.emailer.user_suspended.abide_html", |
+    community_guidelines_url: "https://www.inaturalist.org/pages/community+guidelines", |
+    terms_of_use_url: "https://www.inaturalist.org/pages/terms" |
+  ) |

--- a/app/views/emailer/user_suspended.html.haml
+++ b/app/views/emailer/user_suspended.html.haml
@@ -1,12 +1,16 @@
+- translated_reason = ModeratorAction.translate_reason( @reason )
 %p<>
   = succeed "," do
     = t(:hi_user, user: @user.name.blank? ? @user.login : @user.name)
 - if @indefinite
   %p<>
-    = t("views.emailer.user_suspended.message_indefinite", reason: @reason)
+    = t("views.emailer.user_suspended.message_indefinite", reason: translated_reason)
 - else
   %p<>
-    = t("views.emailer.user_suspended.message_timed", reason: @reason, duration: @suspension_duration)
+    = t("views.emailer.user_suspended.message_timed", |
+      reason: translated_reason, |
+      duration: ApplicationController.helpers.time_until_in_words( @suspended_until ) |
+    ) |
 %p<>
   = t("views.emailer.user_suspended.appeal_html", |
     contact_us_url: "https://help.inaturalist.org/support/tickets/new" |

--- a/app/views/emailer/user_suspended.html.haml
+++ b/app/views/emailer/user_suspended.html.haml
@@ -9,7 +9,7 @@
   %p<>
     = t("views.emailer.user_suspended.message_timed", |
       reason: translated_reason, |
-      duration: ApplicationController.helpers.time_until_in_words( @suspended_until ) |
+      duration: time_until_in_words( @suspended_until ) |
     ) |
 %p<>
   = t("views.emailer.user_suspended.appeal_html", |

--- a/app/views/emailer/user_unsuspended.html.haml
+++ b/app/views/emailer/user_unsuspended.html.haml
@@ -2,7 +2,7 @@
   = succeed "," do
     = t(:hi_user, user: @user.name.blank? ? @user.login : @user.name)
 %p<>
-  = t("views.emailer.user_unsuspended.message_2", site_name: @site_name)
+  = t_with_fallback("views.emailer.user_unsuspended.message_2", "views.emailer.user_unsuspended.message", site_name: @site_name)
 - if @reason.present?
   %p<>
     = t("views.emailer.user_unsuspended.reason", reason: ModeratorAction.translate_reason( @reason ))

--- a/app/views/emailer/user_unsuspended.html.haml
+++ b/app/views/emailer/user_unsuspended.html.haml
@@ -5,7 +5,7 @@
   = t("views.emailer.user_unsuspended.message", site_name: @site_name)
 - if @reason.present?
   %p<>
-    = t("views.emailer.user_unsuspended.reason", reason: @reason)
+    = t("views.emailer.user_unsuspended.reason", reason: ModeratorAction.translate_reason( @reason ))
 %p<>
   = t("views.emailer.user_unsuspended.please_abide_html", |
     community_guidelines_url: "https://www.inaturalist.org/pages/community+guidelines", |

--- a/app/views/emailer/user_unsuspended.html.haml
+++ b/app/views/emailer/user_unsuspended.html.haml
@@ -1,4 +1,3 @@
-= render "header"
 %p<>
   = succeed "," do
     = t(:hi_user, user: @user.name.blank? ? @user.login : @user.name)
@@ -8,5 +7,11 @@
   %p<>
     = t("views.emailer.user_unsuspended.reason", reason: @reason)
 %p<>
-  = raw t("views.emailer.user_unsuspended.login_prompt", login_url: login_url)
-= render "footer"
+  = t("views.emailer.user_unsuspended.please_abide_html", |
+    community_guidelines_url: "https://www.inaturalist.org/pages/community+guidelines", |
+    terms_of_use_url: "https://www.inaturalist.org/pages/terms" |
+  ) |
+%p<>
+  = t("views.emailer.user_unsuspended.contact_us_html", |
+    contact_us_url: "https://help.inaturalist.org/support/tickets/new" |
+  ) |

--- a/app/views/emailer/user_unsuspended.html.haml
+++ b/app/views/emailer/user_unsuspended.html.haml
@@ -2,7 +2,7 @@
   = succeed "," do
     = t(:hi_user, user: @user.name.blank? ? @user.login : @user.name)
 %p<>
-  = t("views.emailer.user_unsuspended.message", site_name: @site_name)
+  = t("views.emailer.user_unsuspended.message_2", site_name: @site_name)
 - if @reason.present?
   %p<>
     = t("views.emailer.user_unsuspended.reason", reason: ModeratorAction.translate_reason( @reason ))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5773,7 +5773,7 @@ en:
     # reason displayed to users who have continued to post copyrighted material to the platform after being warned not to
     # REPLACED with continued_posting_media_without_owners_permission_after_warning below
     continued_copyright_infringement_after_warning: Continued copyright infringement (after warning)
-    # reason displayed to users who have continued to post media to the platform wihtout the media owner's permission after being warned not to
+    # reason displayed to users who have continued to post media to the platform without the media owner's permission after being warned not to
     continued_posting_media_without_owners_permission_after_warning: Continued posting media without media owner's permission (after warning)
     # reason displayed to users who have continued to post artificially generated media to the platform after being warned not to
     continued_posting_of_artificially_generated_media_after_warning: Continued posting of artificially generated media (after warning)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5750,20 +5750,38 @@ en:
     # reason displayed to users who have been suspended for posting of insults or threats
     insults_or_threats: Insults or threats
     # reason displayed to users who have been suspended for posting sexually explicit content
+    # REPLACED with posting_sexually_explicit_human_content below
     sexually_explicit_content: Sexually explicit content
+    # reason displayed to users who have been suspended for posting sexually explicit content of humans
+    posting_sexually_explicit_human_content: Posting sexually explicit human content
     # reason displayed to users who are creating false accounts to circumvent suspensions,
     # https://en.wikipedia.org/wiki/Sock_puppet_account
+    # REPLACED with misusing_a_second_account below
     sockpuppet_accounts: Sockpuppet accounts
+    # reason displayed to users who are creating false accounts to circumvent suspensions or confirm their own identifications
+    misusing_a_second_account: Misusing a second account, such as confirming your own identifications
     # reason displayed to users who have been suspended for intentionally posting false IDs or DQA votes
+    # REPLACED with intentionally_adding_false_data below
     false_ids_or_dqa_votes: Intentionally adding false IDs or DQA votes
+    # reason displayed to users who have been suspended for intentionally adding false data
+    intentionally_adding_false_data: Intentionally adding false data, such as observations, identifications, or Data Quality Assessment votes
     # reason displayed to users who have been suspended for posting machine generated content
+    # REPLACED with adding_machine_generated_content below
     machine_generated_content: Machine generated observations, identifications and comments
+    # reason displayed to users who have been suspended for posting machine generated content
+    adding_machine_generated_content: Adding machine-generated content
     # reason displayed to users who have continued to post copyrighted material to the platform after being warned not to
+    # REPLACED with continued_posting_media_without_owners_permission_after_warning below
     continued_copyright_infringement_after_warning: Continued copyright infringement (after warning)
+    # reason displayed to users who have continued to post media to the platform wihtout the media owner's permission after being warned not to
+    continued_posting_media_without_owners_permission_after_warning: Continued posting media without media owner's permission (after warning)
     # reason displayed to users who have continued to post artificially generated media to the platform after being warned not to
     continued_posting_of_artificially_generated_media_after_warning: Continued posting of artificially generated media (after warning)
     # reason displayed to users who have continued to reduce data quality on the platform after being warned not to
+    # REPLACED with continued_reduction_of_data_quality_such_as_incorrect_ids_after_warning below
     continued_reduction_of_data_quality_after_warning: Continued reduction of data quality (after warning)
+    # reason displayed to users who have continued to reduce data quality on the platform after being warned not to
+    continued_reduction_of_data_quality_such_as_incorrect_ids_after_warning: Continued reduction of data quality, such as adding incorrect identifications (after warning)
   # the time at which a users suspension ends
   suspend_until: Suspend until
   # a note telling users to select the time in their local time zone

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6574,6 +6574,8 @@ en:
     The observer has chosen to trust you with the hidden coordinates of all
     their observations.
   user_updated_an_observation_field_html: '%{user} updated a value for "%{field_name}" on an observation by %{owner}'
+  # An email subject line for an email informing a user that their account has been suspended.
+  user_suspended_email_subject: "%{prefix} Your account has been suspended"
   # An email subject line for an email informing a user that their account has been unsuspended.
   user_unsuspended_email_subject: "%{prefix} Your account has been unsuspended"
   user_wrote_html: <a href="%{url}" target="_blank">%{user}</a> wrote,
@@ -8636,6 +8638,15 @@ en:
         contact_us_html: 'If you have questions or concerns, you can <a href="%{contact_us_url}">contact us</a>.'
         # A link in an email to the login page of the website to prompt the user to login to to regain access their account after it has been unsuspended.
         login_prompt: '<a href="%{login_url}">Log in to your account</a> to continue using the site.'
+      user_suspended:
+        # A message in a suspension notification email for timed suspensions, with the reason and relative time until the suspension is lifted.
+        message_timed: "Your iNaturalist account has been suspended for the following reason: %{reason}. Your suspension will be lifted in %{duration}."
+        # A message in a suspension notification email for indefinite suspensions, with the reason.
+        message_indefinite: "Your iNaturalist account has been suspended indefinitely for the following reason: %{reason}."
+        # A paragraph in a suspension notification email telling users how to appeal and warning about sockpuppet accounts, with a link to support.
+        appeal_html: 'If you believe this suspension was made in error or would like to appeal, please <a href="%{contact_us_url}">contact iNaturalist Support</a>. Keep in mind that using other accounts to evade suspension will result in the other accounts being suspended and their public content removed.'
+        # A paragraph in a suspension notification email asking users to follow community guidelines and terms of use, with links.
+        abide_html: 'All iNaturalist community members are asked to abide by the <a href="%{community_guidelines_url}">Community Guidelines</a> and <a href="%{terms_of_use_url}">Terms of Use</a>.'
       users_updates_suspended:
         message: |
           You have been inactive on %{site_name} for a while, so we have suspended

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8625,8 +8625,15 @@ en:
       user_unsuspended:
         # A line in an email telling a user their account suspension is being lifted lifted.
         message: Your account on %{site_name} has been unsuspended and you can use the site again.
+        # A line in an email telling a user their account suspension is being lifted lifted.
+        message_2: Your account on %{site_name} has been reinstated and you can log in again.
         # A line in an email telling a user why their account was suspended, with a variable for the custom reason.
         reason: "Your account was suspended for the following reason: %{reason}"
+        # A message included in account unsuspension emails requesting that users abide by guidelines and warning of
+        # longer future suspensions.
+        please_abide_html: 'Please abide by the <a href="%{community_guidelines_url}">iNaturalist Community Guidelines</a> and <a href="%{terms_of_use_url}">Terms of Use</a>. Future violations may result in longer suspensions.'
+        # A message in account reinstatement emails telling users how to contact support, with a link.
+        contact_us_html: 'If you have questions or concerns, you can <a href="%{contact_us_url}">contact us</a>.'
         # A link in an email to the login page of the website to prompt the user to login to to regain access their account after it has been unsuspended.
         login_prompt: '<a href="%{login_url}">Log in to your account</a> to continue using the site.'
       users_updates_suspended:

--- a/spec/models/emailer_spec.rb
+++ b/spec/models/emailer_spec.rb
@@ -180,12 +180,6 @@ describe Emailer, "user_unsuspended" do
     expect( mail.body ).to be_blank
   end
 
-  it "should not deliver to a user who prefers no email" do
-    user.update( prefers_no_email: true )
-    mail = Emailer.user_unsuspended( user )
-    expect( mail.body ).to be_blank
-  end
-
   it "should include reason when provided" do
     mail = Emailer.user_unsuspended( user, "spamming" )
     expect( mail.body ).to match( /spamming/ )
@@ -226,12 +220,6 @@ describe Emailer, "user_suspended" do
 
   it "should not deliver to a user with no email" do
     user.update( email: "" )
-    mail = Emailer.user_suspended( user, "hate_speech", nil )
-    expect( mail.body ).to be_blank
-  end
-
-  it "should not deliver to a user who prefers no email" do
-    user.update( prefers_no_email: true )
     mail = Emailer.user_suspended( user, "hate_speech", nil )
     expect( mail.body ).to be_blank
   end

--- a/spec/models/emailer_spec.rb
+++ b/spec/models/emailer_spec.rb
@@ -195,6 +195,76 @@ describe Emailer, "user_unsuspended" do
     mail = Emailer.user_unsuspended( user )
     expect( mail.body ).not_to match( /Reason/ )
   end
+
+  it "should translate a predefined reason key" do
+    mail = Emailer.user_unsuspended( user, "hate_speech" )
+    expect( mail.body ).to match( /#{I18n.t( 'suspension_reasons.hate_speech' )}/ )
+  end
+
+  it "should translate reason in the user's locale" do
+    user.update( locale: "es" )
+    allow( ModeratorAction ).to receive( :translate_reason ) do | reason |
+      expect( I18n.locale.to_s ).to eq "es"
+      reason
+    end
+    Emailer.user_unsuspended( user, "hate_speech" )
+  end
+end
+
+describe Emailer, "user_suspended" do
+  let( :user ) { User.make! }
+
+  it "should work for indefinite suspension" do
+    mail = Emailer.user_suspended( user, "hate_speech", nil )
+    expect( mail.body ).not_to be_blank
+  end
+
+  it "should work for timed suspension" do
+    mail = Emailer.user_suspended( user, "hate_speech", 7.days.from_now )
+    expect( mail.body ).not_to be_blank
+  end
+
+  it "should not deliver to a user with no email" do
+    user.update( email: "" )
+    mail = Emailer.user_suspended( user, "hate_speech", nil )
+    expect( mail.body ).to be_blank
+  end
+
+  it "should not deliver to a user who prefers no email" do
+    user.update( prefers_no_email: true )
+    mail = Emailer.user_suspended( user, "hate_speech", nil )
+    expect( mail.body ).to be_blank
+  end
+
+  it "should translate a predefined reason key" do
+    mail = Emailer.user_suspended( user, "hate_speech", nil )
+    expect( mail.body ).to match( /#{I18n.t( 'suspension_reasons.hate_speech' )}/ )
+  end
+
+  it "should include custom reason text unchanged" do
+    mail = Emailer.user_suspended( user, "spamming", nil )
+    expect( mail.body ).to match( /spamming/ )
+  end
+
+  it "should include duration for timed suspensions" do
+    suspended_until = 7.days.from_now
+    mail = Emailer.user_suspended( user, "hate_speech", suspended_until )
+    expect( mail.body ).to match( /lifted/ )
+  end
+
+  it "should show indefinite message when no suspended_until" do
+    mail = Emailer.user_suspended( user, "hate_speech", nil )
+    expect( mail.body ).to match( /indefinitely/ )
+  end
+
+  it "should translate reason in the user's locale" do
+    user.update( locale: "es" )
+    allow( ModeratorAction ).to receive( :translate_reason ) do | reason |
+      expect( I18n.locale.to_s ).to eq "es"
+      reason
+    end
+    Emailer.user_suspended( user, "hate_speech", nil )
+  end
 end
 
 describe Emailer, "bulk_observation_success" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -870,29 +870,33 @@ describe User do
       expect( mail.subject ).to match( /unsuspended/ )
     end
 
-    it "includes unsuspension reason in unsuspended email for timed suspensions" do
+    it "includes suspension reason in unsuspended email for timed suspensions" do
       user = User.make!(
         suspended_at: Time.zone.now,
-        suspended_until: 7.days.from_now
+        suspended_until: 7.days.from_now,
+        suspension_reason: "they were spamming"
       )
       user.reload
       without_delay do
-        ModeratorAction.make!( action: ModeratorAction::UNSUSPEND, resource: user, reason: "they were spamming" )
+        ModeratorAction.make!( action: ModeratorAction::UNSUSPEND, resource: user )
       end
       mail = ActionMailer::Base.deliveries.last
       expect( mail.body ).to match( /spamming/ )
     end
 
-    it "does not include reason in unsuspended email from user reason" do
+    it "includes unsuspension reason in unsuspended email for indefinite suspensions" do
       user = User.make!(
         suspended_at: Time.zone.now,
         suspended_until: nil,
         suspension_reason: "historical reason"
       )
       user.reload
-      without_delay { ModeratorAction.make!( action: ModeratorAction::UNSUSPEND, resource: user ) }
+      without_delay do
+        ModeratorAction.make!( action: ModeratorAction::UNSUSPEND, resource: user, reason: "unsuspension reason" )
+      end
       mail = ActionMailer::Base.deliveries.last
       expect( mail.body ).not_to match( /historical reason/ )
+      expect( mail.body ).to match( /unsuspension reason/ )
     end
 
     it "suspends the user when given a SUSPEND action" do
@@ -1463,8 +1467,8 @@ describe User do
   describe "merge" do
     elastic_models( Observation, Identification )
 
-    let(:keeper) { make_user_with_privilege( UserPrivilege::INTERACTION ) }
-    let(:reject) { make_user_with_privilege( UserPrivilege::INTERACTION ) }
+    let( :keeper ) { make_user_with_privilege( UserPrivilege::INTERACTION ) }
+    let( :reject ) { make_user_with_privilege( UserPrivilege::INTERACTION ) }
 
     it "should move observations" do
       o = Observation.make!( user: reject )
@@ -1591,14 +1595,14 @@ describe User do
       Delayed::Worker.new.work_off
       expect( reject.project_users.count ).to eq 1
       expect( keeper.project_users.count ).to eq 0
-      expect( project.as_indexed_json[:admins].select do |admin|
+      expect( project.as_indexed_json[:admins].select do | admin |
         admin[:user_id] === reject.id && admin[:role] == "manager"
       end ).not_to be_empty
-      expect( project.as_indexed_json[:admins].map{ |a| a[:user_id] } ).not_to include( keeper.id )
+      expect( project.as_indexed_json[:admins].map {| a | a[:user_id] } ).not_to include( keeper.id )
       without_delay { keeper.merge( reject ) }
       project.reload
       expect( keeper.project_users.count ).to eq 1
-      expect( project.as_indexed_json[:admins].select do |admin|
+      expect( project.as_indexed_json[:admins].select do | admin |
         admin[:user_id] === keeper.id && admin[:role] == "manager"
       end ).not_to be_empty
     end


### PR DESCRIPTION
- **fix(WEB-1050): update max length for suspension reason**
- **fix(WEB-1049): update suspension reason strings**
- **fix(WEB-1048): update user reinstatement email copy**
- **fix: send suspension reason in reinstatement emails for timed suspensions only**
- **feat(WEB-1047): add suspended email**
- **move localization into email templates**
- **fixup! fix: send suspension reason in reinstatement emails for timed suspensions only**
