### PR TITLE
Fixed 4296: discrepancies in location search

### DIFF
--- a/app/assets/javascripts/ang/controllers/observation_search.js.erb
+++ b/app/assets/javascripts/ang/controllers/observation_search.js.erb
@@ -1347,7 +1347,7 @@ var SearchController = function (
     if ( !q ) { return; }
     // query the autocomplete service for the text in the search input
     $scope.placeAutocompleteService.getQueryPredictions(
-      { input: q },
+      { input: q, bounds: { north: 90, south: -90, west: -180, east: 180 },
       function ( predictions, status ) {
         if ( status !== google.maps.places.PlacesServiceStatus.OK
          || predictions.length === 0 || !predictions[0].place_id ) {


### PR DESCRIPTION
https://github.com/inaturalist/inaturalist/issues/4296

## Behavior:
Recommended local results based on your IP instead of global results for common names. For example, searching for 'Asia' in San Francisco would show observations at the Asian Art Museum instead of the continent.

## Update:
Added bounds for the entire globe, which effectively nullifies the local bias in favor of consistent results for anyone.
`bounds: { north: 90, south: -90, west: -180, east: 180 }`
