### PR TITLE
raise specific rails deprecation warnings in CI

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -106,9 +106,10 @@ class GuidesController < ApplicationController
         if params[:print].yesish?
           @layout = params[:layout] if Guide::PDF_LAYOUTS.include?( params[:layout] )
           @layout ||= Guide::GRID
-          @template = "guides/show_#{@layout}.pdf.haml"
-          render layout: "bootstrap.pdf",
+          @template = "guides/show_#{@layout}"
+          render layout: "bootstrap",
             template: @template,
+            formats: :pdf,
             orientation: ( @layout == "journal" ) ? "Landscape" : nil,
             margin: {
               left: 0,

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1230,7 +1230,7 @@ class ObservationsController < ApplicationController
         if fragment_exist?(@cache_key)
           render read_fragment(@cache_key)
         else
-          render :partial => 'add_from_list.html.erb'
+          render :partial => 'add_from_list', :formats => [:html]
         end
       end
     end

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -450,7 +450,7 @@ class PlacesController < ApplicationController
       format.html { redirect_to @place }
       format.json do
         @taxa.map! do | taxon |
-          taxon.html = render_to_string( partial: "taxa/taxon.html.erb",
+          taxon.html = render_to_string( partial: "taxa/taxon", formats: [:html],
             object: taxon, locals: {
               image_options: { size: "small" },
               link_image: true,

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -541,7 +541,7 @@ class ProjectsController < ApplicationController
         render :partial => "projects/observed_taxa_count_widget"
       end
       format.widget do
-        render :js => render_to_string(:partial => "projects/observed_taxa_count_widget.js.erb")
+        render :js => render_to_string(:partial => "projects/observed_taxa_count_widget", :formats => [:js])
       end
     end
   end
@@ -557,7 +557,7 @@ class ProjectsController < ApplicationController
     respond_to do |format|
       format.html
       format.widget do
-        render :js => render_to_string(:partial => "widget.js.erb")
+        render :js => render_to_string(:partial => "widget", :formats => [:js])
       end
     end
   end
@@ -611,7 +611,7 @@ class ProjectsController < ApplicationController
 
     # Load tips HTML
     @taxa.map! do |taxon|
-      taxon.html = render_to_string(:partial => 'taxa/taxon.html.erb', 
+      taxon.html = render_to_string(:partial => 'taxa/taxon', :formats => [:html],
         :object => taxon, :locals => {
           :image_options => {:size => 'small'},
           :link_image => true,

--- a/app/controllers/shared/lists_module.rb
+++ b/app/controllers/shared/lists_module.rb
@@ -353,7 +353,7 @@ module Shared::ListsModule
       format.html { redirect_to @list }
       format.json do
         @taxa.map! do |taxon|
-          taxon.html = render_to_string(:partial => 'taxa/taxon.html.erb', 
+          taxon.html = render_to_string(:partial => 'taxa/taxon', :formats => [:html],
             :object => taxon, :locals => {
               :image_options => {:size => 'small'},
               :link_image => true,

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -14,7 +14,7 @@ class SourcesController < ApplicationController
       format.html
       format.json do
         @sources = @sources.map do |source|
-          source.html = render_to_string(:partial => "chooser.html.haml", :object => source)
+          source.html = render_to_string(:partial => "chooser", :formats => [:html], :object => source)
           source
         end
         render :json => @sources.to_json(:methods => [:html])
@@ -26,7 +26,7 @@ class SourcesController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        @source.html = render_to_string(:partial => "chooser.html.haml", :object => @source)
+        @source.html = render_to_string(:partial => "chooser", :formats => [:html], :object => @source)
         render :json => @source.to_json(:methods => [:html])
       end
     end

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -478,7 +478,7 @@ class TaxaController < ApplicationController
     end
     respond_to do | format |
       format.html do
-        render partial: "clashes.html.haml", locals: { results: @results }
+        render partial: "clashes", formats: [:html], locals: { results: @results }
       end
       format.json do
         render json: @results.to_json( methods: [:html] )

--- a/app/helpers/taxa_helper.rb
+++ b/app/helpers/taxa_helper.rb
@@ -261,9 +261,9 @@ module TaxaHelper
       end
     end
     node[:data][:html] = if is_a?( ActionController::Base )
-      render_to_string( partial: "taxa/taxon.html.erb", object: taxon )
+      render_to_string( partial: "taxa/taxon", formats: [:html], object: taxon )
     else
-      render( partial: "taxa/taxon.html.erb", object: taxon )
+      render( partial: "taxa/taxon", formats: [:html], object: taxon )
     end
 
     node

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -859,7 +859,11 @@ class Observation < ApplicationRecord
     i18n_vars = {}
     key = if taxon
       i18n_vars[:taxon] = if options[:viewer]
-        ApplicationController.render( partial: "taxa/taxon.txt", locals: { taxon: taxon, viewer: options[:viewer] } )
+        ApplicationController.render(
+          partial: "taxa/taxon",
+          formats: [:txt],
+          locals: { taxon: taxon, viewer: options[:viewer] }
+        )
       else
         common_name( locale: I18n.locale )
       end

--- a/app/views/admin/user_content.html.haml
+++ b/app/views/admin/user_content.html.haml
@@ -18,9 +18,6 @@
       $('tr').labelize()
     })
 
-- content_for :extrahead do
-  = stylesheet_link_tag "admin/user_content"
-
 .container-fluid
   .row
     .col-xs-12

--- a/app/views/atlases/show.html.haml
+++ b/app/views/atlases/show.html.haml
@@ -1,6 +1,6 @@
 - content_for :title do
   Atlas for
-  = render "taxa/taxon.txt.erb", taxon: @atlas.taxon
+  = render partial: "taxa/taxon", formats: [:txt], locals: { taxon: @atlas.taxon }
 
 - content_for :extrajs do
   = javascript_include_tag "atlases/show"

--- a/app/views/flags/show.html.haml
+++ b/app/views/flags/show.html.haml
@@ -1,6 +1,6 @@
 :ruby
   @title = if @object.is_a?( Taxon )
-    t(:flag_for_taxon_title_html, title: link_to( render( "taxa/taxon.txt", taxon: @object ), @object ) )
+    t(:flag_for_taxon_title_html, title: link_to( render( partial: "taxa/taxon", formats: [:txt], locals: { taxon: @object } ), @object ) )
   elsif @object.is_a?( Observation )
     t(:flag_for_observation_title_html, title: link_to( @object.to_plain_s, @object ) )
   elsif @object.respond_to?( :title ) || @object.respond_to?( :name )

--- a/app/views/observations/_add_from_list.html.erb
+++ b/app/views/observations/_add_from_list.html.erb
@@ -39,12 +39,12 @@
 <div id="taxa" class="<%= @order %>">
   <% if @order == ListedTaxon::TAXONOMIC_ORDER -%>
     <% for order in @orders %>
-      <h3><%= render :partial => "shared/taxon.html.erb", :object => order %></h3>
+      <h3><%= render :partial => "shared/taxon", :object => order %></h3>
       <% for family in @families.select{|f| f.ancestry.index(order.child_ancestry)} %>
         <a name="<%= dom_id(family) %>"></a>
-        <h4><%= render :partial => "shared/taxon.html.erb", :object => family %></h4>
+        <h4><%= render :partial => "shared/taxon", :object => family %></h4>
         <ul class="listed_taxa">
-          <%= render :partial => 'add_from_list_li.html.erb', 
+          <%= render :partial => 'add_from_list_li', 
             :collection => @listed_taxa.select {|lt| lt.taxon.ancestry.index(family.child_ancestry) } %>
         </ul>
       <% end %>
@@ -52,7 +52,7 @@
 
   <% else %>
     <ul class="listed_taxa">
-      <%= render :partial => 'add_from_list_li.html.erb', :collection => @listed_taxa %>
+      <%= render :partial => 'add_from_list_li', :collection => @listed_taxa %>
     </ul>
   <% end -%>
 </div>

--- a/app/views/observations/_add_from_list_li.html.erb
+++ b/app/views/observations/_add_from_list_li.html.erb
@@ -1,7 +1,7 @@
 <%- listed_taxon ||= add_from_list_li -%>
         <li id="<%= dom_id(listed_taxon.taxon) %>" class="listed_taxon clear">
           <%- 
-            rendered_taxon_name = render(:partial => "shared/taxon.html.erb", :object => listed_taxon.taxon) 
+            rendered_taxon_name = render(:partial => "shared/taxon", :object => listed_taxon.taxon) 
             stripped_taxon_name = strip_tags(rendered_taxon_name).strip
             prevletter ||= nil
             letter = stripped_taxon_name.first.upcase

--- a/app/views/observations/add_from_list.html.erb
+++ b/app/views/observations/add_from_list.html.erb
@@ -40,7 +40,7 @@
 <%- end -%>
 
 <div id="pageheader">
-  <%= render :partial => "observations/new_nav.html.erb" %>
+  <%= render :partial => "observations/new_nav" %>
   
   <h2><%= @pagetitle %></h2>
   <%= form_tag url_for, :method => :get, :id => "listform" do %>
@@ -64,7 +64,7 @@
   <a name="taxa"></a>
   <%= form_tag new_observations_from_list_path, :id => "taxaform" do %>
     <% cache(@cache_key) do %>
-      <%= render :partial => 'add_from_list.html.erb' %>
+      <%= render :partial => 'add_from_list' %>
     <% end %>
     <div class="clear buttonrow">
       <%= submit_tag t(:create_observations), :class => "default button", "data-loading-click" => true %>

--- a/app/views/taxa/_description.html.haml
+++ b/app/views/taxa/_description.html.haml
@@ -67,7 +67,7 @@
         else
           @taxon.name
         end
-        ref = "<ref name=\"inaturalist-#{@taxon.name}\">{{cite web |title=#{render( "taxa/taxon.txt.erb", taxon: @taxon )} |url=#{taxon_url(@taxon)} |website=#{@site.name} |access-date=#{Date.today.strftime('%-d %B %Y')} |language=#{I18n.locale}}}</ref>"
+        ref = "<ref name=\"inaturalist-#{@taxon.name}\">{{cite web |title=#{render( partial: "taxa/taxon", formats: [:txt], locals: { taxon: @taxon } )} |url=#{taxon_url(@taxon)} |website=#{@site.name} |access-date=#{Date.today.strftime('%-d %B %Y')} |language=#{I18n.locale}}}</ref>"
         ref_link = "<ref name=\"inaturalist-#{@taxon.name}\" />"
         structure = <<-WIKI
           #{I18n.t(:taxon_is_a_rank,

--- a/app/views/taxa/browse_photos.html.haml
+++ b/app/views/taxa/browse_photos.html.haml
@@ -1,6 +1,6 @@
 - @no_footer_gap = true
 - content_for :title do
-  =t :photos_of_taxon_html, taxon: render( "taxa/taxon.txt.erb", taxon: @taxon )
+  =t :photos_of_taxon_html, taxon: render( partial: "taxa/taxon", formats: [:txt], locals: { taxon: @taxon } )
 - content_for :extrajs do
   :javascript
     var SERVER_PAYLOAD = {

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,30 @@ module Inaturalist
     config.load_defaults 5.0
     config.active_record.belongs_to_required_by_default = false
 
+    # Curated list of Rails deprecation warnings that block the next upgrade
+    # hop. Matched warnings use the disallowed deprecation behavior: :raise in
+    # test (see config/environments/test.rb), :log everywhere else. Strings
+    # are substring-matched, Regexps are matched against the full message.
+    # Grow this list at each upgrade phase. NOTE: this only covers warnings
+    # emitted after this config is applied at boot; warnings emitted by gems
+    # at require time are not affected.
+    config.active_support.disallowed_deprecation_warnings = [
+      # Removed in Rails 7.0
+      "Rendering actions with '.' in the name is deprecated",
+      # Sprockets: referencing an asset that is not in the pipeline
+      "is not present in the asset pipeline",
+      # Rails 7.x zeitwerk: require_dependency is deprecated
+      "require_dependency",
+      # Rails 7.1: serialize :attr, JSON -> serialize :attr, coder: JSON
+      /Passing the (coder|class) as positional argument/,
+      # Rails 7.2: enum status: {...} -> enum :status, {...}
+      "Defining enums with keyword arguments"
+    ]
+    # Rails 6.1 defaults the disallowed deprecation behavior to :raise; make
+    # :log the safe default for every environment. test.rb overrides this to
+    # :raise so the disallowed list fails CI.
+    config.active_support.disallowed_deprecation = :log
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,13 +14,7 @@ module Inaturalist
     config.load_defaults 5.0
     config.active_record.belongs_to_required_by_default = false
 
-    # Curated list of Rails deprecation warnings that block the next upgrade
-    # hop. Matched warnings use the disallowed deprecation behavior: :raise in
-    # test (see config/environments/test.rb), :log everywhere else. Strings
-    # are substring-matched, Regexps are matched against the full message.
-    # Grow this list at each upgrade phase. NOTE: this only covers warnings
-    # emitted after this config is applied at boot; warnings emitted by gems
-    # at require time are not affected.
+    # Rails deprecation warnings that are disallowed, and raise in CI.
     config.active_support.disallowed_deprecation_warnings = [
       # Removed in Rails 7.0
       "Rendering actions with '.' in the name is deprecated",
@@ -33,9 +27,6 @@ module Inaturalist
       # Rails 7.2: enum status: {...} -> enum :status, {...}
       "Defining enums with keyword arguments"
     ]
-    # Rails 6.1 defaults the disallowed deprecation behavior to :raise; make
-    # :log the safe default for every environment. test.rb overrides this to
-    # :raise so the disallowed list fails CI.
     config.active_support.disallowed_deprecation = :log
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,5 +75,9 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
+  # Deprecations on the curated disallowed list (application.rb) must be
+  # logged, never raised, in production
+  config.active_support.disallowed_deprecation = :log
+
   config.log_formatter = CustomLogFormatter.new
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,8 +75,6 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  # Deprecations on the curated disallowed list (application.rb) must be
-  # logged, never raised, in production
   config.active_support.disallowed_deprecation = :log
 
   config.log_formatter = CustomLogFormatter.new

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,8 +46,6 @@ Rails.application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  # Raise on deprecations from the curated disallowed list (see
-  # config.active_support.disallowed_deprecation_warnings in application.rb)
-  # so upgrade-breaking usage fails CI. Also applies to the e2e test server.
+  # Raise on deprecations from config.active_support.disallowed_deprecation_warnings in application.rb.
   config.active_support.disallowed_deprecation = :raise
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,9 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Raise on deprecations from the curated disallowed list (see
+  # config.active_support.disallowed_deprecation_warnings in application.rb)
+  # so upgrade-breaking usage fails CI. Also applies to the e2e test server.
+  config.active_support.disallowed_deprecation = :raise
 end

--- a/config/initializers/logstasher_subscribe.rb
+++ b/config/initializers/logstasher_subscribe.rb
@@ -2,3 +2,15 @@
 ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*args|
   Logstasher.write_action_controller_log(args)
 end
+
+# Deprecation warnings are published as notifications in production
+# (config.active_support.deprecation = :notify) and are otherwise invisible.
+# Log them so deprecated code paths exercised by real traffic can be found and
+# fixed, then added to the curated disallowed list in config/application.rb,
+# before the next Rails upgrade phase
+ActiveSupport::Notifications.subscribe "deprecation.rails" do | _name, _start, _finish, _id, payload |
+  Logstasher.write_custom_log(
+    "Deprecation warning: #{payload[:message]}",
+    backtrace: payload[:callstack]&.first( 5 )&.map( &:to_s )
+  )
+end

--- a/config/initializers/logstasher_subscribe.rb
+++ b/config/initializers/logstasher_subscribe.rb
@@ -3,11 +3,7 @@ ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*a
   Logstasher.write_action_controller_log(args)
 end
 
-# Deprecation warnings are published as notifications in production
-# (config.active_support.deprecation = :notify) and are otherwise invisible.
-# Log them so deprecated code paths exercised by real traffic can be found and
-# fixed, then added to the curated disallowed list in config/application.rb,
-# before the next Rails upgrade phase
+# Deprecation warnings are published as notifications in production.
 ActiveSupport::Notifications.subscribe "deprecation.rails" do | _name, _start, _finish, _id, payload |
   Logstasher.write_custom_log(
     "Deprecation warning: #{payload[:message]}",

--- a/spec/initializers/disallowed_deprecations_spec.rb
+++ b/spec/initializers/disallowed_deprecations_spec.rb
@@ -2,11 +2,7 @@
 
 require "spec_helper"
 
-# Exercises the curated list in config.active_support.disallowed_deprecation_warnings
-# (config/application.rb). The test environment raises on these
-# (config/environments/test.rb) so CI fails on upgrade-breaking usage, while other
-# environments log them. Messages here mirror the real Rails wording so the specs
-# lock the pattern-to-message contract for each list entry.
+# Tests config.active_support.disallowed_deprecation_warnings
 describe "disallowed deprecation warnings" do
   it "raises on require_dependency deprecations" do
     expect do

--- a/spec/initializers/disallowed_deprecations_spec.rb
+++ b/spec/initializers/disallowed_deprecations_spec.rb
@@ -52,6 +52,12 @@ describe "disallowed deprecation warnings" do
     end.to raise_error( ActiveSupport::DeprecationException )
   end
 
+  it "subscribes to deprecation notifications for production logging" do
+    expect(
+      ActiveSupport::Notifications.notifier.listening?( "deprecation.rails" )
+    ).to be true
+  end
+
   it "does not raise on deprecations that are not on the disallowed list" do
     original_behavior = ActiveSupport::Deprecation.behavior
     begin

--- a/spec/initializers/disallowed_deprecations_spec.rb
+++ b/spec/initializers/disallowed_deprecations_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Exercises the curated list in config.active_support.disallowed_deprecation_warnings
+# (config/application.rb). The test environment raises on these
+# (config/environments/test.rb) so CI fails on upgrade-breaking usage, while other
+# environments log them. Messages here mirror the real Rails wording so the specs
+# lock the pattern-to-message contract for each list entry.
+describe "disallowed deprecation warnings" do
+  it "raises on require_dependency deprecations" do
+    expect do
+      ActiveSupport::Deprecation.warn(
+        "require_dependency is deprecated and will be removed in Rails 7.1"
+      )
+    end.to raise_error( ActiveSupport::DeprecationException )
+  end
+
+  it "raises on positional serialize coder deprecations" do
+    expect do
+      ActiveSupport::Deprecation.warn(
+        "Passing the coder as positional argument is deprecated and will be " \
+          "removed in Rails 7.2. Please pass the coder as a keyword argument."
+      )
+    end.to raise_error( ActiveSupport::DeprecationException )
+  end
+
+  it "raises on keyword-argument enum deprecations" do
+    expect do
+      ActiveSupport::Deprecation.warn(
+        "Defining enums with keyword arguments is deprecated and will be " \
+          "removed in Rails 8.0. Positional arguments should be used instead."
+      )
+    end.to raise_error( ActiveSupport::DeprecationException )
+  end
+
+  it "raises on assets missing from the asset pipeline" do
+    expect do
+      ActiveSupport::Deprecation.warn(
+        "The asset \"admin/user_content.css\" is not present in the asset pipeline.\n" \
+          "Falling back to an asset that may be in the public folder.\n" \
+          "This behavior is deprecated and will be removed."
+      )
+    end.to raise_error( ActiveSupport::DeprecationException )
+  end
+
+  it "raises on rendering actions with '.' in the name" do
+    expect do
+      ActiveSupport::Deprecation.warn(
+        "Rendering actions with '.' in the name is deprecated: guides/show_grid.pdf.haml"
+      )
+    end.to raise_error( ActiveSupport::DeprecationException )
+  end
+
+  it "does not raise on deprecations that are not on the disallowed list" do
+    original_behavior = ActiveSupport::Deprecation.behavior
+    begin
+      # silence the default :stderr behavior to keep test output clean
+      ActiveSupport::Deprecation.behavior = :silence
+      expect do
+        ActiveSupport::Deprecation.warn( "some other deprecation we tolerate for now" )
+      end.not_to raise_error
+    ensure
+      ActiveSupport::Deprecation.behavior = original_behavior
+    end
+  end
+end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -521,6 +521,14 @@ describe Observation do
     end
   end
 
+  describe "#to_plain_s" do
+    it "renders the taxon partial when given a viewer" do
+      taxon = create :taxon, :as_species
+      observation = create :observation, taxon: taxon
+      expect( observation.to_plain_s( viewer: observation.user ) ).to include taxon.name
+    end
+  end
+
   describe "#set_license" do
     let!( :observation ) { create :observation }
 


### PR DESCRIPTION
This PR will cause CI to fail for specific deprecation warnings that have been fixed and added to the `config.active_support.disallowed_deprecation_warnings` array. We should continue to add to this list if we identify new deprecation warnings that need to be disallowed to unblock rails upgrade. This will prevent us from introducing new breaking changes to the rails upgrade pathway.

This PR also fixes existing deprecations that would otherwise throw errors in CI with these changes.

We also log deprecation warnings from production to capture all deprecation warnings in the disallowed list, not just those with test coverage.