### PR TITLE
gracefully handle missing google dependencies

### DIFF
--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -12,8 +12,6 @@ var loadMap3 = function ( ) {
 /* eslint-disable */
 
 // requires GoogleMap classes
-// Pages that load Google Maps asynchronously define google.maps before any
-// library loads, so also check for a member of the "maps" library
 if (
   typeof( google ) == "undefined"
   || typeof( google.maps ) == "undefined"

--- a/app/assets/javascripts/inaturalist/map3.js.erb
+++ b/app/assets/javascripts/inaturalist/map3.js.erb
@@ -12,7 +12,13 @@ var loadMap3 = function ( ) {
 /* eslint-disable */
 
 // requires GoogleMap classes
-if ( typeof( google ) == "undefined" || typeof( google.maps ) == "undefined") {
+// Pages that load Google Maps asynchronously define google.maps before any
+// library loads, so also check for a member of the "maps" library
+if (
+  typeof( google ) == "undefined"
+  || typeof( google.maps ) == "undefined"
+  || typeof( google.maps.Map ) == "undefined"
+) {
   return;
 }
 

--- a/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
@@ -133,10 +133,6 @@ inatTaxonMap.fit = function ( elt ) {
 
 inatTaxonMap.setupGoogleMap = function ( elt ) {
   var options = $( elt ).data( "taxonMapOptions" );
-  // On pages that load Google Maps asynchronously, `google` and `google.maps`
-  // exist before any library loads, so check for a member of the "maps"
-  // library and for the iNaturalist map helpers that loadMap3 defines only
-  // once the library is available
   if (
     typeof ( google ) === "undefined"
     || !google.maps

--- a/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
+++ b/app/assets/javascripts/jquery/plugins/inat/taxonmap.js.erb
@@ -133,7 +133,18 @@ inatTaxonMap.fit = function ( elt ) {
 
 inatTaxonMap.setupGoogleMap = function ( elt ) {
   var options = $( elt ).data( "taxonMapOptions" );
-  if ( typeof ( google ) === "undefined" ) {
+  // On pages that load Google Maps asynchronously, `google` and `google.maps`
+  // exist before any library loads, so check for a member of the "maps"
+  // library and for the iNaturalist map helpers that loadMap3 defines only
+  // once the library is available
+  if (
+    typeof ( google ) === "undefined"
+    || !google.maps
+    || typeof ( google.maps.Map ) !== "function"
+    || typeof ( iNaturalist ) === "undefined"
+    || !iNaturalist.Map
+    || typeof ( iNaturalist.Map.createMap ) !== "function"
+  ) {
     $( elt ).html( "<div class='alert alert-warning alert-inside text-center'>" + I18n.t( "google_maps_not_loaded_error" ) + "</div>" );
     return;
   }

--- a/app/webpack/geo_model/explain/components/app.jsx
+++ b/app/webpack/geo_model/explain/components/app.jsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";
 import SplitTaxon from "../../../shared/components/split_taxon";
 import TaxonMap from "../../../observations/identify/components/taxon_map";
+import { googleMapsIsLoaded } from "../../../shared/google_maps";
 
 /* global GEO_MODEL_TAXON */
 /* global GEO_MODEL_BOUNDS */
@@ -360,7 +361,7 @@ class App extends React.Component {
             }
           }]}
           gestureHandling="auto"
-          mapType={typeof ( google ) !== "undefined" ? google.maps.MapTypeId.TERRAIN : null}
+          mapType={googleMapsIsLoaded( ) ? google.maps.MapTypeId.TERRAIN : null}
           showLegend
         />
         <div className="container">

--- a/app/webpack/geo_model/explain/components/app.jsx
+++ b/app/webpack/geo_model/explain/components/app.jsx
@@ -61,6 +61,9 @@ class App extends React.Component {
 
   componentDidMount( ) {
     this.map = $( ".TaxonMap", ReactDOM.findDOMNode( this ) ).data( "taxonMap" );
+    // The map won't exist if the Maps API failed to load, e.g. when the
+    // browser blocks requests to Google
+    if ( !this.map ) return;
     this.map.setOptions( {
       styles: baseMapStyle,
       minZoom: 2,
@@ -87,6 +90,7 @@ class App extends React.Component {
 
   setLayer( selectLayer ) {
     const { taxon } = this.props;
+    if ( !this.map ) return;
     if ( this.state.selectedLayerIndex ) {
       this.map.overlayMapTypes.setAt( this.state.selectedLayerIndex - 1, null );
     }
@@ -356,7 +360,7 @@ class App extends React.Component {
             }
           }]}
           gestureHandling="auto"
-          mapType={google.maps.MapTypeId.TERRAIN}
+          mapType={typeof ( google ) !== "undefined" ? google.maps.MapTypeId.TERRAIN : null}
           showLegend
         />
         <div className="container">

--- a/app/webpack/geo_model/explain/components/app.jsx
+++ b/app/webpack/geo_model/explain/components/app.jsx
@@ -62,8 +62,7 @@ class App extends React.Component {
 
   componentDidMount( ) {
     this.map = $( ".TaxonMap", ReactDOM.findDOMNode( this ) ).data( "taxonMap" );
-    // The map won't exist if the Maps API failed to load, e.g. when the
-    // browser blocks requests to Google
+    // Handle blocked google requests.
     if ( !this.map ) return;
     this.map.setOptions( {
       styles: baseMapStyle,

--- a/app/webpack/geo_model/explain/webpack-entry.js
+++ b/app/webpack/geo_model/explain/webpack-entry.js
@@ -45,6 +45,7 @@ if (
       /* global loadMap3 */
       loadMap3( );
     } )
-    .catch( ( ) => { } )
+    // eslint-disable-next-line no-console
+    .catch( e => console.warn( "Google Maps failed to load", e ) )
     .then( renderApp );
 }

--- a/app/webpack/geo_model/explain/webpack-entry.js
+++ b/app/webpack/geo_model/explain/webpack-entry.js
@@ -18,20 +18,33 @@ const serverPayload = SERVER_PAYLOAD;
 const taxon = new Taxon( serverPayload.taxon );
 sharedStore.dispatch( setTaxon( taxon ) );
 
-google.maps.importLibrary( "maps" ).then( ( ) => (
-  google.maps.importLibrary( "drawing" )
-) ).then( ( ) => (
-  google.maps.importLibrary( "geometry" )
-) ).then( ( ) => (
-  google.maps.importLibrary( "places" )
-) )
-  .then( ( ) => {
-    /* global loadMap3 */
-    loadMap3( );
-    render(
-      <Provider store={sharedStore}>
-        <AppContainer />
-      </Provider>,
-      document.getElementById( "app" )
-    );
-  } );
+const renderApp = ( ) => render(
+  <Provider store={sharedStore}>
+    <AppContainer />
+  </Provider>,
+  document.getElementById( "app" )
+);
+
+// The Maps API may be unavailable, e.g. when the browser blocks requests to
+// Google; render the app without a map rather than not at all
+if (
+  typeof ( google ) === "undefined"
+  || !google.maps
+  || !google.maps.importLibrary
+) {
+  renderApp( );
+} else {
+  google.maps.importLibrary( "maps" ).then( ( ) => (
+    google.maps.importLibrary( "drawing" )
+  ) ).then( ( ) => (
+    google.maps.importLibrary( "geometry" )
+  ) ).then( ( ) => (
+    google.maps.importLibrary( "places" )
+  ) )
+    .then( ( ) => {
+      /* global loadMap3 */
+      loadMap3( );
+    } )
+    .catch( ( ) => { } )
+    .then( renderApp );
+}

--- a/app/webpack/geo_model/explain/webpack-entry.js
+++ b/app/webpack/geo_model/explain/webpack-entry.js
@@ -25,8 +25,6 @@ const renderApp = ( ) => render(
   document.getElementById( "app" )
 );
 
-// Handles loading Google Maps and its libraries, and adds graceful degradation
-// if the Maps API is blocked by the browser.
 const loadGoogleMaps = ( ) => {
   if (
     typeof ( google ) === "undefined"

--- a/app/webpack/geo_model/explain/webpack-entry.js
+++ b/app/webpack/geo_model/explain/webpack-entry.js
@@ -25,27 +25,22 @@ const renderApp = ( ) => render(
   document.getElementById( "app" )
 );
 
-// The Maps API may be unavailable, e.g. when the browser blocks requests to
-// Google; render the app without a map rather than not at all
-if (
-  typeof ( google ) === "undefined"
-  || !google.maps
-  || !google.maps.importLibrary
-) {
-  renderApp( );
-} else {
-  google.maps.importLibrary( "maps" ).then( ( ) => (
-    google.maps.importLibrary( "drawing" )
-  ) ).then( ( ) => (
-    google.maps.importLibrary( "geometry" )
-  ) ).then( ( ) => (
-    google.maps.importLibrary( "places" )
-  ) )
-    .then( ( ) => {
-      /* global loadMap3 */
-      loadMap3( );
-    } )
-    // eslint-disable-next-line no-console
-    .catch( e => console.warn( "Google Maps failed to load", e ) )
-    .then( renderApp );
-}
+// Handles loading Google Maps and its libraries, and adds graceful degradation
+// if the Maps API is blocked by the browser.
+const loadGoogleMaps = ( ) => {
+  if (
+    typeof ( google ) === "undefined"
+    || !google.maps
+    || !google.maps.importLibrary
+  ) {
+    return Promise.resolve( );
+  }
+  return google.maps.importLibrary( "maps" )
+    .then( ( ) => google.maps.importLibrary( "drawing" ) )
+    .then( ( ) => google.maps.importLibrary( "geometry" ) )
+    .then( ( ) => google.maps.importLibrary( "places" ) )
+    .then( ( ) => loadMap3( ) )
+    .catch( e => console.warn( "Google Maps failed to load", e ) );
+};
+
+loadGoogleMaps( ).then( renderApp );

--- a/app/webpack/observations/identify/components/taxon_map.jsx
+++ b/app/webpack/observations/identify/components/taxon_map.jsx
@@ -107,6 +107,9 @@ class TaxonMap extends React.Component {
   }
 
   setMapFromProps( ) {
+    // the taxonMap jQuery plugin is only defined once the Maps API has
+    // loaded, which never happens if the browser blocks requests to Google
+    if ( typeof ( $.fn.taxonMap ) !== "function" ) return;
     $( ReactDOM.findDOMNode( this ) ).taxonMap( this.props );
   }
 

--- a/app/webpack/observations/identify/components/taxon_map.jsx
+++ b/app/webpack/observations/identify/components/taxon_map.jsx
@@ -102,8 +102,6 @@ class TaxonMap extends React.Component {
       return;
     }
     this.setMapFromProps( );
-    // There is no map to resize if the Maps API never loaded, e.g. when the
-    // browser blocks requests to Google
     const map = $( ReactDOM.findDOMNode( this ) ).data( "taxonMap" );
     if ( map && googleMapsIsLoaded( ) ) {
       google.maps.event.trigger( map, "resize" );
@@ -111,8 +109,6 @@ class TaxonMap extends React.Component {
   }
 
   setMapFromProps( ) {
-    // The plugin itself shows a warning instead of a map when the Maps API
-    // failed to load, e.g. when the browser blocks requests to Google
     $( ReactDOM.findDOMNode( this ) ).taxonMap( this.props );
   }
 

--- a/app/webpack/observations/identify/components/taxon_map.jsx
+++ b/app/webpack/observations/identify/components/taxon_map.jsx
@@ -81,6 +81,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { objectToComparable } from "../../../shared/util";
+import { googleMapsIsLoaded } from "../../../shared/google_maps";
 
 class TaxonMap extends React.Component {
   componentDidMount( ) {
@@ -101,15 +102,17 @@ class TaxonMap extends React.Component {
       return;
     }
     this.setMapFromProps( );
-    if ( typeof ( google ) !== "undefined" ) {
-      google.maps.event.trigger( $( ReactDOM.findDOMNode( this ) ).data( "taxonMap" ), "resize" );
+    // There is no map to resize if the Maps API never loaded, e.g. when the
+    // browser blocks requests to Google
+    const map = $( ReactDOM.findDOMNode( this ) ).data( "taxonMap" );
+    if ( map && googleMapsIsLoaded( ) ) {
+      google.maps.event.trigger( map, "resize" );
     }
   }
 
   setMapFromProps( ) {
-    // the taxonMap jQuery plugin is only defined once the Maps API has
-    // loaded, which never happens if the browser blocks requests to Google
-    if ( typeof ( $.fn.taxonMap ) !== "function" ) return;
+    // The plugin itself shows a warning instead of a map when the Maps API
+    // failed to load, e.g. when the browser blocks requests to Google
     $( ReactDOM.findDOMNode( this ) ).taxonMap( this.props );
   }
 

--- a/app/webpack/observations/identify/components/taxon_map.test.jsx
+++ b/app/webpack/observations/identify/components/taxon_map.test.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import TaxonMap from "./taxon_map";
+
+// shared/util pulls in heic-to, which jest cannot transform
+jest.mock( "../../../shared/util", ( ) => ( {
+  objectToComparable: object => JSON.stringify( object )
+} ) );
+
+describe( "TaxonMap", ( ) => {
+  let taxonMap;
+  let data;
+
+  beforeEach( ( ) => {
+    taxonMap = jest.fn( );
+    data = jest.fn( );
+    global.$ = jest.fn( ( ) => ( { taxonMap, data } ) );
+  } );
+
+  afterEach( ( ) => {
+    delete global.google;
+    delete global.$;
+  } );
+
+  describe( "when Google is blocked on an async-loading page", ( ) => {
+    beforeEach( ( ) => {
+      // google_maps_async_js defines this stub without any network request,
+      // so google is defined but no library members are
+      global.google = { maps: { importLibrary: jest.fn( ) } };
+    } );
+
+    it( "still hands the element to the taxonMap plugin, which shows its own warning", ( ) => {
+      render( <TaxonMap reloadKey="a" /> );
+      expect( taxonMap ).toHaveBeenCalledTimes( 1 );
+    } );
+
+    it( "does not try to resize a map that never loaded when props change", ( ) => {
+      const { rerender } = render( <TaxonMap reloadKey="a" /> );
+      expect( ( ) => rerender( <TaxonMap reloadKey="b" /> ) ).not.toThrow( );
+      expect( taxonMap ).toHaveBeenCalledTimes( 2 );
+    } );
+  } );
+
+  describe( "when the maps library has loaded", ( ) => {
+    const fakeMap = { };
+
+    beforeEach( ( ) => {
+      global.google = {
+        maps: {
+          Map: function Map( ) { },
+          event: { trigger: jest.fn( ) }
+        }
+      };
+      data.mockReturnValue( fakeMap );
+    } );
+
+    it( "resizes the existing map when props change", ( ) => {
+      const { rerender } = render( <TaxonMap reloadKey="a" /> );
+      rerender( <TaxonMap reloadKey="b" /> );
+      expect( global.google.maps.event.trigger ).toHaveBeenCalledWith( fakeMap, "resize" );
+    } );
+
+    it( "does not resize when props are unchanged", ( ) => {
+      const { rerender } = render( <TaxonMap reloadKey="a" /> );
+      rerender( <TaxonMap reloadKey="a" /> );
+      expect( global.google.maps.event.trigger ).not.toHaveBeenCalled( );
+    } );
+  } );
+} );

--- a/app/webpack/observations/identify/components/taxon_map.test.jsx
+++ b/app/webpack/observations/identify/components/taxon_map.test.jsx
@@ -24,8 +24,6 @@ describe( "TaxonMap", ( ) => {
 
   describe( "when Google is blocked on an async-loading page", ( ) => {
     beforeEach( ( ) => {
-      // google_maps_async_js defines this stub without any network request,
-      // so google is defined but no library members are
       global.google = { maps: { importLibrary: jest.fn( ) } };
     } );
 

--- a/app/webpack/observations/uploader/components/google_places_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/google_places_autocomplete.jsx
@@ -10,8 +10,6 @@ class GooglePlacesAutocomplete extends React.Component {
   }
 
   componentDidMount( ) {
-    // Without the Maps API (e.g. Google blocked by the browser) there is
-    // nothing to wire up
     if ( typeof ( google ) === "undefined" ) return;
     this.placesAutocomplete = new google.maps.places.Autocomplete(
       this.input.current,

--- a/app/webpack/observations/uploader/components/google_places_autocomplete.jsx
+++ b/app/webpack/observations/uploader/components/google_places_autocomplete.jsx
@@ -10,6 +10,9 @@ class GooglePlacesAutocomplete extends React.Component {
   }
 
   componentDidMount( ) {
+    // Without the Maps API (e.g. Google blocked by the browser) there is
+    // nothing to wire up
+    if ( typeof ( google ) === "undefined" ) return;
     this.placesAutocomplete = new google.maps.places.Autocomplete(
       this.input.current,
       {

--- a/app/webpack/observations/uploader/components/location_chooser_map.jsx
+++ b/app/webpack/observations/uploader/components/location_chooser_map.jsx
@@ -64,8 +64,7 @@ class LocationChooserMap extends React.Component {
       updateState,
       zoom
     } = this.props;
-    // When Google is blocked the Maps API never loads; skip map setup so the
-    // rest of the location chooser still works
+
     if ( typeof ( google ) === "undefined" ) return;
     const domNode = ReactDOM.findDOMNode( this );
     const map = iNaturalist.Map.createMap( {

--- a/app/webpack/observations/uploader/components/location_chooser_map.jsx
+++ b/app/webpack/observations/uploader/components/location_chooser_map.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import _ from "lodash";
 import util from "../models/util";
 import { objectToComparable } from "../../../shared/util";
-import PhotoMarkerOverlayView from "./photo_marker_overlay_view";
+import definePhotoMarkerOverlayView from "./photo_marker_overlay_view";
 import GooglePlacesAutocomplete from "./google_places_autocomplete";
 
 let lastCenterChange = new Date().getTime();
@@ -64,6 +64,9 @@ class LocationChooserMap extends React.Component {
       updateState,
       zoom
     } = this.props;
+    // When Google is blocked the Maps API never loads; skip map setup so the
+    // rest of the location chooser still works
+    if ( typeof ( google ) === "undefined" ) return;
     const domNode = ReactDOM.findDOMNode( this );
     const map = iNaturalist.Map.createMap( {
       ...iNaturalist.Map.DEFAULT_GOOGLE_MAP_OPTIONS,
@@ -227,6 +230,8 @@ class LocationChooserMap extends React.Component {
       radius
     } = this.props;
 
+    if ( typeof ( google ) === "undefined" || !this.map ) return;
+
     // Determine if we should re-render the overlays
     const comparableKeys = [
       "show",
@@ -286,10 +291,11 @@ class LocationChooserMap extends React.Component {
     }
 
     // Add new markers for obs cards
+    const PhotoMarkerOverlayView = definePhotoMarkerOverlayView( );
     _.each( obsCards, card => {
       if ( card.latitude && !( currentCard && currentCard.id === card.id ) ) {
         const cardImage = $( `[data-id=${card.id}] .carousel-inner img:first` );
-        if ( cardImage.length > 0 ) {
+        if ( PhotoMarkerOverlayView && cardImage.length > 0 ) {
           const overlay = new PhotoMarkerOverlayView(
             cardImage[0].src,
             { lat: card.latitude, lng: card.longitude }
@@ -424,10 +430,12 @@ class LocationChooserMap extends React.Component {
     return (
       <div className="LocationChooserMap map">
         <div className="map-inner" />
-        <GooglePlacesAutocomplete
-          bounds={bounds}
-          onPlacesChanged={this.handlePlacesChanged}
-        />
+        { typeof ( google ) !== "undefined" && (
+          <GooglePlacesAutocomplete
+            bounds={bounds}
+            onPlacesChanged={this.handlePlacesChanged}
+          />
+        ) }
       </div>
     );
   }

--- a/app/webpack/observations/uploader/components/photo_marker_overlay_view.js
+++ b/app/webpack/observations/uploader/components/photo_marker_overlay_view.js
@@ -1,8 +1,5 @@
 let PhotoMarkerOverlayView;
 
-// google.maps.OverlayView only exists once the Maps API has loaded, so the
-// class must be defined lazily rather than at module evaluation time, which
-// would break the whole bundle when Google is blocked
 export default function definePhotoMarkerOverlayView( ) {
   if ( PhotoMarkerOverlayView ) return PhotoMarkerOverlayView;
   if ( typeof ( google ) === "undefined" ) return null;

--- a/app/webpack/observations/uploader/components/photo_marker_overlay_view.js
+++ b/app/webpack/observations/uploader/components/photo_marker_overlay_view.js
@@ -1,33 +1,43 @@
-export default class PhotoMarkerOverlayView extends google.maps.OverlayView {
-  constructor( imgUrl, latLng ) {
-    super( );
-    this.imgUrl = imgUrl;
-    this.latLng = latLng;
-  }
+let PhotoMarkerOverlayView;
 
-  onAdd( ) {
-    this.div = document.createElement( "div" );
-    this.div.style.position = "absolute";
-    this.div.classList.add( "photo-marker" );
-    const img = document.createElement( "img" );
-    img.src = this.imgUrl;
-    this.div.appendChild( img );
-    this.getPanes( ).overlayLayer.appendChild( this.div );
-  }
-
-  draw( ) {
-    const proj = this.getProjection( );
-    if ( proj && this.latLng && this.div ) {
-      const point = proj.fromLatLngToDivPixel( this.latLng );
-      this.div.style.left = `${point.x}px`;
-      this.div.style.top = `${point.y}px`;
+// google.maps.OverlayView only exists once the Maps API has loaded, so the
+// class must be defined lazily rather than at module evaluation time, which
+// would break the whole bundle when Google is blocked
+export default function definePhotoMarkerOverlayView( ) {
+  if ( PhotoMarkerOverlayView ) return PhotoMarkerOverlayView;
+  if ( typeof ( google ) === "undefined" ) return null;
+  PhotoMarkerOverlayView = class extends google.maps.OverlayView {
+    constructor( imgUrl, latLng ) {
+      super( );
+      this.imgUrl = imgUrl;
+      this.latLng = latLng;
     }
-  }
 
-  onRemove() {
-    if ( this.div ) {
-      this.div.parentNode.removeChild( this.div );
-      delete this.div;
+    onAdd( ) {
+      this.div = document.createElement( "div" );
+      this.div.style.position = "absolute";
+      this.div.classList.add( "photo-marker" );
+      const img = document.createElement( "img" );
+      img.src = this.imgUrl;
+      this.div.appendChild( img );
+      this.getPanes( ).overlayLayer.appendChild( this.div );
     }
-  }
+
+    draw( ) {
+      const proj = this.getProjection( );
+      if ( proj && this.latLng && this.div ) {
+        const point = proj.fromLatLngToDivPixel( this.latLng );
+        this.div.style.left = `${point.x}px`;
+        this.div.style.top = `${point.y}px`;
+      }
+    }
+
+    onRemove() {
+      if ( this.div ) {
+        this.div.parentNode.removeChild( this.div );
+        delete this.div;
+      }
+    }
+  };
+  return PhotoMarkerOverlayView;
 }

--- a/app/webpack/observations/uploader/components/photo_marker_overlay_view.test.js
+++ b/app/webpack/observations/uploader/components/photo_marker_overlay_view.test.js
@@ -1,0 +1,62 @@
+describe( "definePhotoMarkerOverlayView", ( ) => {
+  beforeEach( ( ) => {
+    jest.resetModules( );
+    delete global.google;
+  } );
+
+  afterEach( ( ) => {
+    delete global.google;
+  } );
+
+  describe( "when google is not defined", ( ) => {
+    it( "can be imported without throwing", ( ) => {
+      // Regression test for WEB-1240: a top-level `extends
+      // google.maps.OverlayView` threw at module evaluation time when Google
+      // was blocked, taking down the whole observations-uploader bundle
+      expect( ( ) => {
+        // eslint-disable-next-line global-require
+        require( "./photo_marker_overlay_view" );
+      } ).not.toThrow( );
+    } );
+
+    it( "returns null", ( ) => {
+      // eslint-disable-next-line global-require
+      const definePhotoMarkerOverlayView = require( "./photo_marker_overlay_view" ).default;
+      expect( definePhotoMarkerOverlayView( ) ).toBeNull( );
+    } );
+  } );
+
+  describe( "when google.maps is available", ( ) => {
+    class MockOverlayView { }
+
+    beforeEach( ( ) => {
+      global.google = { maps: { OverlayView: MockOverlayView } };
+    } );
+
+    it( "returns a class extending google.maps.OverlayView", ( ) => {
+      // eslint-disable-next-line global-require
+      const definePhotoMarkerOverlayView = require( "./photo_marker_overlay_view" ).default;
+      const PhotoMarkerOverlayView = definePhotoMarkerOverlayView( );
+      const latLng = { lat: 1, lng: 2 };
+      const overlay = new PhotoMarkerOverlayView( "http://example.com/photo.jpg", latLng );
+      expect( overlay ).toBeInstanceOf( MockOverlayView );
+      expect( overlay.imgUrl ).toBe( "http://example.com/photo.jpg" );
+      expect( overlay.latLng ).toBe( latLng );
+    } );
+
+    it( "memoizes the class between calls", ( ) => {
+      // eslint-disable-next-line global-require
+      const definePhotoMarkerOverlayView = require( "./photo_marker_overlay_view" ).default;
+      expect( definePhotoMarkerOverlayView( ) ).toBe( definePhotoMarkerOverlayView( ) );
+    } );
+
+    it( "defines the class even if a previous call ran without google", ( ) => {
+      // eslint-disable-next-line global-require
+      const definePhotoMarkerOverlayView = require( "./photo_marker_overlay_view" ).default;
+      delete global.google;
+      expect( definePhotoMarkerOverlayView( ) ).toBeNull( );
+      global.google = { maps: { OverlayView: MockOverlayView } };
+      expect( definePhotoMarkerOverlayView( ) ).not.toBeNull( );
+    } );
+  } );
+} );

--- a/app/webpack/observations/uploader/components/photo_marker_overlay_view.test.js
+++ b/app/webpack/observations/uploader/components/photo_marker_overlay_view.test.js
@@ -10,9 +10,6 @@ describe( "definePhotoMarkerOverlayView", ( ) => {
 
   describe( "when google is not defined", ( ) => {
     it( "can be imported without throwing", ( ) => {
-      // Regression test for WEB-1240: a top-level `extends
-      // google.maps.OverlayView` threw at module evaluation time when Google
-      // was blocked, taking down the whole observations-uploader bundle
       expect( ( ) => {
         // eslint-disable-next-line global-require
         require( "./photo_marker_overlay_view" );

--- a/app/webpack/observations/uploader/models/util.js
+++ b/app/webpack/observations/uploader/models/util.js
@@ -52,7 +52,6 @@ const util = class util {
 
   // returns a Promise
   static reverseGeocode( lat, lng ) {
-    // new Promise( ) with no executor throws, so resolve with no location
     if ( typeof ( google ) === "undefined" ) return Promise.resolve( null );
     const geocoder = new google.maps.Geocoder( );
     return new Promise( resolve => {

--- a/app/webpack/observations/uploader/models/util.js
+++ b/app/webpack/observations/uploader/models/util.js
@@ -52,7 +52,8 @@ const util = class util {
 
   // returns a Promise
   static reverseGeocode( lat, lng ) {
-    if ( typeof ( google ) === "undefined" ) return new Promise( );
+    // new Promise( ) with no executor throws, so resolve with no location
+    if ( typeof ( google ) === "undefined" ) return Promise.resolve( null );
     const geocoder = new google.maps.Geocoder( );
     return new Promise( resolve => {
       geocoder.geocode( { location: { lat, lng } }, ( results, status ) => {

--- a/app/webpack/shared/google_maps.js
+++ b/app/webpack/shared/google_maps.js
@@ -1,7 +1,4 @@
-// True once the Google Maps "maps" library has actually loaded. Pages using
-// google_maps_async_js define window.google and google.maps.importLibrary
-// before any library loads, without any network request, so `typeof google`
-// alone cannot tell whether the browser blocked requests to Google.
+// True once the Google Maps "maps" library has actually loaded.
 export function googleMapsIsLoaded( ) {
   return typeof ( google ) !== "undefined"
     && !!google.maps

--- a/app/webpack/shared/google_maps.js
+++ b/app/webpack/shared/google_maps.js
@@ -1,0 +1,11 @@
+// True once the Google Maps "maps" library has actually loaded. Pages using
+// google_maps_async_js define window.google and google.maps.importLibrary
+// before any library loads, without any network request, so `typeof google`
+// alone cannot tell whether the browser blocked requests to Google.
+export function googleMapsIsLoaded( ) {
+  return typeof ( google ) !== "undefined"
+    && !!google.maps
+    && typeof ( google.maps.Map ) === "function";
+}
+
+export default googleMapsIsLoaded;

--- a/app/webpack/shared/google_maps.test.js
+++ b/app/webpack/shared/google_maps.test.js
@@ -11,9 +11,6 @@ describe( "googleMapsIsLoaded", ( ) => {
   } );
 
   it( "is false for the async bootstrap stub (async loader blocked)", ( ) => {
-    // google_maps_async_js defines window.google, google.maps and
-    // google.maps.importLibrary with no network request, so these exist even
-    // when the browser blocks Google
     global.google = { maps: { importLibrary: ( ) => Promise.reject( new Error( "blocked" ) ) } };
     expect( googleMapsIsLoaded( ) ).toBe( false );
   } );

--- a/app/webpack/shared/google_maps.test.js
+++ b/app/webpack/shared/google_maps.test.js
@@ -1,0 +1,35 @@
+import { googleMapsIsLoaded } from "./google_maps";
+
+describe( "googleMapsIsLoaded", ( ) => {
+  afterEach( ( ) => {
+    delete global.google;
+  } );
+
+  it( "is false when google is undefined (synchronous loader blocked)", ( ) => {
+    delete global.google;
+    expect( googleMapsIsLoaded( ) ).toBe( false );
+  } );
+
+  it( "is false for the async bootstrap stub (async loader blocked)", ( ) => {
+    // google_maps_async_js defines window.google, google.maps and
+    // google.maps.importLibrary with no network request, so these exist even
+    // when the browser blocks Google
+    global.google = { maps: { importLibrary: ( ) => Promise.reject( new Error( "blocked" ) ) } };
+    expect( googleMapsIsLoaded( ) ).toBe( false );
+  } );
+
+  it( "is false when google.maps is missing", ( ) => {
+    global.google = { };
+    expect( googleMapsIsLoaded( ) ).toBe( false );
+  } );
+
+  it( "is true once the maps library has loaded", ( ) => {
+    global.google = {
+      maps: {
+        Map: function Map( ) { },
+        MapTypeId: { TERRAIN: "terrain" }
+      }
+    };
+    expect( googleMapsIsLoaded( ) ).toBe( true );
+  } );
+} );


### PR DESCRIPTION
Extends previous work in #3243 to handle asynchronous map loading added in 1d0b9284b9a44af8f83c5ec68422ff82f820803a and handle unguarded instances of `google.maps...`.

## Testing

### Conditions to test:
- With all domains accessible.
- With Google requests blocked in dev console: 
<img width="608" height="306" alt="image" src="https://github.com/user-attachments/assets/7edd31d3-7c3d-4722-987d-8d9297779e0e" />


### Paths to test:

- `/observations/upload`
- `/geo_model/7/explain`
- `/observations?taxon_id=7`
- `/observations/1`
- `/observations/identify`
- `/taxa/7`
- `/projects/1` (or some collection project w/ observations)
-  `/observations/compare` (click map tab)