### PR TITLE
feat: change project requirements casual label when excluding non-captives, related to WEB-912

### DIFF
--- a/app/webpack/projects/show/components/requirements.jsx
+++ b/app/webpack/projects/show/components/requirements.jsx
@@ -90,11 +90,17 @@ const Requirements = ( {
         { r.project.title }
       </a>
     ) );
-  const qualityGradeRules = _.isEmpty( project.rule_quality_grade ) ? I18n.t( "any_quality_grade" )
-    : _.map(
-      _.keys( project.rule_quality_grade ),
-      q => I18n.t( q === "research" ? "research_grade" : `${q}_` )
-    ).join( ", " );
+  const qualityGradeRules = _.isEmpty( project.rule_quality_grade )
+    ? I18n.t( "any_quality_grade" )
+    : _.map( _.keys( project.rule_quality_grade ), q => {
+      let i18nKey = `${q}_`;
+      if ( q === "research" ) {
+        i18nKey = "research_grade";
+      } else if ( q === "casual" && project.rule_not_casual_excluding_captive ) {
+        i18nKey = "casual_non_wild_only_";
+      }
+      return I18n.t( i18nKey );
+    } ).join( ", " );
   const media = [];
   if ( project.rule_photos ) {
     media.push( I18n.t( "photo" ) );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1031,6 +1031,9 @@ en:
   card: Card
   casual: casual
   casual_: Casual
+  # Label for the Casual quality grade, but indicating it only includes observations that are marked
+  # casual because they have a quality assessment vote that they are non-wild
+  casual_non_wild_only_: Casual (non-wild only)
   casual_tooltip_html: '"Casual" observations are missing media, location, or a date, or do not meet the requirements of the "Research" or "Needs ID" quality grades for other reasons. <a href="https://www.inaturalist.org/pages/help#quality">Learn more about quality grades</a>'
   casual_tooltip_html2: '"Casual" observations are missing media, location, or a date, or do not meet the requirements of the "Research" or "Needs ID" quality grades for other reasons. <a href="https://help.inaturalist.org/support/solutions/articles/151000169936">Learn more about quality grades</a>'
   categories: Categories

--- a/lib/tasks/inaturalist.rake
+++ b/lib/tasks/inaturalist.rake
@@ -329,6 +329,7 @@ namespace :inaturalist do
       "browse",
       "captive_observations",
       "casual",
+      "casual_non_wild_only_",
       "checklist",
       "copyright",
       "data_quality",


### PR DESCRIPTION
Projects have a new setting to only include casual observations when the only reason they are casual is because they are marked non-wild. This PR updated the project requirements quality grade label from `Casual` to `Casual (non-wild only)` to indicate that project setting is active