### PR TITLE
fix: Prevent header from collapsing, WEB-1079

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -2216,7 +2216,6 @@ $header-line-height: 34px;
   .search {
     margin-bottom: 0;
     margin-right: 10px;
-    min-width: 0;
     display: -webkit-box;
     display: -webkit-flex;
     display: -moz-box;


### PR DESCRIPTION
When the user is no in the responsive test group, the search bar was allowed to shrink to 0. Removing the min-width keeps it open.

Before:
https://github.com/user-attachments/assets/20a3808b-2af4-4934-a8ff-4669ca59d393

After:
https://github.com/user-attachments/assets/1b2f1b6d-709c-499e-818d-f22bcb2a0eaa

