### PR TITLE
fix: project maps should not use any as default parameter value, related to WEB-1061

### DIFF
--- a/app/webpack/projects/show/components/observations_map_view.jsx
+++ b/app/webpack/projects/show/components/observations_map_view.jsx
@@ -8,6 +8,10 @@ import PhotoModalContainer from "../../../taxa/show/containers/photo_modal_conta
 
 const ObservationsMapView = ( { project, config, updateCurrentUser } ) => {
   const totalBounds = project.recent_observations && project.recent_observations.total_bounds;
+  const observationLayerParams = _.omit( {
+    ...project.search_params,
+    color: "iconic"
+  }, "any" );
   return (
     <div className="ObservationsMapView">
       <Grid>
@@ -15,7 +19,7 @@ const ObservationsMapView = ( { project, config, updateCurrentUser } ) => {
           <Col xs={12}>
             <TaxonMap
               placement="projects-show-observations"
-              observationLayers={[Object.assign( { captive: "any" }, project.search_params, { color: "iconic" } )]}
+              observationLayers={[observationLayerParams]}
               showAccuracy
               enableShowAllLayer={false}
               overlayMenu={false}

--- a/app/webpack/projects/show/components/overview_map.jsx
+++ b/app/webpack/projects/show/components/overview_map.jsx
@@ -29,6 +29,10 @@ const OverviewMap = ( { project, config, updateCurrentUser } ) => {
       }
     } );
   }
+  const observationLayerParams = _.omit( {
+    ...project.search_params,
+    color: "iconic"
+  }, "any" );
   return (
     <Grid>
       <Row>
@@ -36,7 +40,7 @@ const OverviewMap = ( { project, config, updateCurrentUser } ) => {
           <h2>{ title }</h2>
           <TaxonMap
             placement="projects-show-overview"
-            observationLayers={[Object.assign( { captive: "any" }, project.search_params, { color: "iconic" } )]}
+            observationLayers={[observationLayerParams]}
             showAccuracy
             enableShowAllLayer={false}
             overlayMenu={false}

--- a/app/webpack/projects/show/components/umbrella_map.jsx
+++ b/app/webpack/projects/show/components/umbrella_map.jsx
@@ -64,7 +64,7 @@ class UmbrellaMap extends Component {
             <TaxonMap
               placement="projects-show-umbrella"
               key={`umbrellamap${project.id}`}
-              observationLayers={[{ captive: "any", ...project.search_params, color: "iconic" }]}
+              observationLayers={[{ ...project.search_params, color: "iconic" }]}
               showAccuracy
               enableShowAllLayer={false}
               clickable={false}

--- a/app/webpack/projects/show/components/umbrella_map.jsx
+++ b/app/webpack/projects/show/components/umbrella_map.jsx
@@ -55,6 +55,10 @@ class UmbrellaMap extends Component {
       place: { id: chunk },
       name: "Places"
     } ) );
+    const observationLayerParams = _.omit( {
+      ...project.search_params,
+      color: "iconic"
+    }, "any" );
     const totalBounds = project.recent_observations && project.recent_observations.total_bounds;
     return (
       <Grid>
@@ -64,7 +68,7 @@ class UmbrellaMap extends Component {
             <TaxonMap
               placement="projects-show-umbrella"
               key={`umbrellamap${project.id}`}
-              observationLayers={[{ ...project.search_params, color: "iconic" }]}
+              observationLayers={[observationLayerParams]}
               showAccuracy
               enableShowAllLayer={false}
               clickable={false}


### PR DESCRIPTION
API v2 doesn't accept "any" as a parameter default that basically does nothing, e.g. captive=any. The project page maps were still sending a few parameters with "any" as a value, leading to 422 errors rendering map tiles. This PR removes any parameter whose value is "any"