### PR TITLE
Fixed 4353: mobile view header bug

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -15,6 +15,7 @@ body {
   padding: 0;
   font-family: Lato, "Trebuchet MS", Arial, sans-serif;
   color: #333;
+  min-width: fit-content;
 }
 html, body {height: 100%;}
 #bodywrapper {min-height: 100%; margin-bottom: -196px;}

--- a/app/assets/stylesheets/lifelists.scss
+++ b/app/assets/stylesheets/lifelists.scss
@@ -52,7 +52,7 @@ body .bootstrap .taxon a {
   flex-direction: column;
   flex: 1;
   width: 100%;
-  min-width: 980px;
+  min-width: fit-content;
   padding: 0px 30px;
   .lifelist-title button.export {
     float: right;

--- a/app/assets/stylesheets/moderator_actions/hide_content.scss
+++ b/app/assets/stylesheets/moderator_actions/hide_content.scss
@@ -1,5 +1,5 @@
 body {
-  min-width: 980px;
+  min-width: fit-content;
 }
 #moderator_action_reason {
   min-height: 100px;

--- a/app/assets/stylesheets/observations/search.scss
+++ b/app/assets/stylesheets/observations/search.scss
@@ -1,7 +1,7 @@
 @import "../colors";
 
 body {
-  min-width: 980px;
+  min-width: fit-content;
 }
 #header {
   margin-bottom: 0px;
@@ -26,7 +26,7 @@ body {
 body.responsive {
   min-width: auto;
   #wrapper {
-    min-width: 980px;
+    min-width: fit-content;
   }
 }
 

--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -26,7 +26,7 @@
 }
 
 body {
-  min-width: 980px;
+  min-width: fit-content;
 }
 
 a:hover, a:focus {
@@ -103,7 +103,7 @@ body.responsive {
     margin-bottom: 0px;
   }
   #app {
-    min-width: 980px;
+    min-width: fit-content;
     padding-top: 20px;
   }
 }

--- a/app/assets/stylesheets/projects/new2.scss
+++ b/app/assets/stylesheets/projects/new2.scss
@@ -6,7 +6,7 @@
 @import "../../../../node_modules/react-bootstrap-datetimepicker/css/bootstrap-datetimepicker.min";
 
 body {
-  min-width: 980px;
+  min-width: fit-content;
 }
 
 #header {

--- a/app/assets/stylesheets/projects/show2.scss
+++ b/app/assets/stylesheets/projects/show2.scss
@@ -13,7 +13,7 @@ $background-color: #1A1A1A;
 
 
 body {
-  min-width: 980px;
+  min-width: fit-content;
 }
 
 .bootstrap {
@@ -50,7 +50,7 @@ body {
 body.responsive {
   min-width: auto;
   #wrapper {
-    min-width: 980px;
+    min-width: fit-content;
     background: $page-background-grey;
   }
 }

--- a/app/assets/stylesheets/taxa/geo_explain.scss
+++ b/app/assets/stylesheets/taxa/geo_explain.scss
@@ -6,7 +6,7 @@
 }
 
 #TaxonGeoExplain {
-  min-width: 980px;
+    min-width: fit-content;
 }
 
 .bootstrap h1 {

--- a/app/assets/stylesheets/taxa/show.scss
+++ b/app/assets/stylesheets/taxa/show.scss
@@ -23,7 +23,7 @@
 
 #TaxonDetail .container-fluid,
 #TaxonDetail .container {
-  min-width: 980px;
+  min-width: fit-content;
 }
 
 body.skip-min-width {

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -18,7 +18,7 @@
 .bootstrap [class*='col-'].bleedcol { padding: 0; }
 .bootstrap [class*='col-'].bigpadded { padding-top: 60px; padding-bottom: 60px; }
 #header {margin-bottom: 0;}
-#wrapper { margin-bottom: 0; min-width: 980px; }
+#wrapper { margin-bottom: 0; min-width: fit-content; }
 #hero { 
   overflow:hidden; 
   background-color: black;


### PR DESCRIPTION
https://github.com/inaturalist/inaturalist/issues/4353

## Behavior:
Header wouldn't extend fully to the width of the screen on mobile view when the search bar is extended. Though not shown in the issue report, this would happen to the footer and other body components too and created a white column next to the main body of the page.

## Update:
As mentioned by @tif-calin, `min-width: 980px` would stop some pages from extending to fit the added width, but some other pages didn't have a min-width at all. I replaced `min-width: 980px;` with `min-width: fit-content;` for css/scss files that had the property and added it to index.scss to cover pages that didn't. These changes don't seem to have an effect on web view, and only fix the mobile view issue.

| Before | After |
| :---: | :---: |
| <img width="1007" height="967" alt="image" src="https://github.com/user-attachments/assets/06fa9270-9947-40b4-bd86-c65012712313" /> | <img width="1007" height="967" alt="image" src="https://github.com/user-attachments/assets/6a091943-dadf-4099-83bc-0927e6a571f6" /> |
| <img width="1013" height="967" alt="image" src="https://github.com/user-attachments/assets/045b2204-7126-4b77-9023-cccaef95cbb2" /> | <img width="1013" height="967" alt="image" src="https://github.com/user-attachments/assets/fca1c863-b1b7-4510-a7af-713f97adf1c0" /> |