### PR TITLE
My sites filter on announcements index

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -4,6 +4,7 @@ class AnnouncementsController < ApplicationController
   before_action :authenticate_user!, except: [:active]
   before_action :site_admin_required, except: [:active, :dismiss]
   before_action :load_announcement, only: [:show, :edit, :update, :destroy, :dismiss, :duplicate]
+  before_action :ensure_can_edit_announcement, only: [:edit, :update, :destroy]
   before_action :load_sites, only: [:new, :edit, :create, :update, :duplicate]
   before_action :load_oauth_applications, only: [:new, :edit, :create, :update, :duplicate]
   before_action :load_parent_announcement_options, only: [:new, :edit, :create, :update, :duplicate]
@@ -14,7 +15,9 @@ class AnnouncementsController < ApplicationController
   # GET /announcements.xml
   def index
     @announcements = Announcement.includes( :sites ).order( "announcements.id desc" ).page( params[:page] )
-    @announcements = @announcements.where( sites: { id: current_user_site_ids } ) unless current_user_site_ids.blank?
+    if current_user_site_ids.present? && params[:site_filter] != "all"
+      @announcements = @announcements.where( sites: { id: current_user_site_ids } )
+    end
     @announcements = @announcements.where( "body ilike ?", "%#{params[:q]}%" ) unless params[:q].blank?
     @active = params[:active].yesish?
     @announcements = @announcements.where( "\"end\" > ?", Time.now ) if @active
@@ -133,6 +136,28 @@ class AnnouncementsController < ApplicationController
 
   def current_user_site_ids
     @current_user_site_ids ||= current_user.site_admins.pluck( :site_id )
+  end
+
+  def announcement_editable_by_current_user?( announcement = @announcement )
+    return true if current_user.is_admin?
+    return false if current_user_site_ids.blank?
+
+    announcement.site_ids.intersect?( current_user_site_ids )
+  end
+  helper_method :announcement_editable_by_current_user?, :current_user_site_ids
+
+  def ensure_can_edit_announcement
+    return if announcement_editable_by_current_user?
+
+    respond_to do | format |
+      format.html do
+        flash[:error] = t( :you_dont_have_permission_to_edit_that_announcement )
+        redirect_to @announcement
+      end
+      format.json do
+        render status: :forbidden, json: { error: t( :you_dont_have_permission_to_edit_that_announcement ) }
+      end
+    end
   end
 
   def load_announcement

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -18,7 +18,12 @@ class AnnouncementsController < ApplicationController
     if current_user_site_ids.present? && params[:site_filter] != "all"
       @announcements = @announcements.where( sites: { id: current_user_site_ids } )
     end
-    @announcements = @announcements.where( "body ilike ?", "%#{params[:q]}%" ) unless params[:q].blank?
+    unless params[:q].blank?
+      sanitized_q = Announcement.sanitize_sql_like( params[:q] )
+      @announcements = @announcements.where(
+        "body ilike ?", "%#{sanitized_q}%"
+      )
+    end
     @active = params[:active].yesish?
     @announcements = @announcements.where( "\"end\" > ?", Time.now ) if @active
     @placement = params[:placement] if Announcement::PLACEMENTS.include?( params[:placement] )

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -31,6 +31,10 @@
             %label
               = check_box_tag :active, !@active, @active, data: { autosubmit: true }
               =t :active
+          - unless current_user_site_ids.blank?
+            .form-group
+              %label{ for: "site_filter" }=t :sites
+              = select_tag :site_filter, options_for_select( [[t( :my_site ), nil], [t( :all ), "all"]], params[:site_filter] ), class: "form-control", id: "site_filter", data: { autosubmit: true }
         = form_tag url_for, method: :get do
           = hidden_fields_for_params
           .input-group
@@ -80,9 +84,10 @@
                 = link_to announcement, class: "btn btn-default btn-sm" do
                   %i.fa.fa-eye
                   = t(:show)
-              %td
-                = link_to edit_announcement_path(announcement), class: "btn btn-default btn-sm" do
-                  %i.fa.fa-pencil
-                  = t(:edit)
+              - if announcement_editable_by_current_user?( announcement )
+                %td
+                  = link_to edit_announcement_path(announcement), class: "btn btn-default btn-sm" do
+                    %i.fa.fa-pencil
+                    = t(:edit)
       = will_paginate @announcements
       = link_to t(:new_announcement), new_announcement_path, class: "btn btn-primary"

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -84,10 +84,9 @@
                 = link_to announcement, class: "btn btn-default btn-sm" do
                   %i.fa.fa-eye
                   = t(:show)
