### PR TITLE
fix: Ensure mobile settings header and footer span screen, WEB-1067

### DIFF
--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -633,8 +633,10 @@ body>div>[role="dialog"] .modal-body {
     z-index: 99;
     box-shadow: 0 0 10px #999;
     background-color: white;
-    width: 100%;
     position: fixed;
+    left: 0;
+    right: 0;
+    padding: 15px;
   }
   .settings-head {
     top: 0;
@@ -642,10 +644,15 @@ body>div>[role="dialog"] .modal-body {
     .btncol {
       display: none;
     }
+    .settings-item {
+      margin: 0;
+    }
+    .mobile-menu {
+      margin: 0;
+    }
   }
   .settings-foot {
     bottom: 0;
-    padding: 15px 0;
   }
   .navcol {
     margin-bottom: 20px;

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -627,7 +627,7 @@ body>div>[role="dialog"] .modal-body {
 }
 
 .noh1 {
-  padding-top: 77px;
+  padding-top: 50px;
   .settings-head,
   .settings-foot {
     z-index: 99;
@@ -636,7 +636,6 @@ body>div>[role="dialog"] .modal-body {
     position: fixed;
     left: 0;
     right: 0;
-    padding: 15px;
   }
   .settings-head {
     top: 0;
@@ -648,11 +647,18 @@ body>div>[role="dialog"] .modal-body {
       margin: 0;
     }
     .mobile-menu {
+      background-color: white;
+      color: #454545;
       margin: 0;
+      width: 100%;
+      height: 44px;
+      text-align: left;
+      padding: 0 30px;
     }
   }
   .settings-foot {
     bottom: 0;
+    padding: 15px;
   }
   .navcol {
     margin-bottom: 20px;
@@ -661,6 +667,12 @@ body>div>[role="dialog"] .modal-body {
       max-width: none;
       width: 93vw;
       display: block;
+    }
+  }
+  .save-button {
+    flex-direction: row;
+    .saved-time {
+      margin-right: 12px;
     }
   }
 }


### PR DESCRIPTION
While there, Abhas asked me to implement a few design changes.

Before:
<img width="386" height="723" alt="Screenshot 2026-06-30 at 3 47 19 PM" src="https://github.com/user-attachments/assets/beb34411-c546-4149-a14b-c6f947e56cca" />

After:
<img width="389" height="724" alt="Screenshot 2026-06-30 at 5 10 02 PM" src="https://github.com/user-attachments/assets/6b1d1232-71fd-4f5e-bed1-64c2619b210f" />
