### PR TITLE
Web 1038 add resources page link to header or footer

### DIFF
--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -15,15 +15,7 @@ module WikiPagesHelper
       page_titles = match[/nav(.*?)\}/, 1].split( "," )
       html = "<ul class='leftmenu'>"
       page_titles.each do | page_title |
-        page_title.strip!
-        link_class = ( @page && @page.title.downcase == page_title.downcase ) ? "active" : nil
-        html += content_tag :li do
-          page = WikiPage.find_by_title( page_title )
-          if page&.title != page_title
-            page = WikiPage.find_by_path( page_title.parameterize )
-          end
-          link_to ( page&.title || page_title ), wiki_link( page&.path || page_title ), class: link_class
-        end
+        html += parse_title( page_title )
       end
       html += "</ul>"
       html
@@ -39,15 +31,7 @@ module WikiPagesHelper
     html = "<ul class='topmenu'>"
     page_titles = navtxt[/nav(.*?)\}/, 1].split( "," )
     page_titles.each do | page_title |
-      page_title.strip!
-      link_class = ( @page && @page.title.downcase == page_title.downcase ) ? "active" : nil
-      html += content_tag :li do
-        page = WikiPage.find_by_title( page_title )
-        if page&.title != page_title
-          page = WikiPage.find_by_path( page_title.parameterize )
-        end
-        link_to ( page&.title || page_title ), wiki_link( page&.path || page_title ), class: link_class
-      end
+      html += parse_title( page_title )
     end
     html += "</ul>"
     raw html
@@ -106,5 +90,21 @@ module WikiPagesHelper
 
   def wiki_user( user )
     "#{link_to( user_image( user ), user )} #{link_to_user( user )}".html_safe
+  end
+
+  private
+
+  def parse_title( page_title )
+    page_title.strip!
+    page_identifier, custom_label = page_title.split( "|", 2 ).map( &:strip )
+    link_class = ( @page && @page.title.downcase == page_identifier.downcase ) ? "active" : nil
+    content_tag :li do
+      page = WikiPage.find_by_title( page_identifier )
+      if page&.title != page_identifier
+        page = WikiPage.find_by_path( page_identifier.parameterize )
+      end
+      link_text = custom_label || page&.title || page_identifier
+      link_to link_text, wiki_link( page&.path || page_identifier ), class: link_class
+    end
   end
 end

--- a/spec/helpers/wiki_pages_helper_spec.rb
+++ b/spec/helpers/wiki_pages_helper_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe WikiPagesHelper do
+  describe "wiki_nav" do
+    let( :page ) { WikiPage.make!( title: "About", path: "about" ) }
+
+    before { @page = page }
+
+    it "renders links for each page title" do
+      WikiPage.make!( title: "Team", path: "team" )
+      result = wiki_nav( "{{nav About, Team}}" )
+      expect( result ).to include( "about" )
+      expect( result ).to include( "team" )
+    end
+
+    it "falls back to path lookup when title does not match exactly" do
+      WikiPage.make!( title: "Resources for sharing about iNaturalist", path: "resources" )
+      result = wiki_nav( "{{nav resources}}" )
+      expect( result ).to include( "/pages/resources" )
+    end
+
+    it "uses page title as link text by default" do
+      resources_page = WikiPage.make!( title: "Resources for sharing about iNaturalist", path: "resources" )
+      result = wiki_nav( "{{nav resources}}" )
+      expect( result ).to include( resources_page.title )
+    end
+
+    it "supports a custom label with pipe syntax" do
+      WikiPage.make!( title: "Resources for sharing about iNaturalist", path: "resources" )
+      result = wiki_nav( "{{nav resources|Resources}}" )
+      expect( result ).to include( ">Resources<" )
+      expect( result ).to include( "/pages/resources" )
+    end
+
+    it "custom label does not show the full page title when a label is given" do
+      WikiPage.make!( title: "Resources for sharing about iNaturalist", path: "resources" )
+      result = wiki_nav( "{{nav resources|Resources}}" )
+      expect( result ).not_to include( "Resources for sharing about iNaturalist" )
+    end
+
+    it "marks the current page link as active" do
+      result = wiki_nav( "{{nav About}}" )
+      expect( result ).to include( "active" )
+    end
+
+    it "does not mark other pages as active" do
+      WikiPage.make!( title: "Team", path: "team" )
+      result = wiki_nav( "{{nav Team}}" )
+      expect( result ).not_to include( "active" )
+    end
+  end
+end


### PR DESCRIPTION
Adds support to the wiki page editors for custom link text in nav shortcodes. This allows an optional pipe delimited string after the page title to set the link text.

This supports a request to add a link to the ["Resources" page](https://www.inaturalist.org/pages/resources), which is titled `Resources for sharing about iNaturalist`, but should have the link text `Resources`.
e.g.
```
{{topnav About|Who are we, iNaturalist Team|Our Team, Supporters, Financials, Press}}
```
<img width="563" height="66" alt="image" src="https://github.com/user-attachments/assets/f552b501-11b4-495e-8d75-9b97bba2f746" />
