### PR TITLE
fix: Allow italics in responsive observation details notes, WEB-1241

### DIFF
--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -683,9 +683,17 @@ a.UserImage,
       margin-top: 15px;
     }
   }
+  // Undo the legacy global .description style, which greys and italicizes the
+  // block and then flips nested <em> back to upright for contrast. Notes are
+  // user prose, so <em> must stay italic.
   .description {
     font-style: normal;
     color: inherit;
+
+    em {
+      font-style: italic;
+      color: inherit;
+    }
   }
   @media ( max-width: $sm-max ) {
     .compare-obs-btn {

--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -683,15 +683,6 @@ a.UserImage,
       margin-top: 15px;
     }
   }
-  .description {
-    font-style: normal;
-    color: inherit;
-
-    em {
-      font-style: italic;
-      color: inherit;
-    }
-  }
   @media ( max-width: $sm-max ) {
     .compare-obs-btn {
       display: none;

--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -683,9 +683,6 @@ a.UserImage,
       margin-top: 15px;
     }
   }
-  // Undo the legacy global .description style, which greys and italicizes the
-  // block and then flips nested <em> back to upright for contrast. Notes are
-  // user prose, so <em> must stay italic.
   .description {
     font-style: normal;
     color: inherit;

--- a/app/webpack/observations/show/components/app.tsx
+++ b/app/webpack/observations/show/components/app.tsx
@@ -257,7 +257,7 @@ class App extends React.Component<AppProps> {
     const taxonUrl = observation.taxon ? `/taxa/${observation.taxon.id}` : null;
     const description = observation.description
       ? (
-        <div className="description">
+        <>
           <h3>
             {
               I18n.t( "notes", {
@@ -266,7 +266,7 @@ class App extends React.Component<AppProps> {
             }
           </h3>
           <UserText text={observation.description} />
-        </div>
+        </>
       )
       : "";
     const qualityGrade = observation.quality_grade === "research"


### PR DESCRIPTION
I for some reason gave this div the `description` class which inherited a global style, which was later "fixed" by overriding with the style we're removing in this PR. That "fix" was preventing italics `em` from displaying because of `font-style: normal`.

There was never any reason for this to be a div let alone a classed one, so we can just use `<>` to wrap.