### PR TITLE
Count impressions with no ip address

### DIFF
--- a/app/models/announcement_impression.rb
+++ b/app/models/announcement_impression.rb
@@ -11,7 +11,6 @@ class AnnouncementImpression < ApplicationRecord
 
   def self.increment_for_announcement( announcement, options = {} )
     return unless announcement.is_a?( Announcement )
-    return unless options[:user_id] || options[:user] || options[:request_ip]
 
     base_impression_options = {
       announcement_id: announcement.id,
@@ -19,7 +18,7 @@ class AnnouncementImpression < ApplicationRecord
     }
 
     if options[:user_id] || options[:user]
-      user_impression_options = base_impression_options.merge( user: options[:user_id] || options[:user] )
+      user_impression_options = base_impression_options.merge( user_id: options[:user_id] || options[:user].id )
       existing_impression = AnnouncementImpression.where( user_impression_options ).first
       if existing_impression
         existing_impression.update(

--- a/spec/models/announcement_impression_spec.rb
+++ b/spec/models/announcement_impression_spec.rb
@@ -74,5 +74,55 @@ describe AnnouncementImpression do
       expect( impression.request_ip ).to eq ip
       expect( impression.impressions_count ).to eq 3
     end
+
+    it "creates an impression for a logged out user when no request_ip is found" do
+      expect( AnnouncementImpression.count ).to eq 0
+      announcement = Announcement.make!
+      AnnouncementImpression.increment_for_announcement( announcement, user: nil, request_ip: nil )
+      expect( AnnouncementImpression.count ).to eq 1
+      impression = AnnouncementImpression.first
+      expect( impression.announcement ).to eq announcement
+      expect( impression.user ).to be_nil
+      expect( impression.request_ip ).to be_nil
+      expect( impression.impressions_count ).to eq 1
+    end
+
+    it "increments impression counts for a logged out user when no request_ip is found" do
+      expect( AnnouncementImpression.count ).to eq 0
+      announcement = Announcement.make!
+      3.times { AnnouncementImpression.increment_for_announcement( announcement, request_ip: nil ) }
+      expect( AnnouncementImpression.count ).to eq 1
+      impression = AnnouncementImpression.first
+      expect( impression.announcement ).to eq announcement
+      expect( impression.user ).to be_nil
+      expect( impression.request_ip ).to be_nil
+      expect( impression.impressions_count ).to eq 3
+    end
+
+    it "creates an impression when given a user_id instead of a user record" do
+      expect( AnnouncementImpression.count ).to eq 0
+      announcement = Announcement.make!
+      user = User.make!
+      AnnouncementImpression.increment_for_announcement( announcement, user_id: user.id, request_ip: ip )
+      expect( AnnouncementImpression.count ).to eq 1
+      impression = AnnouncementImpression.first
+      expect( impression.announcement ).to eq announcement
+      expect( impression.user ).to eq user
+      expect( impression.request_ip ).to eq ip
+      expect( impression.impressions_count ).to eq 1
+    end
+
+    it "increments impression counts when given a user_id instead of a user record" do
+      expect( AnnouncementImpression.count ).to eq 0
+      announcement = Announcement.make!
+      user = User.make!
+      3.times do
+        AnnouncementImpression.increment_for_announcement( announcement, user_id: user.id, request_ip: ip )
+      end
+      expect( AnnouncementImpression.count ).to eq 1
+      impression = AnnouncementImpression.first
+      expect( impression.user ).to eq user
+      expect( impression.impressions_count ).to eq 3
+    end
   end
 end


### PR DESCRIPTION
This is a small change that could increase counted impressions if requests ever come through without IP address, however this seems unlikely, and I did not find any examples in the logs.

It also fixes a bug in passing user_ids correctly to `base_impression_options`.