### PR TITLE
feat: update taxon browse_photos to use API v2, WEB-1104

### DIFF
--- a/app/views/taxa/browse_photos.html.haml
+++ b/app/views/taxa/browse_photos.html.haml
@@ -5,7 +5,7 @@
   :javascript
     var SERVER_PAYLOAD = {
       taxon: #{ @node_taxon_json.encode.html_safe }.results[0],
-      place: #{ @place.to_json( only: [:id, :name, :display_name ] ).html_safe},
+      place: #{ @place.to_json( only: [:id, :uuid, :name, :display_name ] ).html_safe},
       ancestorsShown: #{ @ancestors_shown.to_json.html_safe },
       preferred_taxon_photos_query: #{ ( current_user ? current_user.preferred_taxon_photos_query : nil ).to_json.html_safe }
     }

--- a/app/webpack/projects/show/components/observations_map_view.jsx
+++ b/app/webpack/projects/show/components/observations_map_view.jsx
@@ -8,10 +8,10 @@ import PhotoModalContainer from "../../../taxa/show/containers/photo_modal_conta
 
 const ObservationsMapView = ( { project, config, updateCurrentUser } ) => {
   const totalBounds = project.recent_observations && project.recent_observations.total_bounds;
-  const observationLayerParams = _.omit( {
+  const observationLayerParams = _.omitBy( {
     ...project.search_params,
     color: "iconic"
-  }, "any" );
+  }, v => v === "any" );
   return (
     <div className="ObservationsMapView">
       <Grid>

--- a/app/webpack/projects/show/components/overview_map.jsx
+++ b/app/webpack/projects/show/components/overview_map.jsx
@@ -29,10 +29,10 @@ const OverviewMap = ( { project, config, updateCurrentUser } ) => {
       }
     } );
   }
-  const observationLayerParams = _.omit( {
+  const observationLayerParams = _.omitBy( {
     ...project.search_params,
     color: "iconic"
-  }, "any" );
+  }, v => v === "any" );
   return (
     <Grid>
       <Row>

--- a/app/webpack/projects/show/components/umbrella_map.jsx
+++ b/app/webpack/projects/show/components/umbrella_map.jsx
@@ -55,10 +55,10 @@ class UmbrellaMap extends Component {
       place: { id: chunk },
       name: "Places"
     } ) );
