### PR TITLE
chore(web-1112): increase WikipediaService::CACHE_HOURS and ApiEndpointCache::THROTTLE_RETRY_MINUTES

### DIFF
--- a/app/models/api_endpoint_cache.rb
+++ b/app/models/api_endpoint_cache.rb
@@ -1,5 +1,5 @@
 class ApiEndpointCache < ApplicationRecord
-  THROTTLE_RETRY_MINUTES = 30
+  THROTTLE_RETRY_MINUTES = 90
   THROTTLED_STATUS_CODE = 429
   THROTTLED_BODY_PHRASE = "too many requests".freeze
 

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -154,6 +154,9 @@ base: &base
             # the web app
             default: 1234
     help_email: help@inaturalist.org
+    meta_service_email: help@inaturalist.org
+    admin_user_email: help@inaturalist.org
+    noreply_email: no-reply@inaturalist.org
 
     model_taxonomy: taxonomy.csv
 

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -50,7 +50,7 @@ class MetaService
         request_uri: request_uri,
         timeout: @timeout,
         api_endpoint: api_endpoint,
-        user_agent: "#{Site.default.name}/#{self.class}/#{SERVICE_VERSION}"
+        user_agent: USER_AGENT || "#{Site.default.name}/#{self.class}/#{SERVICE_VERSION}"
       ) )
     rescue Timeout::Error
       raise Timeout::Error, "#{@service_name} didn't respond within #{@timeout} seconds."
@@ -72,7 +72,7 @@ class MetaService
     return unless options[:request_uri]
 
     options[:timeout] ||= 5
-    options[:user_agent] ||= Site.default.name
+    options[:user_agent] ||= USER_AGENT || Site.default.name
     if options[:api_endpoint]
       api_endpoint_cache = ApiEndpointCache.find_or_create_by(
         api_endpoint: options[:api_endpoint],

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -29,7 +29,6 @@ class MetaService
     @method_param ||= "function"
     @default_params = {}
     @debug = options[:debug]
-    @user_agent = "#{Site.default.name}/#{self.class}/#{SERVICE_VERSION}"
   end
 
   attr_reader :timeout, :method_param, :service_name, :api_endpoint
@@ -51,7 +50,7 @@ class MetaService
         request_uri: request_uri,
         timeout: @timeout,
         api_endpoint: api_endpoint,
-        user_agent: @user_agent
+        user_agent: @user_agent || "#{Site.default.name}/#{self.class}/#{SERVICE_VERSION}"
       ) )
     rescue Timeout::Error
       raise Timeout::Error, "#{@service_name} didn't respond within #{@timeout} seconds."
@@ -73,7 +72,8 @@ class MetaService
     return unless options[:request_uri]
 
     options[:timeout] ||= 5
-    options[:user_agent] ||= @user_agent
+    # TODO: make user_agent match in request and fetch_request_uri
+    options[:user_agent] ||= @user_agent || Site.default.name
     if options[:api_endpoint]
       api_endpoint_cache = ApiEndpointCache.find_or_create_by(
         api_endpoint: options[:api_endpoint],

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -29,6 +29,7 @@ class MetaService
     @method_param ||= "function"
     @default_params = {}
     @debug = options[:debug]
+    @user_agent = "#{Site.default.name}/#{self.class}/#{SERVICE_VERSION}"
   end
 
   attr_reader :timeout, :method_param, :service_name, :api_endpoint
@@ -50,7 +51,7 @@ class MetaService
         request_uri: request_uri,
         timeout: @timeout,
         api_endpoint: api_endpoint,
-        user_agent: USER_AGENT || "#{Site.default.name}/#{self.class}/#{SERVICE_VERSION}"
+        user_agent: @user_agent
       ) )
     rescue Timeout::Error
       raise Timeout::Error, "#{@service_name} didn't respond within #{@timeout} seconds."
@@ -72,7 +73,7 @@ class MetaService
     return unless options[:request_uri]
 
     options[:timeout] ||= 5
-    options[:user_agent] ||= USER_AGENT || Site.default.name
+    options[:user_agent] ||= @user_agent
     if options[:api_endpoint]
       api_endpoint_cache = ApiEndpointCache.find_or_create_by(
         api_endpoint: options[:api_endpoint],

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -5,6 +5,7 @@ class WikipediaService < MetaService
 
   # 45 days
   CACHE_HOURS = 1080
+  USER_AGENT = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; help+api@inaturalist.org)"
 
   def initialize( options = {} )
     super

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -3,7 +3,8 @@
 class WikipediaService < MetaService
   attr_accessor :base_url
 
-  CACHE_HOURS = 720
+  # 45 days
+  CACHE_HOURS = 1080
 
   def initialize( options = {} )
     super

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -23,7 +23,8 @@ class WikipediaService < MetaService
     @default_params = {
       format: "xml"
     }
-    @user_agent = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; devops@inaturalist.org) <WikipediaService/Rails/#{SERVICE_VERSION}>"
+    @user_agent = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; " \
+      "#{CONFIG.meta_service_email}) WikipediaService/Rails/#{SERVICE_VERSION}"
 
     return unless subdomain.downcase == "zh"
 

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -5,7 +5,6 @@ class WikipediaService < MetaService
 
   # 45 days
   CACHE_HOURS = 1080
