### PR TITLE
fix: remove admin gate from ModeratorAction#editable_by?

### DIFF
--- a/app/models/moderator_action.rb
+++ b/app/models/moderator_action.rb
@@ -146,7 +146,6 @@ class ModeratorAction < ApplicationRecord
       most_recent = ModeratorAction.where( resource: resource, action: SUSPEND ).order( created_at: :desc ).first
       return false if most_recent && most_recent.id != id
     end
-    return true if editor.is_admin?
 
     editor == user
   end


### PR DESCRIPTION
Remove an additional admin gate for timed suspensions, enabling editing of suspensions for non-admins who created the suspension.