### PR TITLE
fix: Position "No Photo" text properly, WEB-1255

### DIFF
--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -303,6 +303,7 @@ a.UserImage,
           color: #808080;
           text-align: left;
           & > div {
+            position: relative;
             min-height: 500px;
           }
           & > div > i {


### PR DESCRIPTION
Before:
<img width="1133" height="597" alt="Screenshot 2026-09-01 at 4 51 11 PM" src="https://github.com/user-attachments/assets/10672123-8e31-41a0-ac18-1d47cce244a0" />

After:
<img width="1132" height="599" alt="Screenshot 2026-09-01 at 4 50 57 PM" src="https://github.com/user-attachments/assets/c4b64a2c-306f-4853-acd6-7dbfb6a8b7be" />
