### PR TITLE
fix: Prevent secondary name from escaping parenthesis: WEB-1065

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -1076,8 +1076,8 @@ ul.leafylist li li:first-child {
 .taxon.has-com-name > .secondary-name {
   color: #aaa;
 }
-.taxon.has-com-name .secondary-name:before { content: '('; display: contents; }
-.taxon.has-com-name .secondary-name:after { content: ')'; display: contents; }
+.taxon.has-com-name .secondary-name:before { content: '('; display: inline; }
+.taxon.has-com-name .secondary-name:after { content: ')'; display: inline; }
 .taxon.has-com-name.no-parens .secondary-name:before { content: ''; display: inline-block; }
 .taxon.has-com-name.no-parens .secondary-name:after { content: ''; display: inline-block; }
 .taxon .altname { color: #aaa; }
@@ -2036,8 +2036,8 @@ user-icon .icon-person:before {
         .secondary-name {
           color: #aaa;
         }
-        .secondary-name:before { content: '('; display: contents; }
-        .secondary-name:after { content: ')'; display: contents; }
+        .secondary-name:before { content: '('; display: inline; }
+        .secondary-name:after { content: ')'; display: inline; }
       }
       .ac-view {
         &.view-observations {

--- a/app/assets/stylesheets/shared/split_taxon.scss
+++ b/app/assets/stylesheets/shared/split_taxon.scss
@@ -26,7 +26,7 @@
   &.parens .secondary-name:before,
   .secondary-names:before {
     content: '(';
-    display: contents;
+    display: inline;
   }
   .secondary-names .secondary-name:before,
   &.parens .secondary-names .secondary-name:before {
@@ -36,7 +36,7 @@
   &.parens .secondary-name:after,
   .secondary-names:after {
     content: ')';
-    display: contents;
+    display: inline;
   }
   .secondary-names .secondary-name:after,
   &.parens .secondary-names  .secondary-name:after {


### PR DESCRIPTION
Parenthesis are CSS `::before`/`::after` with `display: contents`. Chrome misplaces those when React re-renders in place. Changed to display: inline to prevent escape.