### PR TITLE
Block requests to throttled endpoints in MetaService#fetch_request_uri

### DIFF
--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -93,18 +93,7 @@ class MetaService
         return Nokogiri::XML( api_endpoint_cache.response )
       end
 
-      # Providers like Wikipedia throttle by user agent, so being throttled for one request means
-      # every other request to this endpoint will be throttled too. Back off from the endpoint as a
-      # whole rather than sending requests we expect to fail: each failure extends the throttle
-      # window and overwrites whatever this URL had cached with the throttling message.
       if options[:api_endpoint].recently_throttled?
-        Logstasher.write_hash(
-          subtype: "ApiEndpointBackoff",
-          api_endpoint_id: options[:api_endpoint].id,
-          api_endpoint_title: options[:api_endpoint].title,
-          request_url: options[:request_uri].to_s,
-          last_throttled_at: options[:api_endpoint].last_throttled_at
-        )
         return
       end
     end

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -92,6 +92,21 @@ class MetaService
 
         return Nokogiri::XML( api_endpoint_cache.response )
       end
+
+      # Providers like Wikipedia throttle by user agent, so being throttled for one request means
+      # every other request to this endpoint will be throttled too. Back off from the endpoint as a
+      # whole rather than sending requests we expect to fail: each failure extends the throttle
+      # window and overwrites whatever this URL had cached with the throttling message.
+      if options[:api_endpoint].recently_throttled?
+        Logstasher.write_hash(
+          subtype: "ApiEndpointBackoff",
+          api_endpoint_id: options[:api_endpoint].id,
+          api_endpoint_title: options[:api_endpoint].title,
+          request_url: options[:request_uri].to_s,
+          last_throttled_at: options[:api_endpoint].last_throttled_at
+        )
+        return
+      end
     end
     response = nil
     begin

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -3,6 +3,21 @@
 require "spec_helper"
 
 describe MetaService do
+  let( :api_endpoint ) do
+    ApiEndpoint.make!( base_url: "https://example.com/api?", cache_hours: 720 )
+  end
+  let( :request_uri ) { URI.parse( "https://example.com/api?page=Animalia" ) }
+
+  def stub_fetch( code:, body: )
+    response = double( "Net::HTTPResponse", code: code.to_s, body: body )
+    allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
+    response
+  end
+
+  def cache_for( uri = request_uri )
+    ApiEndpointCache.find_by( api_endpoint: api_endpoint, request_url: uri.to_s )
+  end
+
   describe "#user_agent" do
     it "passes the class-specific user agent to fetch_with_redirects" do
       service = WikipediaService.new
@@ -40,21 +55,6 @@ describe MetaService do
   end
 
   describe ".fetch_request_uri" do
-    let( :api_endpoint ) do
-      ApiEndpoint.make!( base_url: "https://example.com/api?", cache_hours: 720 )
-    end
-    let( :request_uri ) { URI.parse( "https://example.com/api?page=Animalia" ) }
-
-    def stub_fetch( code:, body: )
-      response = double( "Net::HTTPResponse", code: code.to_s, body: body )
-      allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
-      response
-    end
-
-    def cache_for( uri = request_uri )
-      ApiEndpointCache.find_by( api_endpoint: api_endpoint, request_url: uri.to_s )
-    end
-
     it "stores the status code and parses a normal response" do
       stub_fetch( code: 200, body: "<parse><text>ok</text></parse>" )
       result = MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint )
@@ -109,21 +109,7 @@ describe MetaService do
   end
 
   describe ".fetch_request_uri when the endpoint is throttling us" do
-    let( :api_endpoint ) do
-      ApiEndpoint.make!( base_url: "https://example.com/api?", cache_hours: 720 )
-    end
-    let( :request_uri ) { URI.parse( "https://example.com/api?page=Animalia" ) }
     let( :good_response ) { "<parse><text>ok</text></parse>" }