-              - if announcement_editable_by_current_user?( announcement )
-                %td
-                  = link_to edit_announcement_path(announcement), class: "btn btn-default btn-sm" do
-                    %i.fa.fa-pencil
-                    = t(:edit)
+              %td
+                = link_to edit_announcement_path(announcement), disabled: !announcement_editable_by_current_user?( announcement ), class: "btn btn-default btn-sm" do
+                  %i.fa.fa-pencil
+                  = t(:edit)
       = will_paginate @announcements
       = link_to t(:new_announcement), new_announcement_path, class: "btn btn-primary"

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -76,9 +76,10 @@
       = link_to duplicate_announcement_path( @announcement ), class: "btn btn-default pull-right btn-spacer-left" do
         %i.fa.fa-copy
         = t :duplicate_verb
-      = link_to edit_announcement_path( @announcement ), class: "btn btn-primary pull-right" do
-        %i.fa.fa-pencil
-        = t :edit
+      - if announcement_editable_by_current_user?
+        = link_to edit_announcement_path( @announcement ), class: "btn btn-primary pull-right" do
+          %i.fa.fa-pencil
+          = t :edit
       %h2=t :bold_label_colon_value_html, label: t( "activerecord.models.announcement" ), value: @announcement.id
       .row
         - meta_attributes.in_groups( 3 ) do | group |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3480,6 +3480,8 @@ en:
   muted_users: Muted Users
   muting_description: Muting someone prevents you from being notified about any of their activity,
     including "@" mentions, messages, or comments and identifications on your observations.
+  # Label for the default site filter option on the announcements index, showing only announcements for the admin's site
+  my_site: My Site
   n_ago: "%{n} ago"
   n_people_agrees: "%{amount} people agree"
   n_people_disagrees: "%{amount} people disagree"
@@ -7009,6 +7011,8 @@ en:
   you_didnt_select_any_photos_to_tag: You didn't select any photos to tag!
   you_dont_have_permission_to_do_that: You don't have permission to do that.
   you_dont_have_permission_to_edit_that_observation: "You don't have permission to edit that observation."
+  # Error message shown when a site admin tries to edit an announcement that is not targeted to their site
+  you_dont_have_permission_to_edit_that_announcement: You don't have permission to edit that announcement.
   you_dont_have_permission_to_edit_that_project: You don't have permission to edit that project.
   you_dont_have_permission_to_edit_that_taxon: |
     You don't have permission to edit that taxon. Please contact one of the

--- a/spec/controllers/announcements_controller_api_spec.rb
+++ b/spec/controllers/announcements_controller_api_spec.rb
@@ -372,7 +372,7 @@ describe AnnouncementsController do
 
     it "includes current parent even when older than 30 days" do
       old_parent = create :announcement, start: 60.days.ago, end: 31.days.ago
-      child = create :announcement, parent_announcement_id: old_parent.id
+      child = create :announcement, parent_announcement_id: old_parent.id, sites: [site]
       get :edit, params: { id: child.id, inat_site_id: site.id }
       option_ids = assigns( :parent_announcement_options ).map( &:last )
       expect( option_ids ).to include( old_parent.id )
@@ -401,6 +401,149 @@ describe AnnouncementsController do
       announcement = create :announcement, parent_announcement_id: parent_announcement.id
       get :duplicate, params: { id: announcement.id, inat_site_id: site.id }
       expect( assigns( :announcement ).parent_announcement_id ).to be parent_announcement.id
