### PR TITLE
feat: add project filter to exclude observations casual for reasons other than captive, WEB-912

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -12,7 +12,7 @@ var loadMap3 = function ( ) {
 /* eslint-disable */
 
 // requires GoogleMap classes
-if ( typeof( google ) == "undefined" || typeof(google.maps) == "undefined") {
+if ( typeof( google ) == "undefined" || typeof( google.maps ) == "undefined") {
   return;
 }
 

--- a/app/assets/stylesheets/projects/new2.scss
+++ b/app/assets/stylesheets/projects/new2.scss
@@ -257,6 +257,11 @@ body>div>.popover[role="tooltip"].popover-error {
   .members-only label.inline {
     line-height: inherit;
   }
+  .not-casual-excluding-captive {
+    border-top: 1px solid #ddd;
+    margin-top: 10px;
+    padding-top: 10px;
+  }
   .icon-previews {
     margin-top: 15px;
     .badge-div {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -110,13 +110,14 @@ class Project < ApplicationRecord
   preference :rule_native, :boolean
   preference :rule_introduced, :boolean
   preference :rule_members_only, :boolean
+  preference :rule_not_casual_excluding_captive, :boolean
   preference :delegation, :boolean, default: false
   preference :delegated_project_id, :integer
   RULE_PREFERENCES = [
     "rule_quality_grade", "rule_photos", "rule_sounds",
     "rule_observed_on", "rule_d1", "rule_d2", "rule_month",
     "rule_term_id", "rule_term_value_id", "rule_native",
-    "rule_introduced", "rule_members_only"
+    "rule_introduced", "rule_members_only", "rule_not_casual_excluding_captive"
   ].freeze
 
   SUBMISSION_BY_ANYONE = "any"

--- a/app/webpack/projects/form/components/regular_form.jsx
+++ b/app/webpack/projects/form/components/regular_form.jsx
@@ -523,6 +523,22 @@ class RegularForm extends React.Component {
                 />
                 { I18n.t( "casual_" ) }
               </label>
+              { project.rule_quality_grade.casual && (
+                <div className="not-casual-excluding-captive">
+                  <div className="help-text">
+                    { I18n.t( "views.projects.new.exclude_casual_except_captive" ) }
+                  </div>
+                  <label className="inline checkboxradio" htmlFor="project-not-casual-excluding-captive">
+                    <input
+                      type="checkbox"
+                      id="project-not-casual-excluding-captive"
+                      defaultChecked={project.rule_not_casual_excluding_captive}
+                      onChange={e => setRulePreference( "not_casual_excluding_captive", e.target.checked || null )}
+                    />
+                    { I18n.t( "views.projects.new.exclude_all_casual_except_captive" ) }
+                  </label>
+                </div>
+              ) }
             </Col>
             <Col xs={4} className={`members-only${usingDelegation ? " disabled" : ""}`}>
               <label>{ I18n.t( "media_type" ) }</label>

--- a/app/webpack/projects/form/form_reducer.js
+++ b/app/webpack/projects/form/form_reducer.js
@@ -414,6 +414,9 @@ export function submitProject( ) {
         prefers_rule_native: _.isEmpty( project.rule_native ) ? "" : project.rule_native,
         prefers_rule_introduced: _.isEmpty( project.rule_introduced ) ? "" : project.rule_introduced,
         prefers_rule_members_only: _.isEmpty( project.rule_members_only ) ? "" : project.rule_members_only,
+        prefers_rule_not_casual_excluding_captive:
+          _.isEmpty( project.rule_not_casual_excluding_captive )
+            ? "" : project.rule_not_casual_excluding_captive,
         prefers_user_trust: project.prefers_user_trust === true
       }
     };

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8950,6 +8950,15 @@ en:
         end_date_must_be_after_start_date: End date must be after start date
         # validation error when a project's end time is earlier than its start time
         end_time_must_be_after_start_time: End time must be after start time
+        # description for a form option that excludes from the project any observation that
+        # has quality_grade casual, unless the only reason it is casual is because it is marked
+        # captive
+        exclude_casual_except_captive: |
+          Exclude observations that are casual for any reason other than being marked as captive
+        # label for a form field that excludes from the project any observation that
+        # has quality_grade casual, unless the only reason it is casual is because it is marked
+        # captive
+        exclude_all_casual_except_captive: Exclude All Casual Except Captive
         include_annotated_observations: |
           Include only observations annotated with a particular attribute (e.g. life stage),
           or a particular attribute and value (e.g life stage = adult).

--- a/lib/inat_api_service.rb
+++ b/lib/inat_api_service.rb
@@ -92,6 +92,7 @@ module INatAPIService
     "projects[]",
     "q",
     "quality_grade",
+    "not_casual_excluding_captive",
     "radius",
     "rank",
     "reviewed",


### PR DESCRIPTION
Allow collection projects to set a filter to use a new API parameter `not_casual_excluding_captive`. If configured to allow casual observations, that filter will exclude all casual observations that would remain casual if they weren't marked captive. Essentially allow projects to include casual observations when the only reason they are casual is because they are marked captive