### PR TITLE
feat: use v2 map tile endpoints, WEB-1061

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -1142,7 +1142,9 @@ google.maps.Map.prototype.addLayerAndControl = function( tilejson, options ) {
 };
 
 function elasticsearchTileservers( ) {
-  var tileservers = [ <%= CONFIG.tile_servers.elasticsearch.inspect %> ];
+  var tileservers = [ <%= CONFIG.tile_servers.elasticsearch.inspect %> ].map( function( url ) {
+    return url.replace( "/v1", "/v2" );
+  } );
   if( tileservers[0].match(/{n}/) ) {
     var pattern = tileservers[0];
     tileservers = _.map([ "1", "2", "3", "4" ], function( n ) {
@@ -1153,8 +1155,6 @@ function elasticsearchTileservers( ) {
 }
 
 function intereactionsServer( ) {
-  var interactionTileURL = "<%= CONFIG.tile_servers.interactions %>";
-  if( interactionTileURL ) { return interactionTileURL; }
   return elasticsearchTileservers( )[0];
 }
 
@@ -1162,7 +1162,7 @@ function intereactionsServer( ) {
 // different clusters running the same code. node_api_url will
 // be faster for DB/postgis queries
 function postgisTileservers( ) {
-  var nodeApiURL = "<%= CONFIG.public_node_api_url || CONFIG.node_api_url %>";
+  var nodeApiURL = "<%= CONFIG.public_node_api_url || CONFIG.node_api_url %>".replace( "/v1", "/v2" );
   if( nodeApiURL ) { return [ nodeApiURL ]; }
   return elasticsearchTileservers( );
 }

--- a/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
@@ -314,8 +314,9 @@ inatTaxonMap.addTaxonLayers = function ( map, options ) {
     if ( map.taxonLayerSignatures[sig] ) {
       return;
     }
-    $.getJSON( "<%= CONFIG.public_node_api_url || CONFIG.node_api_url %>/taxa/" + layer.taxon.id + "/map_layers", function ( taxonData ) {
-      inatTaxonMap.addTaxonLayer( map, layer, options, taxonData );
+    var apiURL = "<%= CONFIG.public_node_api_url || CONFIG.node_api_url %>".replace( "/v1", "/v2" );
+    $.getJSON( apiURL + "/taxa/" + layer.taxon.id + "/map_layers", function ( response ) {
+      inatTaxonMap.addTaxonLayer( map, layer, options, response.results[0] );
     } );
   } );
 };

--- a/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/taxon_autocomplete.jsx
@@ -400,9 +400,26 @@ class TaxonAutocomplete extends React.Component {
   }
 
   fetchTaxon( ) {
-    const { initialTaxonID } = this.props;
+    const { initialTaxonID, config } = this.props;
     if ( initialTaxonID ) {
-      inaturalistjs.taxa.fetch( initialTaxonID ).then( r => {
+      const params = { };
+      if ( config && config.testingApiV2 ) {
+        params.fields = {
+          id: true,
+          name: true,
+          rank: true,
+          rank_level: true,
+          iconic_taxon_name: true,
+          preferred_common_name: true,
+          is_active: true,
+          extinct: true,
+          ancestor_ids: true,
+          default_photo: {
+            square_url: true
+          }
+        };
+      }
+      inaturalistjs.taxa.fetch( initialTaxonID, params ).then( r => {
         if ( r.results.length > 0 ) {
           this.updateTaxon( { taxon: r.results[0] } );
         }

--- a/app/webpack/observations/uploader/webpack-entry.js
+++ b/app/webpack/observations/uploader/webpack-entry.js
@@ -3,11 +3,13 @@ import { render } from "react-dom";
 import { Provider } from "react-redux";
 import _ from "lodash";
 import moment from "moment";
+import inatjs from "inaturalistjs";
 
 import reducers from "./reducers";
 import Uploader from "./containers/uploader";
 import { fetchSavedLocations } from "./ducks/saved_locations";
 import sharedStore from "../../shared/shared_store";
+import { setConfig } from "../../shared/ducks/config";
 
 moment.locale( I18n.locale );
 
@@ -15,6 +17,18 @@ sharedStore.injectReducers( reducers );
 
 if ( !_.isEmpty( CURRENT_USER ) ) {
   sharedStore.dispatch( fetchSavedLocations( ) );
+}
+
+const element = document.querySelector( "meta[name=\"config:inaturalist_api_url\"]" );
+const defaultApiUrl = element && element.getAttribute( "content" );
+if ( defaultApiUrl ) {
+  sharedStore.dispatch( setConfig( {
+    testingApiV2: true
+  } ) );
+  inatjs.setConfig( {
+    apiURL: defaultApiUrl.replace( "/v1", "/v2" ),
+    writeApiURL: defaultApiUrl.replace( "/v1", "/v2" )
+  } );
 }
 
 render(

--- a/app/webpack/stats/year/components/global_map.jsx
+++ b/app/webpack/stats/year/components/global_map.jsx
@@ -24,7 +24,7 @@ class GlobalMap extends React.Component {
       scrollWheelZoom: false,
       gestureHandling: true
     } );
-    const apiURL = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" );
+    const apiURL = $( "meta[name='config:inaturalist_api_url']" ).attr( "content" ).replace( "/v1", "/v2" );
     L.tileLayer( "https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_nolabels/{z}/{x}/{y}.png", {
       attribution: "&copy; <a href='https://www.openstreetmap.org/copyright/'>OpenStreetMap</a> "
         + "contributors, &copy; <a href='https://carto.com/about-carto/'>CARTO</a>"


### PR DESCRIPTION
* Prefers v2 mapping endpoints over v1 versions
* Updates the observation uploader to use APIv2

Eventually I'd like to clean up how we reference APIv2. Perhaps by adding a new meta tag that contains the V2 URL instead of having to do a string replace in several places. I'd also like to swap out the React config `testingApiV2` with something else as V2 is no longer a test, but more often than not the default. I'll do that in a later PR - this PR implements using v2 in a way consistent with how its been done up until now