### PR TITLE
chore: add specs for different identification workflows, WEB-1006

### DIFF
--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -1215,6 +1215,67 @@ describe Observation do
       expect( o.community_taxon ).to eq s1
     end
 
+    describe "with test cases" do
+      before { setup_test_case_taxonomy }
+
+      it "reverts the community ID and quality grade on identifier account deletion" do
+        o = make_research_grade_candidate_observation
+        Identification.make!( observation: o, taxon: @f, user: o.user )
+        Identification.make!( observation: o, taxon: @s1 )
+        o.reload
+        expect( o.community_taxon ).to eq @f
+        expect( o.quality_grade ).to eq Observation::NEEDS_ID
+
+        second_species_id = Identification.make!( observation: o, taxon: @s1 )
+        o.reload
+        expect( o.community_taxon ).to eq @s1
+        expect( o.quality_grade ).to eq Observation::RESEARCH_GRADE
+
+        without_delay { second_species_id.user.destroy }
+        o.reload
+        expect( o.community_taxon ).to eq @f
+        expect( o.quality_grade ).to eq Observation::NEEDS_ID
+      end
+
+      it "reverts the community ID and quality grade on identification deletion" do
+        o = make_research_grade_candidate_observation
+        Identification.make!( observation: o, taxon: @f, user: o.user )
+        Identification.make!( observation: o, taxon: @s1 )
+        o.reload
+        expect( o.community_taxon ).to eq @f
+        expect( o.quality_grade ).to eq Observation::NEEDS_ID
+
+        second_species_id = Identification.make!( observation: o, taxon: @s1 )
+        o.reload
+        expect( o.community_taxon ).to eq @s1
+        expect( o.quality_grade ).to eq Observation::RESEARCH_GRADE
+
+        without_delay { second_species_id.destroy }
+        o.reload
+        expect( o.community_taxon ).to eq @f
+        expect( o.quality_grade ).to eq Observation::NEEDS_ID
+      end
+
+      it "reverts the community ID and quality grade on identification withdrawal" do
+        o = make_research_grade_candidate_observation
+        Identification.make!( observation: o, taxon: @f, user: o.user )
+        Identification.make!( observation: o, taxon: @s1 )
+        o.reload
+        expect( o.community_taxon ).to eq @f
+        expect( o.quality_grade ).to eq Observation::NEEDS_ID
+
+        second_species_id = Identification.make!( observation: o, taxon: @s1 )
+        o.reload
+        expect( o.community_taxon ).to eq @s1
+        expect( o.quality_grade ).to eq Observation::RESEARCH_GRADE
+
+        without_delay { second_species_id.update( current: false ) }
+        o.reload
+        expect( o.community_taxon ).to eq @f
+        expect( o.quality_grade ).to eq Observation::NEEDS_ID
+      end
+    end
+
     describe "test cases: " do
       before { setup_test_case_taxonomy }
 


### PR DESCRIPTION
The tests simulate similar conditions under which we saw a data problem - an observation not reverting its quality grade and community ID after user deletion. It appears to me these conditions alone were not the source of the problem as they all lead to the expected behavior and not an incorrect community ID and quality grade. There must have been some other factor in the real-world user deletion where the `User.sane_destroy` method wasn't fully processed.

I attempted to look for similar cases in recent observations and have not found any yet: observations with 2 IDs, with one ID above species, where the observer has not opted out of community ID, where the observation hasn't been voted as "Community Taxon be improved: No", where the observation is research grade. I haven't found any yet

For now, I'm adding these new specs to ensure observation quality grade and community ID are updated correctly when an identifier deletes their account, deletes their ID, or withdraws their ID. My best guess is there was some problem processing the delayed job associated with a deleted user which caused it not to run completely, leaving some observations the deleted user ID'd with an unrefreshed community taxon and quality grade, but where the IDs were in fact deleted