### PR TITLE
feat: index what observation quality grade would be if not captive, WEB-912

### DIFF
--- a/app/es_indices/observation_index.rb
+++ b/app/es_indices/observation_index.rb
@@ -11,11 +11,11 @@ class Observation < ApplicationRecord
   scope :load_for_index, lambda {
     includes(
       { user: [:flags, :stored_preferences] }, :confirmed_reviews, :flags,
-      :observation_links, :quality_metrics, :observation_geo_score,
+      :observation_links, :quality_metrics, :observation_geo_score, :community_taxon,
       :votes_for, :stored_preferences, :tags,
       { annotations: :votes_for },
-      { photos: :flags },
-      { sounds: :user },
+      { photos: [:flags, :moderator_actions] },
+      { sounds: [:user, :flags, :moderator_actions] },
       { identifications: [:stored_preferences, :taxon, :moderator_actions] }, :project_observations,
       { taxon: [:conservation_statuses] },
       { observation_field_values: :observation_field },
@@ -46,6 +46,7 @@ class Observation < ApplicationRecord
       end
       indexes :cached_votes_total, type: "short"
       indexes :captive, type: "boolean"
+      indexes :quality_grade_if_not_captive, type: "keyword"
       indexes :comments do
         indexes :body, type: "text", analyzer: "ascii_snowball_analyzer"
         indexes :created_at, type: "date", index: false
@@ -359,6 +360,7 @@ class Observation < ApplicationRecord
         uuid: uuid,
         user: user&.as_indexed_json( no_details: true )&.merge( site_id: user.site_id ),
         captive: captive,
+        quality_grade_if_not_captive: quality_grade_if_not_captive,
         created_time_zone: timezone_object.blank? ? "UTC" : timezone_object.tzinfo.name,
         updated_at: updated_at.in_time_zone( timezone_object || "UTC" ),
         observed_time_zone: timezone_object.blank? ? nil : timezone_object.tzinfo.name,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1479,29 +1479,31 @@ class Observation < ApplicationRecord
       !community_taxon_id.blank? && taxon_id == community_taxon_id
     end
   end
-  
-  def quality_metrics_pass?( metrics = QualityMetric::METRICS )
-    metrics.each do |metric|
-      return false unless passes_quality_metric?(metric)
+
+  def quality_metrics_pass?( metrics = [] )
+    metrics = QualityMetric::METRICS if metrics.blank?
+    metrics.each do | metric |
+      return false unless passes_quality_metric?( metric )
     end
     true
   end
 
-  def passes_quality_metric?(metric)
-    score = quality_metric_score(metric)
+  def passes_quality_metric?( metric )
+    score = quality_metric_score( metric )
     score.blank? || score >= 0.5
   end
 
-  def research_grade_candidate?
+  def research_grade_candidate?( options = {} )
     return false if human?
     return false unless georeferenced?
-    return false unless quality_metrics_pass?
+    return false unless quality_metrics_pass?( options[:metrics] )
     return false unless observed_on?
-    return false unless (photos? || sounds?)
+    return false unless ( photos? || sounds? )
     return false unless appropriate?
+
     true
   end
-  
+
   def human?
     t = community_taxon || taxon
     t && ( t.name =~ /^Homo / || t.name == "Homo" )
@@ -1545,8 +1547,14 @@ class Observation < ApplicationRecord
     observation.quality_grade
   end
 
-  def get_quality_grade
-    if !research_grade_candidate?
+  def quality_grade_if_not_captive
+    return nil unless captive_cultivated?
+
+    get_quality_grade( metrics: QualityMetric::METRICS - [QualityMetric::WILD] )
+  end
+
+  def get_quality_grade( options = {} )
+    if !research_grade_candidate?( options )
       CASUAL
     elsif voted_in_to_needs_id?
       NEEDS_ID
@@ -1584,7 +1592,7 @@ class Observation < ApplicationRecord
       NEEDS_ID
     end
   end
-  
+
   def coordinates_obscured?
     !private_latitude.blank? || !private_longitude.blank?
   end

--- a/spec/helpers/observations_helper_spec.rb
+++ b/spec/helpers/observations_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe ObservationsHelper do
@@ -15,11 +17,11 @@ describe ObservationsHelper do
 
     it "should not return hidden photos" do
       photo = Photo.make!( user: observation.user )
-      op = ObservationPhoto.make!( observation: observation, photo: photo )
+      ObservationPhoto.make!( observation: observation, photo: photo )
       ModeratorAction.make!( resource: photo, action: "hide" )
+      observation.reload
       expect( photo.hidden? ).to be true
       expect( observation_image_url( observation ) ).to be_nil
     end
   end
-
 end

--- a/spec/lib/elastic_model/indices/observation_index_spec.rb
+++ b/spec/lib/elastic_model/indices/observation_index_spec.rb
@@ -202,6 +202,24 @@ describe "Observation Index" do
     expect( moderator_actions.first[:user] ).to be_nil
   end
 
+  describe "quality_grade" do
+    it "indexes quality_grade" do
+      observation = make_research_grade_observation
+      indexed_json = observation.as_indexed_json
+      expect( indexed_json[:quality_grade] ).to eq Observation::RESEARCH_GRADE
+      expect( indexed_json[:quality_grade_if_not_captive] ).to be_nil
+    end
+
+    it "indexes quality_grade_if_not_captive" do
+      observation = make_research_grade_observation
+      QualityMetric.make!( observation: observation, metric: QualityMetric::WILD, agree: false )
+      observation.reload
+      indexed_json = observation.as_indexed_json
+      expect( indexed_json[:quality_grade] ).to eq Observation::CASUAL
+      expect( indexed_json[:quality_grade_if_not_captive] ).to eq Observation::RESEARCH_GRADE
+    end
+  end
+
   describe "photos_count" do
     it "should not count photos with copyright infringement flags" do
       o = Observation.make!

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -1935,6 +1935,99 @@ describe Observation do
       ).to be_blank
     end
   end
+
+  describe "quality_metrics_pass" do
+    it "returns true if there are no metrics to fail" do
+      o = make_research_grade_candidate_observation
+      expect( o.quality_metrics_pass? ).to be true
+    end
+
+    it "returns true if all quality metrics pass" do
+      o = make_research_grade_candidate_observation
+      QualityMetric::METRICS.each do | metric |
+        QualityMetric.make!( observation: o, metric: metric, agree: true )
+      end
+      expect( o.quality_metrics_pass? ).to be true
+    end
+
+    it "returns true if any quality metrics pass" do
+      QualityMetric::METRICS.each do | metric |
+        o = make_research_grade_candidate_observation
+        QualityMetric.make!( observation: o, metric: metric, agree: true )
+        expect( o.quality_metrics_pass? ).to be true
+      end
+    end
+
+    it "returns false any quality metrics fail" do
+      QualityMetric::METRICS.each do | metric |
+        o = make_research_grade_candidate_observation
+        QualityMetric.make!( observation: o, metric: metric, agree: false )
+        expect( o.quality_metrics_pass? ).to be false
+      end
+    end
+
+    it "returns true if a quality metrics votes offset each other" do
+      QualityMetric::METRICS.each do | metric |
+        o = make_research_grade_candidate_observation
+        QualityMetric.make!( observation: o, metric: metric, agree: true )
+        QualityMetric.make!( observation: o, metric: metric, agree: false )
+        expect( o.quality_metrics_pass? ).to be true
+      end
+    end
+
+    it "accepts an array of metrics to check against" do
+      o = make_research_grade_candidate_observation
+      QualityMetric.make!( observation: o, metric: QualityMetric::WILD, agree: false )
+      expect( o.quality_metrics_pass? ).to be false
+      expect( o.quality_metrics_pass?(
+        metrics: QualityMetric::METRICS - [QualityMetric::WILD]
+      ) ).to be true
+    end
+  end
+
+  describe "get_quality_grade" do
+    it "considers high quality observations research grade" do
+      o = make_research_grade_observation
+      expect( o.get_quality_grade ).to be Observation::RESEARCH_GRADE
+    end
+
+    it "considers observations failing quality metrics to be casual" do
+      o = make_research_grade_observation
+      QualityMetric.make!( observation: o, metric: QualityMetric::WILD, agree: false )
+      expect( o.get_quality_grade ).to be Observation::CASUAL
+    end
+
+    it "accepts an array of metrics to check against" do
+      o = make_research_grade_observation
+      QualityMetric.make!( observation: o, metric: QualityMetric::WILD, agree: false )
+      expect( o.get_quality_grade ).to be Observation::CASUAL
+      expect( o.get_quality_grade(
+        metrics: QualityMetric::METRICS - [QualityMetric::WILD]
+      ) ).to be Observation::RESEARCH_GRADE
+    end
+  end
+
+  describe "quality_grade_if_not_captive" do
+    it "returns nil if the observation is not captive" do
+      o = make_research_grade_observation
+      expect( o.quality_grade_if_not_captive ).to be_nil
+    end
+
+    it "considers observations only failing wild metrics to be research grade" do
+      o = make_research_grade_observation
+      QualityMetric.make!( observation: o, metric: QualityMetric::WILD, agree: false )
+      expect( o.get_quality_grade ).to be Observation::CASUAL
+      expect( o.quality_grade_if_not_captive ).to be Observation::RESEARCH_GRADE
+    end
+
+    it "considers observations only failing multiple metrics to be casual" do
+      o = make_research_grade_observation
+      QualityMetric.make!( observation: o, metric: QualityMetric::WILD, agree: false )
+      QualityMetric.make!( observation: o, metric: QualityMetric::DATE, agree: false )
+      expect( o.get_quality_grade ).to be Observation::CASUAL
+      expect( o.quality_grade_if_not_captive ).to be Observation::CASUAL
+    end
+  end
 end
 
 describe Observation, "probably_captive?" do

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -2435,6 +2435,7 @@ describe Observation, "sound_url" do
     sound = LocalSound.make!( user: observation.user )
     ObservationSound.make!( observation: observation, sound: sound )
     ModeratorAction.make!( resource: sound, action: "hide" )
+    observation.reload
     expect( sound.hidden? ).to be true
     expect( observation.sound_url ).to be_nil
   end


### PR DESCRIPTION
When observations are captive, calculate what their quality_grade would be if they were not captive and add that to the ES index. That will allow us to search for observations that are only casual because they are captive - i.e. the observations where quality_grade is casual and quality_grade_if_not_captive is defined but not casual