### PR TITLE
fix(WEB-1062): fix announcement observation date filters

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -342,9 +342,12 @@ class Announcement < ApplicationRecord
       last_observation_created_at = user.last_observation_created_at
       # if the user has never created an observation, don't show the announcement
       return false unless last_observation_created_at
+      # compare on calendar dates so the end date is inclusive of the whole day;
+      # the columns are dates, but last_observation_created_at is a timestamp
+      last_observation_date = last_observation_created_at.to_date
       # if the user has created an observation, but it's outside the date range, don't show
-      return false if last_observation_start_date && last_observation_created_at < last_observation_start_date
-      return false if last_observation_end_date && last_observation_created_at > last_observation_end_date
+      return false if last_observation_start_date && last_observation_date < last_observation_start_date
+      return false if last_observation_end_date && last_observation_date > last_observation_end_date
     end
 
     # If we're including obs apps, look for any obs the user has created with those apps

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -2361,6 +2361,8 @@ class Observation < ApplicationRecord
     User.where( id: user_id ).update_all( observations_count: [user.observations_count.to_i + 1, 0].max )
     user.reload
     user.elastic_index!
+    # The user's most recent observation has changed
+    user.clear_last_observation_created_at_cache
     # For accuracy
     update_user_counter_caches
     true
@@ -2372,6 +2374,8 @@ class Observation < ApplicationRecord
     User.where( id: user_id ).update_all( observations_count: [user.observations_count.to_i - 1, 0].max )
     user.reload
     user.elastic_index!
+    # The destroyed observation may have been the user's most recent one
+    user.clear_last_observation_created_at_cache
     update_user_counter_caches
     true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2011,12 +2011,17 @@ class User < ApplicationRecord
     nil
   end
 
+  def last_observation_created_at_cache_key
+    "users/#{id}/last_observation_created_at"
+  end
+
   # Creation datetime of the user's last observation by creation date. Note
   # that if the cache expiry time needs to be extended, more than a day will
   # probably be too limiting for announcement obs date targeting to be
-  # useful.
+  # useful. The cache is also cleared when the user creates or destroys an
+  # observation (see Observation#update_user_counter_caches_after_*).
   def last_observation_created_at
-    Rails.cache.fetch( "users/#{id}/last_observation_created_at", expires_in: 1.hour ) do
+    Rails.cache.fetch( last_observation_created_at_cache_key, expires_in: 1.hour ) do
       last_observation = Observation.elastic_query(
         user_id: id,
         order: "desc",
@@ -2025,6 +2030,10 @@ class User < ApplicationRecord
       ).first
       last_observation&.created_at
     end
+  end
+
+  def clear_last_observation_created_at_cache
+    Rails.cache.delete( last_observation_created_at_cache_key )
   end
 
   # Iterates over recently created accounts of unknown spammer status, zero

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -464,6 +464,12 @@ describe Announcement do
         obs = create :observation, created_at: 1.day.ago
         expect( annc.targeted_to_user?( obs.user ) ).to be false
       end
+
+      it "includes users whose last observation is on the end date" do
+        annc = create :announcement, target_logged_in: Announcement::YES, last_observation_end_date: Date.current
+        obs = create :observation, created_at: Time.zone.now
+        expect( annc.targeted_to_user?( obs.user ) ).to be true
+      end
     end
 
     it "includes and excludes users by observation oauth application ids" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2502,4 +2502,27 @@ describe User do
     u
   end
 end
+
+describe User, "last_observation_created_at" do
+  elastic_models( Observation )
+
+  it "reflects a newly created observation" do
+    user = User.make!
+    Observation.make!( user: user, created_at: 3.days.ago )
+    # warm the cache with the older observation
+    expect( user.last_observation_created_at.to_date ).to eq 3.days.ago.to_date
+    Observation.make!( user: user, created_at: Time.now )
+    expect( user.last_observation_created_at.to_date ).to eq Time.now.to_date
+  end
+
+  it "reflects destruction of the most recent observation" do
+    user = User.make!
+    Observation.make!( user: user, created_at: 3.days.ago )
+    recent = Observation.make!( user: user, created_at: Time.now )
+    # warm the cache with the most recent observation
+    expect( user.last_observation_created_at.to_date ).to eq Time.now.to_date
+    recent.destroy
+    expect( user.last_observation_created_at.to_date ).to eq 3.days.ago.to_date
+  end
+end
 # rubocop:enable Style/FrozenStringLiteralComment


### PR DESCRIPTION
- invalidates `last_observation_created_at_cache_key` when observations are created or destroyed
- converts `last_observation_created_at` to a date before comparison with announcement filters