### PR TITLE
fix: Add responsive variant to dashboard updates cache key, WEB-1256

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,11 +60,12 @@ class UsersController < ApplicationController
     :cache_path => Proc.new {|c|
       c.send(
         :dashboard_updates_url,
-        :user_id => c.instance_variable_get("@current_user").id,
-        :ssl => c.request.ssl?
+        :user_id => c.instance_variable_get( "@current_user" ).id,
+        :ssl => c.request.ssl?,
+        :variant => Array( c.request.variant ).first
       )
     },
-    :if => Proc.new {|c| 
+    :if => Proc.new {|c|
       (c.params.keys - %w(action controller format)).blank?
     }
   cache_sweeper :user_sweeper, :only => [:update]


### PR DESCRIPTION
We were sometimes serving cached legacy dashboard html with responsive CSS. The legacy .sub-badge is absolutely-positioned for the legacy layout, so on the responsive dashboard it lands on top of the observations (the reported "flag icon covering observations").

I was able to reproduce locally by enabling caching in development with:
```
  config.action_controller.perform_caching = true
  config.cache_store = :memory_store
```
then restarting the server. I already had a timeline item with the activity badge for my user, so I first removed my user from the responsive global test group via console*, then loaded the page, caching the legacy html. Then I moved my user to the responsive global test group and reloaded. The resulting page loaded with legacy html but responsive css and reproduced the bug:
<img width="879" height="508" alt="Screenshot 2026-09-02 at 4 24 59 PM" src="https://github.com/user-attachments/assets/c3be7984-7877-423b-9dee-51017bc73545" />

*Just FYI, I couldn't reproduce this without manually updating the test group from console because otherwise the cache was expired by the sweeper. In production, there appears to be some other mechanism allowing this to happen from simply clicking the banner. Maybe something like a network site URL preventing the the sweeper from deleting the cache when the test group update occurs. Regardless changing the cache key should solve this problem.