+    end
+  end
+
+  describe "index" do
+    describe "as site admin" do
+      let( :site ) { create :site }
+      let( :other_site ) { create :site }
+      let( :user ) { create :user }
+      before do
+        create( :site ) unless Site.default
+        SiteAdmin.create!( site: site, user: user )
+        sign_in user
+      end
+
+      it "shows announcements targeted to the admin's site" do
+        site_announcement = create :announcement, sites: [site]
+        get :index, params: { inat_site_id: site.id }
+        expect( assigns( :announcements ) ).to include( site_announcement )
+      end
+
+      it "excludes global announcements by default" do
+        global_announcement = create :announcement
+        get :index, params: { inat_site_id: site.id }
+        expect( assigns( :announcements ) ).not_to include( global_announcement )
+      end
+
+      it "excludes announcements for other sites by default" do
+        other_announcement = create :announcement, sites: [other_site]
+        get :index, params: { inat_site_id: site.id }
+        expect( assigns( :announcements ) ).not_to include( other_announcement )
+      end
+
+      it "shows all announcements when site_filter is all" do
+        site_announcement = create :announcement, sites: [site]
+        other_announcement = create :announcement, sites: [other_site]
+        global_announcement = create :announcement
+        get :index, params: { inat_site_id: site.id, site_filter: "all" }
+        expect( assigns( :announcements ) ).to include( site_announcement )
+        expect( assigns( :announcements ) ).to include( other_announcement )
+        expect( assigns( :announcements ) ).to include( global_announcement )
+      end
+    end
+  end
+
+  describe "edit" do
+    describe "as site admin" do
+      let( :site ) { create :site }
+      let( :other_site ) { create :site }
+      let( :user ) { create :user }
+      before do
+        create( :site ) unless Site.default
+        SiteAdmin.create!( site: site, user: user )
+        sign_in user
+      end
+
+      it "allows editing announcements targeted to the admin's site" do
+        announcement = create :announcement, sites: [site]
+        get :edit, params: { id: announcement.id, inat_site_id: site.id }
+        expect( response ).to be_successful
+      end
+
+      it "denies editing announcements targeted to another site" do
+        announcement = create :announcement, sites: [other_site]
+        get :edit, params: { id: announcement.id, inat_site_id: site.id }
+        expect( response ).to redirect_to( announcement )
+        expect( flash[:error] ).to be_present
+      end
+
+      it "denies editing global announcements" do
+        announcement = create :announcement
+        get :edit, params: { id: announcement.id, inat_site_id: site.id }
+        expect( response ).to redirect_to( announcement )
+      end
+    end
+
+    describe "as staff admin" do
+      let( :admin ) { make_admin }
+      before { sign_in admin }
+
+      it "can edit any announcement" do
+        announcement = create :announcement
+        get :edit, params: { id: announcement.id }
+        expect( response ).to be_successful
+      end
+    end
+  end
+
+  describe "update" do
+    describe "as site admin" do
+      let( :site ) { create :site }
+      let( :other_site ) { create :site }
+      let( :user ) { create :user }
+      before do
+        create( :site ) unless Site.default
+        SiteAdmin.create!( site: site, user: user )
+        sign_in user
+      end
+
+      it "allows updating announcements targeted to the admin's site" do
+        announcement = create :announcement, sites: [site]
+        put :update, params: { id: announcement.id, inat_site_id: site.id, announcement: { body: "updated" } }
+        expect( response ).to redirect_to( announcement )
+      end
+
+      it "denies updating announcements targeted to another site" do
+        announcement = create :announcement, sites: [other_site]
+        put :update, params: { id: announcement.id, inat_site_id: site.id, announcement: { body: "updated" } }
+        expect( response ).to redirect_to( announcement )
+        expect( flash[:error] ).to be_present
+      end
+    end
+  end
+
+  describe "destroy" do
+    describe "as site admin" do
+      let( :site ) { create :site }
+      let( :other_site ) { create :site }
+      let( :user ) { create :user }
+      before do
+        create( :site ) unless Site.default
+        SiteAdmin.create!( site: site, user: user )
+        sign_in user
+      end
+
+      it "allows destroying announcements targeted to the admin's site" do
+        announcement = create :announcement, sites: [site]
+        delete :destroy, params: { id: announcement.id, inat_site_id: site.id }
+        expect( Announcement.find_by_id( announcement.id ) ).to be_nil
+      end
+
+      it "denies destroying announcements targeted to another site" do
+        announcement = create :announcement, sites: [other_site]
+        delete :destroy, params: { id: announcement.id, inat_site_id: site.id }
+        expect( response ).to redirect_to( announcement )
+        expect( Announcement.find_by_id( announcement.id ) ).not_to be_nil
+      end
+
+      it "denies destroying global announcements" do
+        announcement = create :announcement
+        delete :destroy, params: { id: announcement.id, inat_site_id: site.id }
+        expect( response ).to redirect_to( announcement )
+        expect( Announcement.find_by_id( announcement.id ) ).not_to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Updates the announcements index for site admins to list all announcements, allowing site admins to duplicate global announcements to create variants for their site. In addition this explicitly enforces preventing site admins from editing announcements from other sites, rather than relying on these being inaccessible to partner site admins.