-  USER_AGENT = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; devops@inaturalist.org)"
 
   def initialize( options = {} )
     super
@@ -24,6 +23,8 @@ class WikipediaService < MetaService
     @default_params = {
       format: "xml"
     }
+    @user_agent = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; devops@inaturalist.org) <WikipediaService/Rails/#{SERVICE_VERSION}>"
+
     return unless subdomain.downcase == "zh"
 
     @default_params[:variant] = locale.downcase

--- a/lib/wikipedia_service.rb
+++ b/lib/wikipedia_service.rb
@@ -5,7 +5,7 @@ class WikipediaService < MetaService
 
   # 45 days
   CACHE_HOURS = 1080
-  USER_AGENT = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; help+api@inaturalist.org)"
+  USER_AGENT = "#{Site.default.name}/#{SERVICE_VERSION} (#{Site.default.url}; devops@inaturalist.org)"
 
   def initialize( options = {} )
     super

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -7,8 +7,8 @@ describe MetaService do
     it "passes the class-specific user agent to fetch_with_redirects" do
       service = WikipediaService.new
       expected_user_agent = "#{Site.default.name}/1 " \
-        "(#{Site.default.url}; devops@inaturalist.org) " \
-        "<WikipediaService/Rails/1>"
+        "(#{Site.default.url}; #{CONFIG.meta_service_email}) " \
+        "WikipediaService/Rails/1"
       response = double( "Net::HTTPResponse", code: "200", body: "<parse><text>ok</text></parse>" )
       allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
       service.parse( page: "Animalia" )

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -26,6 +26,17 @@ describe MetaService do
       expect( MetaService ).to have_received( :fetch_with_redirects ).
         with( hash_including( user_agent: expected_user_agent ) )
     end
+
+    it "passes just sitename to fetch_with_redirects from fetch_request_uri" do
+      service = MetaService.new
+      service.instance_variable_set( :@endpoint, "https://example.com/api?" )
+      expected_user_agent = "#{Site.default.name}/MetaService/#{MetaService::SERVICE_VERSION}"
+      response = double( "Net::HTTPResponse", code: "200", body: "<result>ok</result>" )
+      allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
+      service.parse( page: "Animalia" )
+      expect( MetaService ).to have_received( :fetch_with_redirects ).
+        with( hash_including( user_agent: expected_user_agent ) )
+    end
   end
 
   describe ".fetch_request_uri" do

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -3,6 +3,31 @@
 require "spec_helper"
 
 describe MetaService do
+  describe "#user_agent" do
+    it "passes the class-specific user agent to fetch_with_redirects" do
+      service = WikipediaService.new
+      expected_user_agent = "#{Site.default.name}/1 " \
+        "(#{Site.default.url}; devops@inaturalist.org) " \
+        "<WikipediaService/Rails/1>"
+      response = double( "Net::HTTPResponse", code: "200", body: "<parse><text>ok</text></parse>" )
+      allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
+      service.parse( page: "Animalia" )
+      expect( MetaService ).to have_received( :fetch_with_redirects ).
+        with( hash_including( user_agent: expected_user_agent ) )
+    end
+
+    it "passes the generic user agent to fetch_with_redirects for the base service" do
+      service = MetaService.new
+      service.instance_variable_set( :@endpoint, "https://example.com/api?" )
+      expected_user_agent = "#{Site.default.name}/MetaService/#{MetaService::SERVICE_VERSION}"
+      response = double( "Net::HTTPResponse", code: "200", body: "<result>ok</result>" )
+      allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
+      service.parse( page: "Animalia" )
+      expect( MetaService ).to have_received( :fetch_with_redirects ).
+        with( hash_including( user_agent: expected_user_agent ) )
+    end
+  end
+
   describe ".fetch_request_uri" do
     let( :api_endpoint ) do
       ApiEndpoint.make!( base_url: "https://example.com/api?", cache_hours: 720 )

--- a/spec/lib/taxon_describers/wikipedia_spec.rb
+++ b/spec/lib/taxon_describers/wikipedia_spec.rb
@@ -14,7 +14,7 @@ describe "TaxonDescribers" do
       expect(endpoint.description).to eq nil
       expect(endpoint.documentation_url).to eq "https://en.wikipedia.org/w/api.php"
       expect(endpoint.base_url).to eq "https://en.wikipedia.org/w/api.php?"
-      expect(endpoint.cache_hours).to eq 720
+      expect(endpoint.cache_hours).to eq 1080
     end
 
     it "creates the endpoint based on locale" do


### PR DESCRIPTION
Increase our caching and too many requests throttle retry behavior.

If issues with other external services are seen after this is deployed. Merge and deploy https://github.com/inaturalist/inaturalist/pull/4986 to revert the changes to the user_agent being sent by `MetaService`. These could show up as errors with integrations with Conabio or EOL, which also use `MetaService`.