### PR TITLE
feat: Add en-CA locale: WEB-1270

### DIFF
--- a/config/locales/en-CA.yml
+++ b/config/locales/en-CA.yml
@@ -1,0 +1,9 @@
+en-CA:
+  number:
+    format:
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      format:
+        significant: true
+        strip_insignificant_zeros: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3158,6 +3158,7 @@ en:
     de: German
     el: Greek
     en: English
+    en-CA: English (Canada)
     en-GB: English (UK)
     eo: Esperanto
     es: Spanish


### PR DESCRIPTION
Adds English (Canada) locale.

en-CA is registered as a supported locale (new config/locales/en-CA.yml) and listed as en-CA: English (Canada) in the locales: block of config/locales/en.yml, which—after regenerating the JS translations—makes English (Canada) appear in the account language dropdown.