### PR TITLE
fix(WEB-1021): set tabIndex=-1 for nominate checkbox on ID modal

### DIFF
--- a/app/webpack/observations/identify/components/identification_form.jsx
+++ b/app/webpack/observations/identify/components/identification_form.jsx
@@ -98,6 +98,7 @@ class IdentificationForm extends React.Component {
               <input
                 type="checkbox"
                 id="nominate-id"
+                tabIndex={-1}
                 defaultChecked={nominate}
                 disabled={_.size( content ) === 0}
                 onChange={e => {

--- a/app/webpack/observations/show/components/activity_create_panel.jsx
+++ b/app/webpack/observations/show/components/activity_create_panel.jsx
@@ -198,6 +198,7 @@ class ActivityCreatePanel extends React.Component {
                   onChange={e => {
                     setNominateOnSubmit( e.target.checked );
                   }}
+                  tabIndex={-1}
                 />
                 <label
                   className="identificationNomination"


### PR DESCRIPTION
Prevents tab navigating through the add identification modal from selecting the `Nominate as an ID Tip (diagnostic characteristics that teach others to identify this organism)` checkbox.

Test this out at `/observations/identify`

<img width="652" height="295" alt="image" src="https://github.com/user-attachments/assets/5dd37a3d-142a-4590-b957-82e8f5e094f0" />