-    const observationLayerParams = _.omit( {
+    const observationLayerParams = _.omitBy( {
       ...project.search_params,
       color: "iconic"
-    }, "any" );
+    }, v => v === "any" );
     const totalBounds = project.recent_observations && project.recent_observations.total_bounds;
     return (
       <Grid>

--- a/app/webpack/taxa/photos/ducks/photos.js
+++ b/app/webpack/taxa/photos/ducks/photos.js
@@ -17,6 +17,45 @@ const DEFAULT_PARAMS = {
   quality_grade: "research"
 };
 
+const OBSERVATION_FIELDS = {
+  id: true,
+  taxon: {
+    iconic_taxon_name: true,
+    id: true,
+    is_active: true,
+    name: true,
+    preferred_common_name: true,
+    rank: true,
+    rank_level: true
+  },
+  photos: {
+    attribution: true,
+    attribution_name: true,
+    id: true,
+    license_code: true,
+    small_url: true,
+    medium_url: true,
+    original_dimensions: {
+      width: true,
+      height: true
+    },
+    url: true
+  },
+  user: {
+    login: true,
+    name: true,
+    icon_url: true
+  }
+};
+
+const PLACE_SEARCH_FIELDS = {
+  id: true,
+  uuid: true,
+  name: true,
+  display_name: true,
+  place_type: true
+};
+
 export function setUrl( newParams, options = {} ) {
   const defaultParams = options.defaultParams || DEFAULT_PARAMS;
   // don't put defaults in the URL
@@ -86,8 +125,10 @@ export default function reducer( state = DEFAULT_STATE, action ) {
       newState.perPage = action.perPage;
       break;
     case UPDATE_OBSERVATION_PARAMS:
-      newState.observationParams = Object.assign( { }, state.observationParams,
-        action.params );
+      newState.observationParams = {
+        ...state.observationParams,
+        ...action.params
+      };
       _.forEach( newState.observationParams, ( v, k ) => {
         if (
           v === null
@@ -209,23 +250,25 @@ function observationPhotosFromObservations( observations ) {
 export function fetchObservationPhotos( options = {} ) {
   return function ( dispatch, getState ) {
     const s = getState( );
-    const params = Object.assign(
-      { },
-      defaultObservationParams( s ),
-      s.photos.observationParams,
-      {
-        photos: true,
-        page: options.page,
-        per_page: options.perPage || 12
-      }
-    );
+    const params = _.omitBy( {
+      ...defaultObservationParams( s ),
+      ...s.photos.observationParams,
+      photos: true,
+      page: options.page,
+      per_page: options.perPage || 12
+    }, v => v === "any" );
     delete params.verifiable;
+    if ( s.config.testingApiV2 ) {
+      params.fields = OBSERVATION_FIELDS;
+    }
     return inatjs.observations.search( params )
       .then( response => {
         let observationPhotos = observationPhotosFromObservations( response.results );
         if ( params.photo_license && params.photo_license !== "any" ) {
-          observationPhotos = _.filter( observationPhotos,
-            op => op.photo.license_code === params.photo_license );
+          observationPhotos = _.filter(
+            observationPhotos,
+            op => op.photo.license_code === params.photo_license
+          );
         }
         let action = appendObservationPhotos;
         if ( options.reload ) {
@@ -254,12 +297,14 @@ function fetchPhotosGroupedByParam( param, values ) {
   return function ( dispatch, getState ) {
     const s = getState( );
     const limit = 12;
-    const baseParams = Object.assign(
-      { },
-      defaultObservationParams( s ),
-      s.photos.observationParams,
-      { per_page: limit }
-    );
+    const baseParams = _.omitBy( {
+      ...defaultObservationParams( s ),
+      ...s.photos.observationParams,
+      per_page: limit
+    }, v => v === "any" );
+    if ( s.config.testingApiV2 ) {
+      baseParams.fields = OBSERVATION_FIELDS;
+    }
     _.forEach( values, value => {
       let groupName = value;
       let groupObject;
@@ -361,7 +406,7 @@ export function hydrateFromUrlParams( params ) {
     if ( !params ) {
       params = {};
     }
-    const { taxon } = getState( );
+    const { taxon, config } = getState( );
     if ( params.grouping ) {
       const termGroupingMatch = params.grouping.match( /terms:([0-9]+)$/ );
       if ( termGroupingMatch ) {
@@ -387,7 +432,11 @@ export function hydrateFromUrlParams( params ) {
       if ( params.place_id === "any" ) {
         dispatch( setConfig( { chosenPlace: null } ) );
       } else {
-        inatjs.places.fetch( params.place_id ).then(
+        const placeSearchParams = { };
+        if ( config.testingApiV2 ) {
+          placeSearchParams.fields = PLACE_SEARCH_FIELDS;
+        }
+        inatjs.places.fetch( params.place_id, placeSearchParams ).then(
           response => {
             dispatch( setConfig( { chosenPlace: response.results[0] } ) );
           },

--- a/app/webpack/taxa/photos/webpack-entry.js
+++ b/app/webpack/taxa/photos/webpack-entry.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
-import { Taxon } from "inaturalistjs";
+import inatjs, { Taxon } from "inaturalistjs";
 import photosReducer, { reloadPhotos, hydrateFromUrlParams } from "./ducks/photos";
 import { setConfig } from "../../shared/ducks/config";
 import taxonReducer, { setTaxon, fetchTerms } from "../shared/ducks/taxon";
@@ -40,6 +40,19 @@ if ( serverPayload.ancestorsShown ) {
     ancestorsShown: serverPayload.ancestorsShown
   } ) );
 }
+
+const element = document.querySelector( "meta[name=\"config:inaturalist_api_url\"]" );
+const defaultApiUrl = element && element.getAttribute( "content" );
+if ( defaultApiUrl ) {
+  sharedStore.dispatch( setConfig( {
+    testingApiV2: true
+  } ) );
+  inatjs.setConfig( {
+    apiURL: defaultApiUrl.replace( "/v1", "/v2" ),
+    writeApiURL: defaultApiUrl.replace( "/v1", "/v2" )
+  } );
+}
+
 const taxon = new Taxon( serverPayload.taxon );
 sharedStore.dispatch( setTaxon( taxon ) );
 // fetch taxon terms before rendering the photo browser, in case


### PR DESCRIPTION
This PR makes it so the taxon browse_photos page uses API v2. It also fixes some buggy parameter cleaning I added to projects, since I was making similar changes to parameter cleaning for browse_photos. I will later submit a cleanup PR for all this API v2 work to remove the `testingApiV2` config name with something more appropriate