### PR TITLE
fix: Use legacy components on Identify, WEB-1183

### DIFF
--- a/app/webpack/observations/identify/containers/activity_item_container.js
+++ b/app/webpack/observations/identify/containers/activity_item_container.js
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 import { setConfig } from "../../../shared/ducks/config";
 import { showModeratorActionForm } from "../../../shared/ducks/moderator_actions";
-import ActivityItem from "../../show/components/activity_item";
+import ActivityItem from "../../show/components/activity_item_legacy";
 import {
   addID,
   fetchCurrentObservation,

--- a/app/webpack/observations/identify/containers/annotations_container.js
+++ b/app/webpack/observations/identify/containers/annotations_container.js
@@ -1,5 +1,5 @@
 import { connect } from "react-redux";
-import Annotations from "../../show/components/annotations";
+import Annotations from "../../show/components/annotations_legacy";
 import {
   addAnnotation,
   deleteAnnotation,


### PR DESCRIPTION
https://github.com/inaturalist/inaturalist/pull/4987 forgot to update the `ActivityItem` and `Annotations` to import from the legacy file for Identify, which caused some incorrect styles.

**Before**
<img width="451" height="410" alt="Screenshot 2026-08-04 at 2 42 20 PM" src="https://github.com/user-attachments/assets/2808e9bf-00f9-40cb-83b6-3b82c78d0e82" />
<img width="449" height="389" alt="Screenshot 2026-08-04 at 2 42 28 PM" src="https://github.com/user-attachments/assets/f49da670-cc9d-4726-bc84-f7cae3929181" />

**After**
<img width="452" height="449" alt="Screenshot 2026-08-04 at 2 41 07 PM" src="https://github.com/user-attachments/assets/a9f30d7a-65c5-4969-be31-91a8c12977d5" />
<img width="451" height="367" alt="Screenshot 2026-08-04 at 2 41 13 PM" src="https://github.com/user-attachments/assets/917477f3-33e3-4526-a225-3a7e10598b24" />
