### PR TITLE
feat: Add dismiss button to test group join toggle, WEB-1224

### DIFF
--- a/app/assets/stylesheets/bootstrap_bundle.scss
+++ b/app/assets/stylesheets/bootstrap_bundle.scss
@@ -402,4 +402,10 @@ body>div>.popover .label {
       line-height: 18px;
     }
   }
+
+  // Flex would make the inline link its own flex item and drop the spaces
+  // around it, so prose banners stay block level.
+  &.TestGroupBanner--text {
+    display: block;
+  }
 }

--- a/app/assets/stylesheets/bootstrap_bundle.scss
+++ b/app/assets/stylesheets/bootstrap_bundle.scss
@@ -353,25 +353,19 @@ body>div>.popover .label {
     position: absolute;
     top: -10px;
     right: -10px;
-    float: none;
-    width: 22px;
-    height: 22px;
-    padding: 0;
-    border: 1px solid rgba( 0, 0, 0, 0.15 );
-    border-radius: 50%;
-    background-color: #e0e0e0;
-    color: #666;
-    font-size: 16px;
-    font-weight: normal;
-    line-height: 22px;
+    background-color: #999;
+    color: white;
+    display: block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50px;
+    text-align: center;
+    line-height: 12px;
+    padding: 0 0 1px 0;
+    border: 0 transparent;
     text-shadow: none;
     opacity: 1;
-
-    &:hover,
-    &:focus {
-      background-color: #cccccc;
-      color: #333;
-    }
+    font-size: 14px;
   }
 
   .TestGroupBanner-feedback {
@@ -393,11 +387,7 @@ body>div>.popover .label {
     .TestGroupBanner-dismiss {
       top: 50%;
       right: 4px;
-      width: 18px;
-      height: 18px;
-      margin-top: -9px;
-      font-size: 13px;
-      line-height: 18px;
+      margin-top: -10px;
     }
   }
 

--- a/app/assets/stylesheets/bootstrap_bundle.scss
+++ b/app/assets/stylesheets/bootstrap_bundle.scss
@@ -384,10 +384,22 @@ body>div>.popover .label {
     gap: 0;
     max-width: 800px;
     margin: 0 auto;
-    padding: 5px 15px;
+    padding: 5px 30px;
     font-size: 12px;
     line-height: 18px;
     border-top: 0;
     border-radius: 0 0 4px 4px;
+
+    // The compact strip hangs off the header, so its dismiss button sits
+    // inside the strip rather than overlapping the header above it.
+    .TestGroupBanner-dismiss {
+      top: 50%;
+      right: 4px;
+      width: 18px;
+      height: 18px;
+      margin-top: -9px;
+      font-size: 13px;
+      line-height: 18px;
+    }
   }
 }

