### PR TITLE
fix: Position place menu by its containing block, WEB-1226

### DIFF
--- a/app/webpack/taxa/shared/components/taxon_page_header.tsx
+++ b/app/webpack/taxa/shared/components/taxon_page_header.tsx
@@ -66,7 +66,9 @@ const TaxonPageHeader = ( {
         <div id="place-chooser-container">
           { PlaceChooserContainer && (
             <PlaceChooserContainer
-              container={document.getElementById( "app" ) ?? undefined}
+              container={
+                document.querySelector<HTMLElement>( "#wrapper.bootstrap" ) ?? undefined
+              }
               clearButton
             />
           ) }

--- a/app/webpack/taxa/show/components/app_legacy.jsx
+++ b/app/webpack/taxa/show/components/app_legacy.jsx
@@ -72,7 +72,10 @@ const App = ( { taxon, showNewTaxon, config } ) => {
                 }
               </h1>
               <div id="place-chooser-container">
-                <PlaceChooserContainer container={$( "#app" ).get( 0 )} clearButton />
+                <PlaceChooserContainer
+                  container={$( "#wrapper.bootstrap" ).get( 0 )}
+                  clearButton
+                />
               </div>
             </div>
           </Col>


### PR DESCRIPTION
#app no longer starts at #wrapper's top so the popover is drawn too high by that gap, fix by pointing the overlay at #wrapper

Before:
<img width="288" height="137" alt="Screenshot 2026-08-14 at 9 46 00 AM" src="https://github.com/user-attachments/assets/4de49ce2-e4ea-4f41-83e7-a9c3ebe66bc8" />

After:
<img width="234" height="138" alt="Screenshot 2026-08-14 at 9 46 19 AM" src="https://github.com/user-attachments/assets/d11e55ab-6539-41b6-b9c4-07922f016d49" />
