### PR TITLE
fix: taxon browse_photos style fixes, WEB-1102

### DIFF
--- a/app/webpack/shared/components/taxon_photo.module.css
+++ b/app/webpack/shared/components/taxon_photo.module.css
@@ -45,6 +45,9 @@
   cursor: pointer;
   font-family: inherit;
   box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  bottom: 0;
 }
 
 .modal-btn i {
@@ -68,6 +71,7 @@
   gap: 4px;
   pointer-events: none;
   box-sizing: border-box;
+  margin-top: auto;
 }
 
 .taxon-label a {
@@ -84,6 +88,11 @@
 .taxon-label :global(.SplitTaxon > .display-name),
 .taxon-label :global(.display-names) {
   display: block;
+}
+
+.taxon-label :global(.SplitTaxon a.display-name),
+.taxon-label :global(.SplitTaxon a.secondary-name) {
+  color: white;
 }
 
 .taxon-label :global(.display-name) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6746,6 +6746,8 @@ en:
   view_projects_from_place: "View projects from %{place}"
   view_sample: View Sample
   view_stats: View Stats
+  # Text for a link that takes the user to the relevant taxon details page
+  view_taxon: View Taxon
   view_taxon_change: View Taxon Change
   view_taxon_changes: View Taxon Changes
   view_taxon_framework_relationship: View taxon framework relationship


### PR DESCRIPTION
* Makes it so taxon names in the browse_photos grid are white, which is what they were until some recent changes
* It also makes it so the entire grid cell is clickable to open the photo modal, which was also the behavior until recently
* Adds a translation for a link label that previously had no matching translation