--- a/app/assets/stylesheets/bootstrap_bundle.scss
+++ b/app/assets/stylesheets/bootstrap_bundle.scss
@@ -390,8 +390,6 @@ body>div>.popover .label {
     border-top: 0;
     border-radius: 0 0 4px 4px;
 
-    // The compact strip hangs off the header, so its dismiss button sits
-    // inside the strip rather than overlapping the header above it.
     .TestGroupBanner-dismiss {
       top: 50%;
       right: 4px;
@@ -403,8 +401,6 @@ body>div>.popover .label {
     }
   }
 
-  // Flex would make the inline link its own flex item and drop the spaces
-  // around it, so prose banners stay block level.
   &.TestGroupBanner--text {
     display: block;
   }

--- a/app/assets/stylesheets/bootstrap_bundle.scss
+++ b/app/assets/stylesheets/bootstrap_bundle.scss
@@ -337,6 +337,7 @@ body>div>.popover .label {
 }
 
 .bootstrap .TestGroupBanner.alert {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -345,6 +346,32 @@ body>div>.popover .label {
   .TestGroupBanner-action {
     display: inline-block;
     padding-left: 5px;
+  }
+
+  // Hangs off the banner's top right corner rather than sitting inside it.
+  .TestGroupBanner-dismiss {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    float: none;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid rgba( 0, 0, 0, 0.15 );
+    border-radius: 50%;
+    background-color: #e0e0e0;
+    color: #666;
+    font-size: 16px;
+    font-weight: normal;
+    line-height: 22px;
+    text-shadow: none;
+    opacity: 1;
+
+    &:hover,
+    &:focus {
+      background-color: #cccccc;
+      color: #333;
+    }
   }
 
   .TestGroupBanner-feedback {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,6 +123,7 @@ class User < ApplicationRecord
   preference :suggestions_sort, :string
   preference :taxon_page_tab, :string
   preference :taxon_page_ancestors_shown, :boolean, default: false
+  preference :hide_responsive_global_toggle, :boolean, default: false
 
   NOTIFICATION_PREFERENCES = %w(
     comment_email_notification

--- a/app/views/shared/_test_group_toggle.html.haml
+++ b/app/views/shared/_test_group_toggle.html.haml
@@ -19,7 +19,7 @@
   :javascript
     ( function ( ) {
       var container = document.getElementById( "test-group-container" );
-      var key = "dismissedTestGroup:#{group}#{':joined' if joined}";
+      var key = "dismissedTestGroup:#{group}";
       var snoozeMs = 5 * 24 * 60 * 60 * 1000;
       try {
         var dismissedAt = Number( localStorage.getItem( key ) );

--- a/app/views/shared/_test_group_toggle.html.haml
+++ b/app/views/shared/_test_group_toggle.html.haml
@@ -4,9 +4,31 @@
   - key_prefix = group.tr( "-", "_" )
   - status_key = joined ? :"#{key_prefix}_test_joined_status" : :"#{key_prefix}_test_prompt"
   - path = joined ? leave_test_user_path( current_user, test: group ) : join_test_user_path( current_user, test: group )
-  .test-group-container
+  .test-group-container{ id: "test-group-container" }
     .TestGroupBanner.alert.alert-warning.text-center{ class: ( "TestGroupBanner--compact" if joined ) }
       = t( status_key )
       - if joined && ( feedback_url = feedback_urls[group] )
         = link_to t( :feedback ), feedback_url, class: "TestGroupBanner-feedback", target: "_blank", rel: "noopener noreferrer"
       = button_to t( joined ? :stop_testing : :yes ), path, method: :put, class: "btn #{joined ? 'btn-warning btn-xs' : 'btn-success'}", form_class: "TestGroupBanner-action"
+      - unless joined
+        %button.close.TestGroupBanner-dismiss{ type: "button", title: t( :dismiss ), "aria-label" => t( :dismiss ) }
+          %span{ "aria-hidden" => "true" }= "×"
+  - unless joined
+    :javascript
+      ( function ( ) {
+        var container = document.getElementById( "test-group-container" );
+        var key = "dismissedTestGroup:#{group}";
+        var snoozeMs = 5 * 24 * 60 * 60 * 1000;
+        try {
+          var dismissedAt = Number( localStorage.getItem( key ) );
+          if ( Date.now( ) - dismissedAt < snoozeMs ) {
+            container.style.display = "none";
+          } else if ( dismissedAt ) {
+            localStorage.removeItem( key );
+          }
+        } catch ( e ) { /* storage unavailable, banner just stays */ }
+        container.querySelector( ".TestGroupBanner-dismiss" ).addEventListener( "click", function ( ) {
+          container.style.display = "none";
+          try { localStorage.setItem( key, Date.now( ) ); } catch ( e ) { }
+        } );
+      } )( );

--- a/app/views/shared/_test_group_toggle.html.haml
+++ b/app/views/shared/_test_group_toggle.html.haml
@@ -10,25 +10,23 @@
       - if joined && ( feedback_url = feedback_urls[group] )
         = link_to t( :feedback ), feedback_url, class: "TestGroupBanner-feedback", target: "_blank", rel: "noopener noreferrer"
       = button_to t( joined ? :stop_testing : :yes ), path, method: :put, class: "btn #{joined ? 'btn-warning btn-xs' : 'btn-success'}", form_class: "TestGroupBanner-action"
-      - unless joined
-        %button.close.TestGroupBanner-dismiss{ type: "button", title: t( :dismiss ), "aria-label" => t( :dismiss ) }
-          %span{ "aria-hidden" => "true" }= "×"
-  - unless joined
-    :javascript
-      ( function ( ) {
-        var container = document.getElementById( "test-group-container" );
-        var key = "dismissedTestGroup:#{group}";
-        var snoozeMs = 5 * 24 * 60 * 60 * 1000;
-        try {
-          var dismissedAt = Number( localStorage.getItem( key ) );
-          if ( Date.now( ) - dismissedAt < snoozeMs ) {
-            container.style.display = "none";
-          } else if ( dismissedAt ) {
-            localStorage.removeItem( key );
-          }
-        } catch ( e ) { /* storage unavailable, banner just stays */ }
-        container.querySelector( ".TestGroupBanner-dismiss" ).addEventListener( "click", function ( ) {
+      %button.close.TestGroupBanner-dismiss{ type: "button", title: t( :dismiss ), "aria-label" => t( :dismiss ) }
+        %span{ "aria-hidden" => "true" }= "×"
+  :javascript
+    ( function ( ) {
+      var container = document.getElementById( "test-group-container" );
+      var key = "dismissedTestGroup:#{group}#{':joined' if joined}";
+      var snoozeMs = 5 * 24 * 60 * 60 * 1000;
+      try {
+        var dismissedAt = Number( localStorage.getItem( key ) );
+        if ( Date.now( ) - dismissedAt < snoozeMs ) {
           container.style.display = "none";
-          try { localStorage.setItem( key, Date.now( ) ); } catch ( e ) { }
-        } );
-      } )( );
+        } else if ( dismissedAt ) {
+          localStorage.removeItem( key );
+        }
+      } catch ( e ) { /* storage unavailable, banner just stays */ }
+      container.querySelector( ".TestGroupBanner-dismiss" ).addEventListener( "click", function ( ) {
+        container.style.display = "none";
+        try { localStorage.setItem( key, Date.now( ) ); } catch ( e ) { }
+      } );
+    } )( );

--- a/app/views/shared/_test_group_toggle.html.haml
+++ b/app/views/shared/_test_group_toggle.html.haml
@@ -12,10 +12,9 @@
       = button_to t( joined ? :stop_testing : :yes ), path, method: :put, class: "btn #{joined ? 'btn-warning btn-xs' : 'btn-success'}", form_class: "TestGroupBanner-action"
       %button.close.TestGroupBanner-dismiss{ type: "button", title: t( :dismiss ), "aria-label" => t( :dismiss ) }
         %span{ "aria-hidden" => "true" }= "×"
-  - if joined
-    .test-group-container.hidden{ id: "test-group-dismissed-notice" }
-      .TestGroupBanner.alert.alert-info.text-center.TestGroupBanner--compact.TestGroupBanner--text
-        = t( :leave_this_test_group_in_account_settings_html, url: generic_edit_user_path( anchor: "account" ) )
+  .test-group-container.hidden{ id: "test-group-dismissed-notice" }
+    .TestGroupBanner.alert.alert-info.text-center.TestGroupBanner--compact.TestGroupBanner--text
+      = t( :join_or_leave_this_test_in_account_settings_html, url: generic_edit_user_path( anchor: "account" ) )
   :javascript
     ( function ( ) {
       var container = document.getElementById( "test-group-container" );

--- a/app/views/shared/_test_group_toggle.html.haml
+++ b/app/views/shared/_test_group_toggle.html.haml
@@ -12,6 +12,10 @@
       = button_to t( joined ? :stop_testing : :yes ), path, method: :put, class: "btn #{joined ? 'btn-warning btn-xs' : 'btn-success'}", form_class: "TestGroupBanner-action"
       %button.close.TestGroupBanner-dismiss{ type: "button", title: t( :dismiss ), "aria-label" => t( :dismiss ) }
         %span{ "aria-hidden" => "true" }= "×"
+  - if joined
+    .test-group-container.hidden{ id: "test-group-dismissed-notice" }
+      .TestGroupBanner.alert.alert-info.text-center.TestGroupBanner--compact.TestGroupBanner--text
+        = t( :leave_this_test_group_in_account_settings_html, url: generic_edit_user_path( anchor: "account" ) )
   :javascript
     ( function ( ) {
       var container = document.getElementById( "test-group-container" );
@@ -25,8 +29,10 @@
           localStorage.removeItem( key );
         }
       } catch ( e ) { /* storage unavailable, banner just stays */ }
+      var notice = document.getElementById( "test-group-dismissed-notice" );
       container.querySelector( ".TestGroupBanner-dismiss" ).addEventListener( "click", function ( ) {
         container.style.display = "none";
+        if ( notice ) { notice.classList.remove( "hidden" ); }
         try { localStorage.setItem( key, Date.now( ) ); } catch ( e ) { }
       } );
     } )( );

--- a/app/views/shared/_test_group_toggle.html.haml
+++ b/app/views/shared/_test_group_toggle.html.haml
@@ -1,5 +1,6 @@
 - feedback_urls = { "responsive-global" => "https://inaturalist.typeform.com/to/HZsu49MO" }
-- if logged_in?
+- toggle_opt_out_preference = "prefers_hide_#{group.underscore}_toggle";
+- if logged_in? && !current_user.try( toggle_opt_out_preference )
   - joined = current_user.in_test_group?( group )
   - key_prefix = group.tr( "-", "_" )
   - status_key = joined ? :"#{key_prefix}_test_joined_status" : :"#{key_prefix}_test_prompt"
@@ -11,27 +12,18 @@
         = link_to t( :feedback ), feedback_url, class: "TestGroupBanner-feedback", target: "_blank", rel: "noopener noreferrer"
       = button_to t( joined ? :stop_testing : :yes ), path, method: :put, class: "btn #{joined ? 'btn-warning btn-xs' : 'btn-success'}", form_class: "TestGroupBanner-action"
       %button.close.TestGroupBanner-dismiss{ type: "button", title: t( :dismiss ), "aria-label" => t( :dismiss ) }
-        %span{ "aria-hidden" => "true" }= "×"
+        %i{ class: "fa fa-close" }
   .test-group-container.hidden{ id: "test-group-dismissed-notice" }
     .TestGroupBanner.alert.alert-info.text-center.TestGroupBanner--compact.TestGroupBanner--text
       = t( :join_or_leave_this_test_in_account_settings_html, url: generic_edit_user_path( anchor: "account" ) )
   :javascript
     ( function ( ) {
       var container = document.getElementById( "test-group-container" );
-      var key = "dismissedTestGroup:#{group}";
-      var snoozeMs = 5 * 24 * 60 * 60 * 1000;
-      try {
-        var dismissedAt = Number( localStorage.getItem( key ) );
-        if ( Date.now( ) - dismissedAt < snoozeMs ) {
-          container.style.display = "none";
-        } else if ( dismissedAt ) {
-          localStorage.removeItem( key );
-        }
-      } catch ( e ) { /* storage unavailable, banner just stays */ }
+      var toggleOptOutPreference = "#{toggle_opt_out_preference}";
       var notice = document.getElementById( "test-group-dismissed-notice" );
       container.querySelector( ".TestGroupBanner-dismiss" ).addEventListener( "click", function ( ) {
         container.style.display = "none";
         if ( notice ) { notice.classList.remove( "hidden" ); }
-        try { localStorage.setItem( key, Date.now( ) ); } catch ( e ) { }
+        updateSession( { [toggleOptOutPreference]: true } )
       } );
     } )( );

--- a/app/webpack/users/edit/components/account.jsx
+++ b/app/webpack/users/edit/components/account.jsx
@@ -217,7 +217,7 @@ const Account = ( {
                   <td className="col-xs-4 borderless table-row">
                     { I18n.t( "mobile_friendly_mode" ) }
                   </td>
-                  <td className="col-xs-4 borderless table-row">
+                  <td className="col-xs-4 borderless table-row text-center">
                     <button
                       type="button"
                       className="btn btn-success"
@@ -225,6 +225,16 @@ const Account = ( {
                     >
                       { config.currentUser.isInTestGroup( "responsive-global" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
                     </button>
+                    { config.currentUser.isInTestGroup( "responsive-global" ) && (
+                      <a
+                        className="btn btn-link"
+                        href="https://inaturalist.typeform.com/to/HZsu49MO"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        { I18n.t( "feedback" ) }
+                      </a>
+                    ) }
                   </td>
                 </tr>
                 { viewerIsAdmin && (

--- a/app/webpack/users/edit/components/account.jsx
+++ b/app/webpack/users/edit/components/account.jsx
@@ -210,88 +210,88 @@ const Account = ( {
               </SettingsItem>
             )
             : <div className="nocontent"><div className="loading_spinner" /></div> }
-          { ( viewerIsAdmin || config.currentUser.isInTestGroup( "helpful-id-tips-reviewer" ) ) && (
-            <SettingsItem header="Test Groups" htmlFor="user_test_groups">
-              <table className="table">
-                <tbody className="borderless">
-                  { viewerIsAdmin && (
-                    <>
-                      <tr>
-                        <td className="col-xs-4 borderless table-row">
-                          Responsive Global
-                        </td>
-                        <td className="col-xs-4 borderless table-row">
-                          <button
-                            type="button"
-                            className="btn btn-success"
-                            onClick={( ) => toggleGroup( "responsive-global" )}
-                          >
-                            { config.currentUser.isInTestGroup( "responsive-global" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
-                          </button>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className="col-xs-4 borderless table-row">
-                          Responsive Header
-                        </td>
-                        <td className="col-xs-4 borderless table-row">
-                          <button
-                            type="button"
-                            className="btn btn-success"
-                            onClick={( ) => toggleGroup( "responsive-header" )}
-                          >
-                            { config.currentUser.isInTestGroup( "responsive-header" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
-                          </button>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className="col-xs-4 borderless table-row">
-                          Responsive Obs Detail
-                        </td>
-                        <td className="col-xs-4 borderless table-row">
-                          <button
-                            type="button"
-                            className="btn btn-success"
-                            onClick={( ) => toggleGroup( "responsive-obs-detail" )}
-                          >
-                            { config.currentUser.isInTestGroup( "responsive-obs-detail" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
-                          </button>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className="col-xs-4 borderless table-row">
-                          Responsive Taxon Detail
-                        </td>
-                        <td className="col-xs-4 borderless table-row">
-                          <button
-                            type="button"
-                            className="btn btn-success"
-                            onClick={( ) => toggleGroup( "responsive-taxon-detail" )}
-                          >
-                            { config.currentUser.isInTestGroup( "responsive-taxon-detail" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
-                          </button>
-                        </td>
-                      </tr>
-                    </>
-                  ) }
+          <SettingsItem header={I18n.t( "test_groups" )} htmlFor="user_test_groups">
+            <table className="table">
+              <tbody className="borderless">
+                <tr>
+                  <td className="col-xs-4 borderless table-row">
+                    { I18n.t( "mobile_friendly_mode" ) }
+                  </td>
+                  <td className="col-xs-4 borderless table-row">
+                    <button
+                      type="button"
+                      className="btn btn-success"
+                      onClick={( ) => toggleGroup( "responsive-global" )}
+                    >
+                      { config.currentUser.isInTestGroup( "responsive-global" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
+                    </button>
+                  </td>
+                </tr>
+                { viewerIsAdmin && (
+                <>
                   <tr>
                     <td className="col-xs-4 borderless table-row">
-                      Helpful ID Tips
+                      Responsive Header
                     </td>
                     <td className="col-xs-4 borderless table-row">
                       <button
                         type="button"
                         className="btn btn-success"
-                        onClick={( ) => toggleGroup( "helpful-id-tips" )}
+                        onClick={( ) => toggleGroup( "responsive-header" )}
                       >
-                        { config.currentUser.isInTestGroup( "helpful-id-tips" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
+                        { config.currentUser.isInTestGroup( "responsive-header" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
                       </button>
                     </td>
                   </tr>
-                </tbody>
-              </table>
-            </SettingsItem>
-          )}
+                  <tr>
+                    <td className="col-xs-4 borderless table-row">
+                      Responsive Obs Detail
+                    </td>
+                    <td className="col-xs-4 borderless table-row">
+                      <button
+                        type="button"
+                        className="btn btn-success"
+                        onClick={( ) => toggleGroup( "responsive-obs-detail" )}
+                      >
+                        { config.currentUser.isInTestGroup( "responsive-obs-detail" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
+                      </button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="col-xs-4 borderless table-row">
+                      Responsive Taxon Detail
+                    </td>
+                    <td className="col-xs-4 borderless table-row">
+                      <button
+                        type="button"
+                        className="btn btn-success"
+                        onClick={( ) => toggleGroup( "responsive-taxon-detail" )}
+                      >
+                        { config.currentUser.isInTestGroup( "responsive-taxon-detail" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
+                      </button>
+                    </td>
+                  </tr>
+                </>
+                ) }
+                { ( viewerIsAdmin || config.currentUser.isInTestGroup( "helpful-id-tips-reviewer" ) ) && (
+                <tr>
+                  <td className="col-xs-4 borderless table-row">
+                    Helpful ID Tips
+                  </td>
+                  <td className="col-xs-4 borderless table-row">
+                    <button
+                      type="button"
+                      className="btn btn-success"
+                      onClick={( ) => toggleGroup( "helpful-id-tips" )}
+                    >
+                      { config.currentUser.isInTestGroup( "helpful-id-tips" ) ? I18n.t( "leave" ) : I18n.t( "join" ) }
+                    </button>
+                  </td>
+                </tr>
+                ) }
+              </tbody>
+            </table>
+          </SettingsItem>
         </div>
       </div>
       <div className="row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2872,6 +2872,10 @@ en:
   jobs: Jobs
   join: Join
   join_and_add_an_observation_to_project_html: Join and Add An Observation to %{project}
+  # Shown after dismissing a banner that invites you to join, or lets you
+  # leave, a test of a new feature, pointing at the other place to do both
+  join_or_leave_this_test_in_account_settings_html: |
+    You can join or leave this test any time in your <a href="%{url}">account settings</a>.
   join_project: Join this project
   # Prompt to join a specific project
   join_project?: Join %{project}?
@@ -2950,10 +2954,6 @@ en:
   leave: Leave
   leave_a_comment: Leave a comment
   leave_this_project: Leave this project
-  # Shown after dismissing the banner that lets you leave a test of a new
-  # feature, pointing at the other place you can leave it
-  leave_this_test_group_in_account_settings_html: |
-    You can leave this test any time in your <a href="%{url}">account settings</a>.
   # Terminal nodes in a taxonomic tree
   leaves: leaves
   legacy_authentication_notice_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3372,6 +3372,9 @@ en:
   # Label shown when a date has not been entered
   missing_date: Missing Date
   mobile: Mobile
+  # Name of the test group for the responsive, mobile-friendly redesign of the
+  # site, matching the wording of the banner that prompts you to join it
+  mobile_friendly_mode: Mobile-Friendly Mode
   moderation_history_for_user_html: Moderation history for %{user}
   moderation_history_desc_html: |
     This includes moderator actions (e.g. hiding or unhiding comments), notes,
@@ -6078,6 +6081,9 @@ en:
   # Describes buttons that let you control the format of text, e.g. bold, italic, etc.
   text_formatting_controls: Text formatting controls
   text_editing_controls: Text editing controls
+  # Heading for the account settings section where you join or leave tests of
+  # new features
+  test_groups: Test Groups
   thank_you!: Thank you!
   thanks!: Thanks!
   thanks_from_all_of_us_here_at: Thanks from all of us here at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2950,6 +2950,10 @@ en:
   leave: Leave
   leave_a_comment: Leave a comment
   leave_this_project: Leave this project
+  # Shown after dismissing the banner that lets you leave a test of a new
+  # feature, pointing at the other place you can leave it
+  leave_this_test_group_in_account_settings_html: |
+    You can leave this test any time in your <a href="%{url}">account settings</a>.
   # Terminal nodes in a taxonomic tree
   leaves: leaves
   legacy_authentication_notice_html: |

--- a/spec/views/layouts/bootstrap.rb
+++ b/spec/views/layouts/bootstrap.rb
@@ -76,12 +76,12 @@ describe "layouts/bootstrap" do
       expect( rendered ).to have_tag( "button.TestGroupBanner-dismiss" )
     end
 
-    it "renders no dismiss button for a user who has joined the group" do
+    it "renders a dismiss button for a user who has joined the group" do
       allow( view ).to receive( :current_user ).and_return( User.make!( test_groups: "responsive-global" ) )
       allow( view ).to receive( :logged_in? ).and_return( true )
       @test_group_toggle = "responsive-global"
       render
-      expect( rendered ).not_to have_tag( "button.TestGroupBanner-dismiss" )
+      expect( rendered ).to have_tag( "button.TestGroupBanner-dismiss" )
     end
   end
 

--- a/spec/views/layouts/bootstrap.rb
+++ b/spec/views/layouts/bootstrap.rb
@@ -67,6 +67,22 @@ describe "layouts/bootstrap" do
       render
       expect( rendered ).not_to have_tag( "div.TestGroupBanner" )
     end
+
+    it "renders a dismiss button for a user who has not joined the group" do
+      allow( view ).to receive( :current_user ).and_return( User.make! )
+      allow( view ).to receive( :logged_in? ).and_return( true )
+      @test_group_toggle = "responsive-global"
+      render
+      expect( rendered ).to have_tag( "button.TestGroupBanner-dismiss" )
+    end
+
+    it "renders no dismiss button for a user who has joined the group" do
+      allow( view ).to receive( :current_user ).and_return( User.make!( test_groups: "responsive-global" ) )
+      allow( view ).to receive( :logged_in? ).and_return( true )
+      @test_group_toggle = "responsive-global"
+      render
+      expect( rendered ).not_to have_tag( "button.TestGroupBanner-dismiss" )
+    end
   end
 
   describe "flash" do

--- a/spec/views/layouts/bootstrap.rb
+++ b/spec/views/layouts/bootstrap.rb
@@ -83,6 +83,22 @@ describe "layouts/bootstrap" do
       render
       expect( rendered ).to have_tag( "button.TestGroupBanner-dismiss" )
     end
+
+    it "renders a hidden account settings notice for a joined user only" do
+      allow( view ).to receive( :current_user ).and_return( User.make!( test_groups: "responsive-global" ) )
+      allow( view ).to receive( :logged_in? ).and_return( true )
+      @test_group_toggle = "responsive-global"
+      render
+      expect( rendered ).to have_tag( "div#test-group-dismissed-notice.hidden" )
+    end
+
+    it "renders no account settings notice for a user who has not joined" do
+      allow( view ).to receive( :current_user ).and_return( User.make! )
+      allow( view ).to receive( :logged_in? ).and_return( true )
+      @test_group_toggle = "responsive-global"
+      render
+      expect( rendered ).not_to have_tag( "div#test-group-dismissed-notice" )
+    end
   end
 
   describe "flash" do

--- a/spec/views/layouts/bootstrap.rb
+++ b/spec/views/layouts/bootstrap.rb
@@ -67,38 +67,6 @@ describe "layouts/bootstrap" do
       render
       expect( rendered ).not_to have_tag( "div.TestGroupBanner" )
     end
-
-    it "renders a dismiss button for a user who has not joined the group" do
-      allow( view ).to receive( :current_user ).and_return( User.make! )
-      allow( view ).to receive( :logged_in? ).and_return( true )
-      @test_group_toggle = "responsive-global"
-      render
-      expect( rendered ).to have_tag( "button.TestGroupBanner-dismiss" )
-    end
-
-    it "renders a dismiss button for a user who has joined the group" do
-      allow( view ).to receive( :current_user ).and_return( User.make!( test_groups: "responsive-global" ) )
-      allow( view ).to receive( :logged_in? ).and_return( true )
-      @test_group_toggle = "responsive-global"
-      render
-      expect( rendered ).to have_tag( "button.TestGroupBanner-dismiss" )
-    end
-
-    it "renders a hidden account settings notice for a joined user only" do
-      allow( view ).to receive( :current_user ).and_return( User.make!( test_groups: "responsive-global" ) )
-      allow( view ).to receive( :logged_in? ).and_return( true )
-      @test_group_toggle = "responsive-global"
-      render
-      expect( rendered ).to have_tag( "div#test-group-dismissed-notice.hidden" )
-    end
-
-    it "renders no account settings notice for a user who has not joined" do
-      allow( view ).to receive( :current_user ).and_return( User.make! )
-      allow( view ).to receive( :logged_in? ).and_return( true )
-      @test_group_toggle = "responsive-global"
-      render
-      expect( rendered ).not_to have_tag( "div#test-group-dismissed-notice" )
-    end
   end
 
   describe "flash" do

--- a/spec/views/shared/_test_group_toggle.html.haml_spec.rb
+++ b/spec/views/shared/_test_group_toggle.html.haml_spec.rb
@@ -21,7 +21,7 @@ describe "shared/_test_group_toggle" do
       expect( rendered ).to have_tag( "div.TestGroupBanner" ) do
         with_tag "form[action*='join_test'][action*='responsive-global']"
       end
-      expect( rendered ).not_to have_tag( "div.TestGroupBanner--compact" )
+      expect( rendered ).not_to have_tag( "#test-group-container div.TestGroupBanner--compact" )
       expect( rendered ).not_to have_tag( "div.TestGroupBanner .btn-xs" )
     end
 


### PR DESCRIPTION
- Show dismiss button on test group toggles
- Show message about how to leave test group via settings after dismissing opt-out toggle that disappears after navigating away
- Set localstorage on dismiss item to re-show either opt-in or opt-out test group toggle after 5 days
- Add ability for any user to leave responsiveness test group and leave feedback via settings

Opt-in:
<img width="1185" height="153" alt="Screenshot 2026-08-13 at 4 45 07 PM" src="https://github.com/user-attachments/assets/55e8f98b-0cf7-4dc8-b498-dff2fdcdb180" />

Opt-out:
<img width="844" height="139" alt="Screenshot 2026-08-13 at 4 44 31 PM" src="https://github.com/user-attachments/assets/c6629d4e-6d81-427e-8bfd-edad74432ca6" />

Message after opt-out dismissal:
<img width="835" height="96" alt="Screenshot 2026-08-13 at 4 44 41 PM" src="https://github.com/user-attachments/assets/2629086f-cf2c-4824-b8e2-b826425dd0d4" />

User setting:
<img width="309" height="148" alt="Screenshot 2026-08-13 at 4 44 23 PM" src="https://github.com/user-attachments/assets/ea41821b-bc91-4ff8-a1b7-ae95024a3f6e" />
