### PR TITLE
fix(web-1016): cache apt-get results in pre-build

### DIFF
--- a/.github/apt-packages.txt
+++ b/.github/apt-packages.txt
@@ -1,0 +1,10 @@
+libpq-dev
+build-essential
+libcurl4-openssl-dev
+gdal-bin
+proj-bin
+proj-data
+libgeos-dev
+libgeos++-dev
+libproj-dev
+ffmpeg

--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -90,12 +90,16 @@ jobs:
       run: |
         curl --verbose --show-error http://localhost:9200
 
+    - name: Compute cache date
+      id: cache-date
+      run: echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
     - name: Restore apt package cache
       id: apt-cache
       uses: actions/cache@v4
       with:
         path: ~/apt-packages
-        key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
+        key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
 
     - name: Install dependencies
       timeout-minutes: 10

--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Restore apt package cache
       id: apt-cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ~/apt-packages
         key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/apt-packages.txt') }}

--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -99,7 +99,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/apt-packages
-        key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
+        key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/apt-packages.txt') }}
 
     - name: Install dependencies
       timeout-minutes: 10
@@ -114,10 +114,10 @@ jobs:
           echo "Cache miss - downloading from mirror..."
           sudo apt-get update --fix-missing
         fi
-        sudo apt-get install -y --no-install-recommends \
+        xargs sudo apt-get install -y --no-install-recommends \
           -o Acquire::Retries=5 \
           -o Acquire::http::Timeout="15" \
-          libpq-dev build-essential libcurl4-openssl-dev gdal-bin proj-bin proj-data libgeos-dev libgeos++-dev libproj-dev ffmpeg
+          < .github/apt-packages.txt
 
     - name: Use Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -90,10 +90,30 @@ jobs:
       run: |
         curl --verbose --show-error http://localhost:9200
 
+    - name: Restore apt package cache
+      id: apt-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/apt-packages
+        key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
+
     - name: Install dependencies
+      timeout-minutes: 10
       run: |
-        sudo apt-get -qq update --fix-missing
-        sudo apt-get -yqq install libpq-dev build-essential libcurl4-openssl-dev gdal-bin proj-bin proj-data libgeos-dev libgeos++-dev libproj-dev ffmpeg
+        sudo rm -f /var/lib/man-db/auto-update
+        sudo ln -sf /bin/true /usr/bin/mandb
+        if [ -d ~/apt-packages/archives ] && ls ~/apt-packages/archives/*.deb &>/dev/null; then
+          echo "Restoring cached packages and lists..."
+          sudo cp ~/apt-packages/archives/*.deb /var/cache/apt/archives/
+          sudo cp -a ~/apt-packages/lists/. /var/lib/apt/lists/
+        else
+          echo "Cache miss - downloading from mirror..."
+          sudo apt-get update --fix-missing
+        fi
+        sudo apt-get install -y --no-install-recommends \
+          -o Acquire::Retries=5 \
+          -o Acquire::http::Timeout="15" \
+          libpq-dev build-essential libcurl4-openssl-dev gdal-bin proj-bin proj-data libgeos-dev libgeos++-dev libproj-dev ffmpeg
 
     - name: Use Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/CI-pre-build.yml
+++ b/.github/workflows/CI-pre-build.yml
@@ -15,3 +15,25 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         cancel_others: true
+    - uses: actions/checkout@v5
+
+    - name: Cache apt packages
+      id: apt-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/apt-packages
+        key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
+
+    - name: Download apt packages
+      timeout-minutes: 10
+      if: steps.apt-cache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update --fix-missing
+        sudo apt-get install -y --no-install-recommends -d \
+          -o Acquire::Retries=5 \
+          -o Acquire::http::Timeout="15" \
+          libpq-dev build-essential libcurl4-openssl-dev gdal-bin proj-bin proj-data libgeos-dev libgeos++-dev libproj-dev ffmpeg
+        mkdir -p ~/apt-packages/archives ~/apt-packages/lists
+        cp /var/cache/apt/archives/*.deb ~/apt-packages/archives/
+        sudo rsync -a --exclude='partial' --exclude='lock' /var/lib/apt/lists/ ~/apt-packages/lists/
+        sudo chown -R $USER:$USER ~/apt-packages/

--- a/.github/workflows/CI-pre-build.yml
+++ b/.github/workflows/CI-pre-build.yml
@@ -17,12 +17,16 @@ jobs:
         cancel_others: true
     - uses: actions/checkout@v5
 
+    - name: Compute cache date
+      id: cache-date
+      run: echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
     - name: Cache apt packages
       id: apt-cache
       uses: actions/cache@v4
       with:
         path: ~/apt-packages
-        key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
+        key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
 
     - name: Download apt packages
       timeout-minutes: 10

--- a/.github/workflows/CI-pre-build.yml
+++ b/.github/workflows/CI-pre-build.yml
@@ -26,17 +26,17 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/apt-packages
-        key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/workflows/CI-pre-build.yml', '.github/workflows/CI-build-test.yml') }}
+        key: apt-packages-${{ runner.os }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('.github/apt-packages.txt') }}
 
     - name: Download apt packages
       timeout-minutes: 10
       if: steps.apt-cache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update --fix-missing
-        sudo apt-get install -y --no-install-recommends -d \
+        xargs sudo apt-get install -y --no-install-recommends -d \
           -o Acquire::Retries=5 \
           -o Acquire::http::Timeout="15" \
-          libpq-dev build-essential libcurl4-openssl-dev gdal-bin proj-bin proj-data libgeos-dev libgeos++-dev libproj-dev ffmpeg
+          < .github/apt-packages.txt
         mkdir -p ~/apt-packages/archives ~/apt-packages/lists
         cp /var/cache/apt/archives/*.deb ~/apt-packages/archives/
         sudo rsync -a --exclude='partial' --exclude='lock' /var/lib/apt/lists/ ~/apt-packages/lists/

--- a/.github/workflows/CICD-pr.yml
+++ b/.github/workflows/CICD-pr.yml
@@ -10,6 +10,7 @@ jobs:
   pre-build:
     uses: ./.github/workflows/CI-pre-build.yml
   build-and-test:
+    needs: pre-build
     uses: ./.github/workflows/CI-build-test.yml
   e2e-tests:
     uses: ./.github/workflows/CI-e2e-tests.yml


### PR DESCRIPTION
This PR runs `apt-get update` and `install` in `CI-pre-build.yml` persisting the results to a cache, shared by the current branch, for up to one day. This cache is then loaded by each matrix instance.

There are also a couple other optimizations added:

- The `-no-install-recommends` flag doesn't install unnecessary package dependencies.

- Set `timeout-minutes: 10` so that dependency installation will fail quickly if connections are slow.

- Set apt options to retry on request failures and timeout a request if it does not connect in 15 seconds.

- We disable man page installation which speeds up installation.