### PR TITLE
Display last good cache

### DIFF
--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -88,14 +88,11 @@ class MetaService
           status_code: 200
         )
 
-        return_response( api_endpoint_cache.response, options )
+        return return_response( api_endpoint_cache.response, options )
       end
 
       if api_endpoint_cache.cached? && !options[:force_update]
-        # A throttled response is not a valid API response; treat it as if there
-        # was no response rather than parsing the throttling message.
-
-        return_response( api_endpoint_cache.response, options )
+        return return_response( api_endpoint_cache.response, options )
       end
     end
     response = nil
@@ -125,7 +122,7 @@ class MetaService
       return
     end
 
-    return_response( response, options )
+    return_response( response.body, options )
   end
 
   def self.fetch_with_redirects( options, attempts = 3 )
@@ -144,11 +141,12 @@ class MetaService
     response
   end
 
-  private def return_response( response, options )
+  def self.return_response( body, options )
     if options[:raw_response]
-      return response.body
+      return body
     end
 
-    Nokogiri::XML( response.body )
+    Nokogiri::XML( body )
   end
+  private_class_method :return_response
 end

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -82,16 +82,22 @@ class MetaService
       return if api_endpoint_cache.in_progress?
 
       if options[:api_endpoint].recently_throttled?
-        api_endpoint_cache = ApiEndpointCache.find_or_create_by(
+        return if options[:force_update]
+
+        api_endpoint_cache = ApiEndpointCache.find_by(
           api_endpoint: options[:api_endpoint],
           request_url: options[:request_uri].to_s,
-          status_code: 200
+          status_code: 200,
+          success: true,
         )
+        return unless api_endpoint_cache
 
         return return_response( api_endpoint_cache.response, options )
       end
 
       if api_endpoint_cache.cached? && !options[:force_update]
+        return if api_endpoint_cache.throttled?
+
         return return_response( api_endpoint_cache.response, options )
       end
     end

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -84,15 +84,9 @@ class MetaService
       if options[:api_endpoint].recently_throttled?
         return if options[:force_update]
 
-        api_endpoint_cache = ApiEndpointCache.find_by(
-          api_endpoint: options[:api_endpoint],
-          request_url: options[:request_uri].to_s,
-          status_code: 200,
-          success: true,
-        )
-        return unless api_endpoint_cache
-
-        return return_response( api_endpoint_cache.response, options )
+        if api_endpoint_cache.success? && api_endpoint_cache.status_code == 200
+          return return_response( api_endpoint_cache.response, options )
+        end
       end
 
       if api_endpoint_cache.cached? && !options[:force_update]

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -81,20 +81,21 @@ class MetaService
       )
       return if api_endpoint_cache.in_progress?
 
+      if options[:api_endpoint].recently_throttled?
+        api_endpoint_cache = ApiEndpointCache.find_or_create_by(
+          api_endpoint: options[:api_endpoint],
+          request_url: options[:request_uri].to_s,
+          status_code: 200
+        )
+
+        return_response( api_endpoint_cache.response, options )
+      end
+
       if api_endpoint_cache.cached? && !options[:force_update]
         # A throttled response is not a valid API response; treat it as if there
         # was no response rather than parsing the throttling message.
-        return if api_endpoint_cache.throttled?
 
-        if options[:raw_response]
-          return api_endpoint_cache.response
-        end
-
-        return Nokogiri::XML( api_endpoint_cache.response )
-      end
-
-      if options[:api_endpoint].recently_throttled?
-        return
+        return_response( api_endpoint_cache.response, options )
       end
     end
     response = nil
@@ -124,11 +125,7 @@ class MetaService
       return
     end
 
-    if options[:raw_response]
-      return response.body
-    end
-
-    Nokogiri::XML( response.body )
+    return_response( response, options )
   end
 
   def self.fetch_with_redirects( options, attempts = 3 )
@@ -145,5 +142,13 @@ class MetaService
       return fetch_with_redirects( options, attempts - 1 )
     end
     response
+  end
+
+  private def return_response( response, options )
+    if options[:raw_response]
+      return response.body
+    end
+
+    Nokogiri::XML( response.body )
   end
 end

--- a/lib/meta_service.rb
+++ b/lib/meta_service.rb
@@ -84,9 +84,9 @@ class MetaService
       if options[:api_endpoint].recently_throttled?
         return if options[:force_update]
 
-        if api_endpoint_cache.success? && api_endpoint_cache.status_code == 200
-          return return_response( api_endpoint_cache.response, options )
-        end
+        return unless api_endpoint_cache.success? && api_endpoint_cache.status_code == 200
+
+        return return_response( api_endpoint_cache.response, options )
       end
 
       if api_endpoint_cache.cached? && !options[:force_update]

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -150,8 +150,6 @@ describe MetaService do
       [cold_uri, expired_uri, lapsed_429_uri].each do | uri |
         MetaService.fetch_request_uri( request_uri: uri, api_endpoint: api_endpoint )
       end
-      # Only rows with no usable body have nothing to hand back. The expired row is covered by
-      # "serves an expired cached response rather than nothing" — it returns content, not nil.
       [cold_uri, lapsed_429_uri].each do | uri |
         expect(
           MetaService.fetch_request_uri( request_uri: uri, api_endpoint: api_endpoint )
@@ -160,8 +158,6 @@ describe MetaService do
     end
 
     it "serves an expired cached response rather than nothing" do
-      # Stale-serve: while we are backing off, a row whose cache_hours window has lapsed is still
-      # the best answer we have, so return it instead of leaving the user with no content.
       make_expired_good_cache
       api_endpoint.update( last_throttled_at: 1.minute.ago )
       expect( MetaService ).not_to receive( :fetch_with_redirects )

--- a/spec/lib/meta_service_spec.rb
+++ b/spec/lib/meta_service_spec.rb
@@ -148,10 +148,26 @@ describe MetaService do
       api_endpoint.update( last_throttled_at: 1.minute.ago )
       expect( MetaService ).not_to receive( :fetch_with_redirects )
       [cold_uri, expired_uri, lapsed_429_uri].each do | uri |
+        MetaService.fetch_request_uri( request_uri: uri, api_endpoint: api_endpoint )
+      end
+      # Only rows with no usable body have nothing to hand back. The expired row is covered by
+      # "serves an expired cached response rather than nothing" — it returns content, not nil.
+      [cold_uri, lapsed_429_uri].each do | uri |
         expect(
           MetaService.fetch_request_uri( request_uri: uri, api_endpoint: api_endpoint )
         ).to be_nil
       end
+    end
+
+    it "serves an expired cached response rather than nothing" do
+      # Stale-serve: while we are backing off, a row whose cache_hours window has lapsed is still
+      # the best answer we have, so return it instead of leaving the user with no content.
+      make_expired_good_cache
+      api_endpoint.update( last_throttled_at: 1.minute.ago )
+      expect( MetaService ).not_to receive( :fetch_with_redirects )
+      result = MetaService.fetch_request_uri( request_uri: request_uri, api_endpoint: api_endpoint )
+      expect( result ).to be_a( Nokogiri::XML::Document )
+      expect( result.at( "text" ).inner_text ).to eq "ok"
     end
 
     it "still serves a fresh cached response" do


### PR DESCRIPTION
When the ApiEndpoint is throttled, return the last successful ApiEndpointCache, if it exists.