-
-    def stub_fetch( code:, body: )
-      response = double( "Net::HTTPResponse", code: code.to_s, body: body )
-      allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
-      response
-    end
-
-    def cache_for( uri = request_uri )
-      ApiEndpointCache.find_by( api_endpoint: api_endpoint, request_url: uri.to_s )
-    end
 
     def make_expired_good_cache( uri = request_uri )
       ApiEndpointCache.make!( api_endpoint: api_endpoint, request_url: uri.to_s,

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -107,4 +107,96 @@ describe MetaService do
       expect( cache_for.success ).to be true
     end
   end
+
+  describe ".fetch_request_uri when the endpoint is throttling us" do
+    let( :api_endpoint ) do
+      ApiEndpoint.make!( base_url: "https://example.com/api?", cache_hours: 720 )
+    end
+    let( :request_uri ) { URI.parse( "https://example.com/api?page=Animalia" ) }
+    let( :good_response ) { "<parse><text>ok</text></parse>" }
+
+    def stub_fetch( code:, body: )
+      response = double( "Net::HTTPResponse", code: code.to_s, body: body )
+      allow( MetaService ).to receive( :fetch_with_redirects ).and_return( response )
+      response
+    end
+
+    def cache_for( uri = request_uri )
+      ApiEndpointCache.find_by( api_endpoint: api_endpoint, request_url: uri.to_s )
+    end
+
+    def make_expired_good_cache( uri = request_uri )
+      ApiEndpointCache.make!( api_endpoint: api_endpoint, request_url: uri.to_s,
+        status_code: 200, success: true, response: good_response,
+        request_began_at: ( api_endpoint.cache_hours + 1 ).hours.ago,
+        request_completed_at: ( api_endpoint.cache_hours + 1 ).hours.ago )
+    end
+
+    it "does not send a request and returns nil" do
+      api_endpoint.update( last_throttled_at: 1.minute.ago )
+      expect( MetaService ).not_to receive( :fetch_with_redirects )
+      result = MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint )
+      expect( result ).to be_nil
+    end
+
+    it "leaves an expired cached response intact instead of overwriting it with a throttle body" do
+      cache = make_expired_good_cache
+      api_endpoint.update( last_throttled_at: 1.minute.ago )
+      expect( MetaService ).not_to receive( :fetch_with_redirects )
+      MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint )
+      cache.reload
+      expect( cache.response ).to eq good_response
+      expect( cache.success ).to be true
+      expect( cache.status_code ).to eq 200
+    end
+
+    it "blocks requests for every cache row, whatever state that row is in" do
+      cold_uri = URI.parse( "https://example.com/api?page=Fungi" )
+      expired_uri = URI.parse( "https://example.com/api?page=Plantae" )
+      lapsed_429_uri = URI.parse( "https://example.com/api?page=Protozoa" )
+      make_expired_good_cache( expired_uri )
+      ApiEndpointCache.make!( api_endpoint: api_endpoint, request_url: lapsed_429_uri.to_s,
+        status_code: 429, success: false, response: "You are making too many requests.",
+        request_began_at: ( ApiEndpointCache::THROTTLE_RETRY_MINUTES + 1 ).minutes.ago,
+        request_completed_at: ( ApiEndpointCache::THROTTLE_RETRY_MINUTES + 1 ).minutes.ago )
+      api_endpoint.update( last_throttled_at: 1.minute.ago )
+      expect( MetaService ).not_to receive( :fetch_with_redirects )
+      [cold_uri, expired_uri, lapsed_429_uri].each do | uri |
+        expect(
+          MetaService.fetch_request_uri( request_uri: uri, api_endpoint: api_endpoint )
+        ).to be_nil
+      end
+    end
+
+    it "still serves a fresh cached response" do
+      ApiEndpointCache.make!( api_endpoint: api_endpoint, request_url: request_uri.to_s,
+        status_code: 200, success: true, response: good_response,
+        request_began_at: 1.minute.ago, request_completed_at: 1.minute.ago )
+      api_endpoint.update( last_throttled_at: 1.minute.ago )
+      expect( MetaService ).not_to receive( :fetch_with_redirects )
+      result = MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint )
+      expect( result ).to be_a( Nokogiri::XML::Document )
+      expect( result.at( "text" ).inner_text ).to eq "ok"
+    end
+
+    it "suppresses a forced refresh too, so it cannot destroy a cached response" do
+      cache = make_expired_good_cache
+      api_endpoint.update( last_throttled_at: 1.minute.ago )
+      expect( MetaService ).not_to receive( :fetch_with_redirects )
+      result = MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint,
+        force_update: true )
+      expect( result ).to be_nil
+      expect( cache.reload.response ).to eq good_response
+    end
+
+    it "resumes fetching once the throttle window has passed" do
+      api_endpoint.update(
+        last_throttled_at: ( ApiEndpointCache::THROTTLE_RETRY_MINUTES + 1 ).minutes.ago
+      )
+      stub_fetch( code: 200, body: good_response )
+      result = MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint )
+      expect( result ).to be_a( Nokogiri::XML::Document )
+      expect( cache_for.success ).to be true
+    end
+  end
 end


### PR DESCRIPTION
I think this might address the underlying cause of persistent throttling by blocking all requests to throttled endpoints within the `fetch_request_uri` method.