### PR TITLE
fix: Use legacy recent observations component on project page, WEB-1222

### DIFF
--- a/app/webpack/projects/show/containers/recent_observations_container.js
+++ b/app/webpack/projects/show/containers/recent_observations_container.js
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 import _ from "lodash";
 import { stringify } from "querystring";
-import RecentObservations from "../../../taxa/show/components/recent_observations";
+import RecentObservations from "../../../taxa/show/components/recent_observations_legacy";
 import { showPhotoModal, setPhotoModal } from "../../../taxa/shared/ducks/photo_modal";
 
 function mapStateToProps( state ) {


### PR DESCRIPTION
Missed that the projects page imports the taxa recent observations component. The old-styled version was moved to `*_legacy.jsx` so importing the new-styled component caused bad rendering due to missing container styles. Fix is to import legacy.