### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/app/assets/javascripts/atlases/edit.js
+++ b/app/assets/javascripts/atlases/edit.js
@@ -9,9 +9,12 @@ $( function ( ) {
       url: $this.attr( "href" ),
       success: function ( data ) {
         console.log( "success" ); // eslint-disable-line no-console
-        var tableRow = "<tr><td><a href=\"/places/" + data.place_id + "\">"
-          + data.place_name + "</a></td><td></td></tr>";
-        $( "tbody.places tr:last" ).after( tableRow );
+        var $tableRow = $( "<tr></tr>" ).append(
+          $( "<td></td>" ).append(
+            $( "<a></a>" ).attr( "href", "/places/" + data.place_id ).text( data.place_name )
+          )
+        ).append( $( "<td></td>" ) );
+        $( "tbody.places tr:last" ).after( $tableRow );
       },
       error: function ( ) {
         console.log( "error" ); // eslint-disable-line no-console
@@ -32,13 +35,16 @@ $( function ( ) {
       url: $this.attr( "href" ),
       data: { place_id: placeID, atlas_id: atlasID },
       success: function ( data ) {
-        var tableRow = "<tr><td><a href=\"/places/" + data.place_id + "\">"
-          + data.place_name + "</a></td><td></td></tr>";
+        var $tableRow = $( "<tr></tr>" ).append(
+          $( "<td></td>" ).append(
+            $( "<a></a>" ).attr( "href", "/places/" + data.place_id ).text( data.place_name )
+          )
+        ).append( $( "<td></td>" ) );
         if ( $( "tbody.exploded tr:last" ) ) {
-          $( "tbody.exploded" ).append( tableRow );
+          $( "tbody.exploded" ).append( $tableRow );
           $( ".no_exploded" ).fadeOut( );
         } else {
-          $( "tbody.exploded tr:last" ).after( tableRow );
+          $( "tbody.exploded tr:last" ).after( $tableRow );
         }
       },
       error: function ( ) {

--- a/app/assets/javascripts/jquery/plugins/jquery.ui.autocomplete.html.js
+++ b/app/assets/javascripts/jquery/plugins/jquery.ui.autocomplete.html.js
@@ -14,7 +14,7 @@ var proto = $.ui.autocomplete.prototype,
 function filter( array, term ) {
 	var matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i" );
 	return $.grep( array, function(value) {
-		return matcher.test( $( "<div>" ).html( value.label || value.value || value ).text() );
+		return matcher.test( $( "<div>" ).text( value.label || value.value || value ).text() );
 	});
 }
 
@@ -32,7 +32,7 @@ $.extend( proto, {
 	_renderItem: function( ul, item) {
 		return $( "<li></li>" )
 			.data( "item.autocomplete", item )
-			.append( $( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.label ) )
+			.append( $( "<a></a>" ).text( item.label ) )
 			.appendTo( ul );
 	}
 });


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `app/assets/javascripts/jquery/plugins/jquery.ui.autocomplete.html.js:L28`

In `jquery.ui.autocomplete.html.js`, the `_renderItem` method uses `.html()` to render item labels when `this.options.html` is true. If user-controlled data is passed as the `label` property without proper sanitization, this can lead to XSS attacks. The `filter` function also uses `.html()` and `.text()` which could be exploited if malicious HTML is present in the source array.

## Solution

Ensure all user-provided data passed to the autocomplete is sanitized before being used as labels. Consider using a sanitization library like DOMPurify, or if the html option is not needed, disable it. If html rendering is required, sanitize the input server-side or use a client-side sanitizer before passing data to the autocomplete.

## Changes

- `app/assets/javascripts/jquery/plugins/jquery.ui.autocomplete.html.js` (modified)
- `app/assets/javascripts/atlases/edit.js` (modified)