### PR TITLE
fix: Prevent header from overflowing, WEB-1261

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -457,6 +457,8 @@ $(document).ready(function() {
   $('.dna').dnaHighlight()
 
   if ( $( "#header" ).length > 0 ) {
+    fitHeader( );
+    $( window ).on( "resize", _.debounce( fitHeader, 100 ) );
     $( "#header .search input" ).universalAutocomplete( );
     function showHeaderSearch() {
       $( "#headersearch" ).addClass( "open" );
@@ -974,6 +976,26 @@ $.fn.naturalHeight = function() {
 }
 
 
+// Beyond this the exact number adds width without adding meaning, and the
+// header has little width to spare on narrow screens.
+var MAX_HEADER_COUNT = 99
+
+function headerCountLabel(count) {
+  return count > MAX_HEADER_COUNT ? MAX_HEADER_COUNT + "+" : count
+}
+
+// The header lays out in a single row, so long notification counts can push it
+// wider than the viewport. Dropping the least essential item is preferable to
+// horizontal overflow of the whole page.
+function fitHeader() {
+  var header = document.getElementById( "header" );
+  if ( !header ) { return; }
+  header.classList.remove( "crowded" );
+  if ( header.scrollWidth > header.clientWidth ) {
+    header.classList.add( "crowded" );
+  }
+}
+
 function setUpdatesCount(count, options) {
   options = options || {}
   if (count > 0) {
@@ -982,7 +1004,7 @@ function setUpdatesCount(count, options) {
     } else {
       $('#header .updates').switchClass('', 'hasupdates')
     }
-    $('#header .updates .count').html(count)
+    $('#header .updates .count').html(headerCountLabel(count))
   } else {
     if (options.skipAnimation) {
       $('#header .updates').removeClass('hasupdates')
@@ -991,6 +1013,7 @@ function setUpdatesCount(count, options) {
     }
     $('#header .updates .count').html(0)
   }
+  fitHeader()
 }
 
 function getUpdatesCount() {
@@ -1007,7 +1030,7 @@ function setMessagesCount(count, options) {
     } else {
       $('#header .messages').switchClass('', 'hasupdates')
     }
-    $('#header .messages .count').html(count)
+    $('#header .messages .count').html(headerCountLabel(count))
   } else {
     if (options.skipAnimation) {
       $('#header .messages').removeClass('hasupdates')
@@ -1016,6 +1039,7 @@ function setMessagesCount(count, options) {
     }
     $('#header .messages .count').html(0)
   }
+  fitHeader()
 }
 
 function getMessagesCount() {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -457,8 +457,6 @@ $(document).ready(function() {
   $('.dna').dnaHighlight()
 
   if ( $( "#header" ).length > 0 ) {
-    fitHeader( );
-    $( window ).on( "resize", _.debounce( fitHeader, 100 ) );
     $( "#header .search input" ).universalAutocomplete( );
     function showHeaderSearch() {
       $( "#headersearch" ).addClass( "open" );
@@ -976,92 +974,6 @@ $.fn.naturalHeight = function() {
 }
 
 
-// Beyond this the exact number adds width without adding meaning, and the
-// header has little width to spare on narrow screens.
-var MAX_HEADER_COUNT = 99
-
-function headerCountLabel(count) {
-  return count > MAX_HEADER_COUNT ? MAX_HEADER_COUNT + "+" : count
-}
-
-// The header lays out in a single row, so long notification counts can push it
-// wider than the viewport. Dropping the least essential item is preferable to
-// horizontal overflow of the whole page.
-function fitHeader() {
-  var header = document.getElementById( "header" );
-  if ( !header ) { return; }
-  header.classList.remove( "crowded" );
-  if ( header.scrollWidth > header.clientWidth ) {
-    header.classList.add( "crowded" );
-  }
-}
-
-function setUpdatesCount(count, options) {
-  options = options || {}
-  if (count > 0) {
-    if (options.skipAnimation) {
-      $('#header .updates').addClass('hasupdates')
-    } else {
-      $('#header .updates').switchClass('', 'hasupdates')
-    }
-    $('#header .updates .count').html(headerCountLabel(count))
-  } else {
-    if (options.skipAnimation) {
-      $('#header .updates').removeClass('hasupdates')
-    } else {
-      $('#header .updates').switchClass('hasupdates', '')
-    }
-    $('#header .updates .count').html(0)
-  }
-  fitHeader()
-}
-
-function getUpdatesCount() {
-  $.getJSON('/users/updates_count.json', function(data) {
-    setUpdatesCount(data.count)
-  })
-}
-
-function setMessagesCount(count, options) {
-  options = options || {}
-  if (count > 0) {
-    if (options.skipAnimation) {
-      $('#header .messages').addClass('hasupdates')
-    } else {
-      $('#header .messages').switchClass('', 'hasupdates')
-    }
-    $('#header .messages .count').html(headerCountLabel(count))
-  } else {
-    if (options.skipAnimation) {
-      $('#header .messages').removeClass('hasupdates')
-    } else {
-      $('#header .messages').switchClass('hasupdates', '')
-    }
-    $('#header .messages .count').html(0)
-  }
-  fitHeader()
-}
-
-function getMessagesCount() {
-  $.getJSON('/messages/count.json', function(data) {
-    setMessagesCount(data.count)
-  })
-}
-
-function getHeaderCounts() {
-  var apiToken = $( "meta[name='inaturalist-api-token']" ).attr( "content" );
-  $.ajax({
-    url: "<%= CONFIG.node_api_url_v2 %>/users/notification_counts",
-    headers: {
-      Authorization: apiToken
-    },
-    success: function( data ) {
-      setUpdatesCount( data.updates_count );
-      setMessagesCount( data.messages_count );
-    }
-  });
-
-}
 
 $.fn.subscriptionSettings = function() {
   var options = $.extend(true, {

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -2400,10 +2400,8 @@ $header-line-height: 34px;
     margin: 3px 0;
   }
 
-  // Toggled by fitHeader() when the header's contents no longer fit the
-  // viewport, which happens on narrow screens once the notification counts grow
-  // to several digits. The upload button is the first thing to go because the
-  // user menu still offers the same link.
+  // Toggled by fitHeader() when the header's contents no longer fit the viewport
+  // The upload button removed because the user menu still offers access
   &.crowded {
     .add-obs {
       display: none;

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -2400,6 +2400,19 @@ $header-line-height: 34px;
     margin: 3px 0;
   }
 
+  // Toggled by fitHeader() when the header's contents no longer fit the
+  // viewport, which happens on narrow screens once the notification counts grow
+  // to several digits. The upload button is the first thing to go because the
+  // user menu still offers the same link.
+  &.crowded {
+    .add-obs {
+      display: none;
+    }
+    .dropdown-menu .add-obs-menu-item {
+      display: block;
+    }
+  }
+
   .communitytab {
     .dropdown-menu {
       img {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -137,6 +137,8 @@
 
   <div id="inat-universal-autocomplete"></div>
   
+  <%= javascript_include_tag "webpack/runtime-webpack" %>
+  <%= javascript_include_tag "webpack/header-webpack" %>
   <% if logged_in? -%>
     <script type="text/javascript" charset="utf-8">
       setUpdatesCount(<%= session[:updates_count].to_i %>)
@@ -149,7 +151,6 @@
       ga('set', 'dimension1', <%=raw logged_in? ? "'true'" : "'false'" %>);
     }
   </script>
-  <%= javascript_include_tag "webpack/runtime-webpack" %>
   <%= javascript_include_tag "webpack/react-main-webpack" %>
   <%= javascript_include_tag "webpack/users-confirmation-banner-webpack" %>
 </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -139,13 +139,6 @@
   
   <%= javascript_include_tag "webpack/runtime-webpack" %>
   <%= javascript_include_tag "webpack/header-webpack" %>
-  <% if logged_in? -%>
-    <script type="text/javascript" charset="utf-8">
-      setUpdatesCount(<%= session[:updates_count].to_i %>)
-      setMessagesCount(<%= session[:messages_count].to_i %>)
-      setTimeout( getHeaderCounts, 1000 )
-    </script>
-  <% end -%>
   <script type="text/javascript">
     if (typeof(ga) != 'undefined') {
       ga('set', 'dimension1', <%=raw logged_in? ? "'true'" : "'false'" %>);

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -242,12 +242,5 @@
       <%= javascript_include_tag "webpack/users-confirmation-banner-webpack" %>
     <% end %>
     <%= yield :extrajs %>
-    <% if logged_in? -%>
-      <script type="text/javascript" charset="utf-8">
-        setUpdatesCount(<%= session[:updates_count].to_i %>)
-        setMessagesCount(<%= session[:messages_count].to_i %>)
-        setTimeout( getHeaderCounts, 1000 )
-      </script>
-    <% end -%>
   </body>
 </html>

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -235,8 +235,10 @@
       <%= javascript_include_tag "map_bundle" %>
       <%= google_maps_async_js %>
     <% end %>
+    <%# The header renders on every page, including the ones that skip React %>
+    <%= javascript_include_tag "webpack/runtime-webpack" %>
+    <%= javascript_include_tag "webpack/header-webpack" %>
     <% unless @skip_react %>
-      <%= javascript_include_tag "webpack/runtime-webpack" %>
       <%= javascript_include_tag "webpack/react-main-webpack" %>
       <%= javascript_include_tag "webpack/users-confirmation-banner-webpack" %>
     <% end %>

--- a/app/views/layouts/bootstrap.html.erb
+++ b/app/views/layouts/bootstrap.html.erb
@@ -235,7 +235,6 @@
       <%= javascript_include_tag "map_bundle" %>
       <%= google_maps_async_js %>
     <% end %>
-    <%# The header renders on every page, including the ones that skip React %>
     <%= javascript_include_tag "webpack/runtime-webpack" %>
     <%= javascript_include_tag "webpack/header-webpack" %>
     <% unless @skip_react %>

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -175,7 +175,7 @@
           %ul.dropdown-menu.dropdown-menu-right{ aria: { labelledby: "header-user-menu-dropdown-toggle" } }
             %li= link_to t(:dashboard), home_path
             %li= link_to t(:edit_observations), observations_by_login_path(current_user.login), :class => "observations_link"
-            %li.header-xs.header-sm
+            %li.header-xs.header-sm.add-obs-menu-item
               = link_to t(:add_observations), upload_observations_path
             %li= link_to t(:calendar), calendar_path(current_user.login), :class => "calendar_link"
             %li= link_to t(:identifications), identifications_by_login_path(current_user.login), :class => "identifications_link"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,6 +1,7 @@
 - site = @site || CONFIG
 - header_search_open = session[:header_search_open].yesish? || ( logged_in? && session[:header_search_open] != false )
-#header.bootstrap{ class: header_search_open ? "search-open" : nil }
+- header_counts = logged_in? ? { updates_count: session[:updates_count].to_i, messages_count: session[:messages_count].to_i } : {}
+#header.bootstrap{ class: header_search_open ? "search-open" : nil, data: header_counts }
   #narrow-menu.navtabs
     .dropdown
       #header-narrow-dropdown-toggle.dropdown-toggle{ data: { toggle: "dropdown" }, aria: { haspopup: "true", expanded: "false" } }

--- a/app/webpack/globals.d.ts
+++ b/app/webpack/globals.d.ts
@@ -34,7 +34,6 @@ interface JQueryStubResult {
   textcompleteUsers: ( ) => void;
   addClass: ( className: string ) => JQueryStubResult;
   removeClass: ( className: string ) => JQueryStubResult;
-  // jQuery UI: animates the transition between the two class sets
   switchClass: ( remove: string, add: string ) => JQueryStubResult;
   html: ( content?: string ) => string;
 }

--- a/app/webpack/globals.d.ts
+++ b/app/webpack/globals.d.ts
@@ -32,14 +32,20 @@ interface JQueryStubResult {
   val: ( value?: string ) => string;
   find: ( selector: string ) => JQueryStubResult;
   textcompleteUsers: ( ) => void;
+  addClass: ( className: string ) => JQueryStubResult;
+  removeClass: ( className: string ) => JQueryStubResult;
+  // jQuery UI: animates the transition between the two class sets
+  switchClass: ( remove: string, add: string ) => JQueryStubResult;
+  html: ( content?: string ) => string;
 }
 interface JQueryDeparam {
   ( str: string ): Record<string, unknown>;
   querystring( ): Record<string, unknown>;
 }
 interface JQueryStub {
-  ( selector: string | Element, context?: Element | null ): JQueryStubResult;
-  ajax( url: string, settings?: Record<string, unknown> ): unknown;
+  ( selector: string | Element | Window, context?: Element | null ): JQueryStubResult;
+  ajax( url: string | Record<string, unknown>, settings?: Record<string, unknown> ): unknown;
+  getJSON( url: string, success: ( data: never ) => void ): unknown;
   each<T>(
     collection: ArrayLike<T> | Record<string, T>,
     callback: ( indexOrKey: number | string, value: T ) => void

--- a/app/webpack/shared/header/header.test.ts
+++ b/app/webpack/shared/header/header.test.ts
@@ -1,16 +1,4 @@
-import { fitHeader, headerCountLabel } from "./header";
-
-describe( "headerCountLabel", ( ) => {
-  it( "renders a count that fits as itself", ( ) => {
-    expect( headerCountLabel( 0 ) ).toEqual( "0" );
-    expect( headerCountLabel( 99 ) ).toEqual( "99" );
-  } );
-
-  it( "caps a count that would widen the header", ( ) => {
-    expect( headerCountLabel( 100 ) ).toEqual( "99+" );
-    expect( headerCountLabel( 8888 ) ).toEqual( "99+" );
-  } );
-} );
+import { fitHeader } from "./header";
 
 describe( "fitHeader", ( ) => {
   interface Widths { scrollWidth: number; clientWidth: number }

--- a/app/webpack/shared/header/header.test.ts
+++ b/app/webpack/shared/header/header.test.ts
@@ -1,0 +1,57 @@
+import { fitHeader, headerCountLabel } from "./header";
+
+describe( "headerCountLabel", ( ) => {
+  it( "renders a count that fits as itself", ( ) => {
+    expect( headerCountLabel( 0 ) ).toEqual( "0" );
+    expect( headerCountLabel( 99 ) ).toEqual( "99" );
+  } );
+
+  it( "caps a count that would widen the header", ( ) => {
+    expect( headerCountLabel( 100 ) ).toEqual( "99+" );
+    expect( headerCountLabel( 8888 ) ).toEqual( "99+" );
+  } );
+} );
+
+describe( "fitHeader", ( ) => {
+  interface Widths { scrollWidth: number; clientWidth: number }
+
+  const renderHeader = ( { scrollWidth, clientWidth }: Widths ) => {
+    document.body.innerHTML = "<div id=\"header\"></div>";
+    const header = document.getElementById( "header" ) as HTMLElement;
+    // jsdom lays nothing out, so both widths are 0 without this
+    Object.defineProperty( header, "scrollWidth", { value: scrollWidth } );
+    Object.defineProperty( header, "clientWidth", { value: clientWidth } );
+    return header;
+  };
+
+  it( "leaves a header that fits alone", ( ) => {
+    const header = renderHeader( { scrollWidth: 375, clientWidth: 375 } );
+
+    fitHeader( );
+
+    expect( header.classList.contains( "crowded" ) ).toBe( false );
+  } );
+
+  it( "marks a header whose contents overflow", ( ) => {
+    const header = renderHeader( { scrollWidth: 383, clientWidth: 375 } );
+
+    fitHeader( );
+
+    expect( header.classList.contains( "crowded" ) ).toBe( true );
+  } );
+
+  it( "clears the mark once the header fits again", ( ) => {
+    const header = renderHeader( { scrollWidth: 375, clientWidth: 375 } );
+    header.classList.add( "crowded" );
+
+    fitHeader( );
+
+    expect( header.classList.contains( "crowded" ) ).toBe( false );
+  } );
+
+  it( "does nothing on a page with no header", ( ) => {
+    document.body.innerHTML = "";
+
+    expect( ( ) => fitHeader( ) ).not.toThrow( );
+  } );
+} );

--- a/app/webpack/shared/header/header.test.ts
+++ b/app/webpack/shared/header/header.test.ts
@@ -1,4 +1,4 @@
-import { fitHeader, initHeaderCounts } from "./header";
+import { fitHeader, readHeaderCounts } from "./header";
 
 describe( "fitHeader", ( ) => {
   interface Widths { scrollWidth: number; clientWidth: number }
@@ -44,41 +44,16 @@ describe( "fitHeader", ( ) => {
   } );
 } );
 
-describe( "initHeaderCounts", ( ) => {
-  let countHtml: jest.Mock;
-
-  beforeEach( ( ) => {
-    jest.useFakeTimers( );
-    countHtml = jest.fn( );
-    // Minimal jQuery stand-in: setHeaderCount only needs class toggles and .html
-    const chain = {
-      addClass: jest.fn( ),
-      removeClass: jest.fn( ),
-      switchClass: jest.fn( ),
-      html: countHtml,
-      on: jest.fn( )
-    };
-    ( global as unknown as Record<string, unknown> ).$ = jest.fn( ( ) => chain );
-  } );
-
-  afterEach( ( ) => {
-    jest.useRealTimers( );
-  } );
-
-  it( "applies the counts stamped on #header", ( ) => {
+describe( "readHeaderCounts", ( ) => {
+  it( "reads the counts stamped on #header", ( ) => {
     document.body.innerHTML = "<div id=\"header\" data-updates-count=\"5\" data-messages-count=\"3\"></div>";
 
-    initHeaderCounts( );
-
-    expect( countHtml ).toHaveBeenCalledWith( "5" );
-    expect( countHtml ).toHaveBeenCalledWith( "3" );
+    expect( readHeaderCounts( ) ).toEqual( { updates: 5, messages: 3 } );
   } );
 
-  it( "does nothing when the counts are absent", ( ) => {
+  it( "returns null when the counts are absent", ( ) => {
     document.body.innerHTML = "<div id=\"header\"></div>";
 
-    initHeaderCounts( );
-
-    expect( countHtml ).not.toHaveBeenCalled( );
+    expect( readHeaderCounts( ) ).toBeNull( );
   } );
 } );

--- a/app/webpack/shared/header/header.test.ts
+++ b/app/webpack/shared/header/header.test.ts
@@ -1,4 +1,4 @@
-import { fitHeader } from "./header";
+import { fitHeader, initHeaderCounts } from "./header";
 
 describe( "fitHeader", ( ) => {
   interface Widths { scrollWidth: number; clientWidth: number }
@@ -41,5 +41,44 @@ describe( "fitHeader", ( ) => {
     document.body.innerHTML = "";
 
     expect( ( ) => fitHeader( ) ).not.toThrow( );
+  } );
+} );
+
+describe( "initHeaderCounts", ( ) => {
+  let countHtml: jest.Mock;
+
+  beforeEach( ( ) => {
+    jest.useFakeTimers( );
+    countHtml = jest.fn( );
+    // Minimal jQuery stand-in: setHeaderCount only needs class toggles and .html
+    const chain = {
+      addClass: jest.fn( ),
+      removeClass: jest.fn( ),
+      switchClass: jest.fn( ),
+      html: countHtml,
+      on: jest.fn( )
+    };
+    ( global as unknown as Record<string, unknown> ).$ = jest.fn( ( ) => chain );
+  } );
+
+  afterEach( ( ) => {
+    jest.useRealTimers( );
+  } );
+
+  it( "applies the counts stamped on #header", ( ) => {
+    document.body.innerHTML = "<div id=\"header\" data-updates-count=\"5\" data-messages-count=\"3\"></div>";
+
+    initHeaderCounts( );
+
+    expect( countHtml ).toHaveBeenCalledWith( "5" );
+    expect( countHtml ).toHaveBeenCalledWith( "3" );
+  } );
+
+  it( "does nothing when the counts are absent", ( ) => {
+    document.body.innerHTML = "<div id=\"header\"></div>";
+
+    initHeaderCounts( );
+
+    expect( countHtml ).not.toHaveBeenCalled( );
   } );
 } );

--- a/app/webpack/shared/header/header.ts
+++ b/app/webpack/shared/header/header.ts
@@ -61,9 +61,6 @@ export function getHeaderCounts( ): void {
   } );
 }
 
-// Apply the notification counts the server stamps on #header, then refresh them
-// from the API shortly after load. Absent data attributes mean a logged-out
-// visitor, so there is nothing to show or fetch.
 export function initHeaderCounts( ): void {
   const header = document.getElementById( "header" );
   const updates = header?.dataset.updatesCount;

--- a/app/webpack/shared/header/header.ts
+++ b/app/webpack/shared/header/header.ts
@@ -1,12 +1,8 @@
-// Behavior for the site header rendered by app/views/shared/_header.html.haml.
-
 interface CountOptions {
   skipAnimation?: boolean;
 }
 
-// The header lays out in a single row, so long notification counts can push it
-// wider than the viewport. Dropping the least essential item is preferable to
-// horizontal overflow of the whole page.
+// Enable the "crowded" class when header overflows the viewport
 export function fitHeader( ): void {
   const header = document.getElementById( "header" );
   if ( !header ) { return; }

--- a/app/webpack/shared/header/header.ts
+++ b/app/webpack/shared/header/header.ts
@@ -4,14 +4,6 @@ interface CountOptions {
   skipAnimation?: boolean;
 }
 
-// Beyond this the exact number adds width without adding meaning, and the
-// header has little width to spare on narrow screens.
-const MAX_HEADER_COUNT = 99;
-
-export function headerCountLabel( count: number ): string {
-  return count > MAX_HEADER_COUNT ? `${MAX_HEADER_COUNT}+` : String( count );
-}
-
 // The header lays out in a single row, so long notification counts can push it
 // wider than the viewport. Dropping the least essential item is preferable to
 // horizontal overflow of the whole page.
@@ -50,7 +42,7 @@ function setHeaderCount(
     $( selector ).switchClass( hasCount ? "" : "hasupdates", hasCount ? "hasupdates" : "" );
   }
 
-  $( `${selector} .count` ).html( hasCount ? headerCountLabel( count ) : "0" );
+  $( `${selector} .count` ).html( String( count ) );
   fitHeader( );
 }
 

--- a/app/webpack/shared/header/header.ts
+++ b/app/webpack/shared/header/header.ts
@@ -50,18 +50,6 @@ export function setMessagesCount( count: number, options: CountOptions = {} ): v
   setHeaderCount( "messages", count, options );
 }
 
-export function getUpdatesCount( ): void {
-  $.getJSON( "/users/updates_count.json", ( data: { count: number } ) => {
-    setUpdatesCount( data.count );
-  } );
-}
-
-export function getMessagesCount( ): void {
-  $.getJSON( "/messages/count.json", ( data: { count: number } ) => {
-    setMessagesCount( data.count );
-  } );
-}
-
 export function getHeaderCounts( ): void {
   $.ajax( {
     url: `${apiUrlV2( )}/users/notification_counts`,
@@ -71,4 +59,18 @@ export function getHeaderCounts( ): void {
       setMessagesCount( data.messages_count );
     }
   } );
+}
+
+// Apply the notification counts the server stamps on #header, then refresh them
+// from the API shortly after load. Absent data attributes mean a logged-out
+// visitor, so there is nothing to show or fetch.
+export function initHeaderCounts( ): void {
+  const header = document.getElementById( "header" );
+  const updates = header?.dataset.updatesCount;
+  const messages = header?.dataset.messagesCount;
+  if ( updates === undefined || messages === undefined ) { return; }
+
+  setUpdatesCount( Number( updates ), { skipAnimation: true } );
+  setMessagesCount( Number( messages ), { skipAnimation: true } );
+  window.setTimeout( getHeaderCounts, 1000 );
 }

--- a/app/webpack/shared/header/header.ts
+++ b/app/webpack/shared/header/header.ts
@@ -1,0 +1,86 @@
+// Behavior for the site header rendered by app/views/shared/_header.html.haml.
+
+interface CountOptions {
+  skipAnimation?: boolean;
+}
+
+// Beyond this the exact number adds width without adding meaning, and the
+// header has little width to spare on narrow screens.
+const MAX_HEADER_COUNT = 99;
+
+export function headerCountLabel( count: number ): string {
+  return count > MAX_HEADER_COUNT ? `${MAX_HEADER_COUNT}+` : String( count );
+}
+
+// The header lays out in a single row, so long notification counts can push it
+// wider than the viewport. Dropping the least essential item is preferable to
+// horizontal overflow of the whole page.
+export function fitHeader( ): void {
+  const header = document.getElementById( "header" );
+  if ( !header ) { return; }
+
+  header.classList.remove( "crowded" );
+  if ( header.scrollWidth > header.clientWidth ) {
+    header.classList.add( "crowded" );
+  }
+}
+
+function apiUrlV2( ): string {
+  const meta = document.querySelector( "meta[name='config:inaturalist_api_url_v2']" );
+  return meta?.getAttribute( "content" ) || "";
+}
+
+function apiToken( ): string {
+  const meta = document.querySelector( "meta[name='inaturalist-api-token']" );
+  return meta?.getAttribute( "content" ) || "";
+}
+
+function setHeaderCount(
+  nav: "updates" | "messages",
+  count: number,
+  options: CountOptions = {}
+): void {
+  const selector = `#header .${nav}`;
+  const hasCount = count > 0;
+
+  if ( options.skipAnimation ) {
+    $( selector )[hasCount ? "addClass" : "removeClass"]( "hasupdates" );
+  } else {
+    // switchClass animates the color change; addClass would snap to it.
+    $( selector ).switchClass( hasCount ? "" : "hasupdates", hasCount ? "hasupdates" : "" );
+  }
+
+  $( `${selector} .count` ).html( hasCount ? headerCountLabel( count ) : "0" );
+  fitHeader( );
+}
+
+export function setUpdatesCount( count: number, options: CountOptions = {} ): void {
+  setHeaderCount( "updates", count, options );
+}
+
+export function setMessagesCount( count: number, options: CountOptions = {} ): void {
+  setHeaderCount( "messages", count, options );
+}
+
+export function getUpdatesCount( ): void {
+  $.getJSON( "/users/updates_count.json", ( data: { count: number } ) => {
+    setUpdatesCount( data.count );
+  } );
+}
+
+export function getMessagesCount( ): void {
+  $.getJSON( "/messages/count.json", ( data: { count: number } ) => {
+    setMessagesCount( data.count );
+  } );
+}
+
+export function getHeaderCounts( ): void {
+  $.ajax( {
+    url: `${apiUrlV2( )}/users/notification_counts`,
+    headers: { Authorization: apiToken( ) },
+    success: ( data: { updates_count: number; messages_count: number } ) => {
+      setUpdatesCount( data.updates_count );
+      setMessagesCount( data.messages_count );
+    }
+  } );
+}

--- a/app/webpack/shared/header/header.ts
+++ b/app/webpack/shared/header/header.ts
@@ -61,13 +61,20 @@ export function getHeaderCounts( ): void {
   } );
 }
 
-export function initHeaderCounts( ): void {
+export function readHeaderCounts( ): { updates: number; messages: number } | null {
   const header = document.getElementById( "header" );
   const updates = header?.dataset.updatesCount;
   const messages = header?.dataset.messagesCount;
-  if ( updates === undefined || messages === undefined ) { return; }
+  if ( updates === undefined || messages === undefined ) { return null; }
 
-  setUpdatesCount( Number( updates ), { skipAnimation: true } );
-  setMessagesCount( Number( messages ), { skipAnimation: true } );
+  return { updates: Number( updates ), messages: Number( messages ) };
+}
+
+export function initHeaderCounts( ): void {
+  const counts = readHeaderCounts( );
+  if ( !counts ) { return; }
+
+  setUpdatesCount( counts.updates, { skipAnimation: true } );
+  setMessagesCount( counts.messages, { skipAnimation: true } );
   window.setTimeout( getHeaderCounts, 1000 );
 }

--- a/app/webpack/shared/header/webpack-entry.ts
+++ b/app/webpack/shared/header/webpack-entry.ts
@@ -1,0 +1,34 @@
+// Exposes the header behavior to the layouts, which call the count setters from
+// an inline script, and to the legacy Sprockets bundle, which calls them from
+// the notification dropdown handlers.
+import debounce from "lodash/debounce";
+import {
+  fitHeader,
+  getHeaderCounts,
+  getMessagesCount,
+  getUpdatesCount,
+  setMessagesCount,
+  setUpdatesCount
+} from "./header";
+
+Object.assign( window, {
+  fitHeader,
+  getHeaderCounts,
+  getMessagesCount,
+  getUpdatesCount,
+  setMessagesCount,
+  setUpdatesCount
+} );
+
+function start( ): void {
+  if ( !document.getElementById( "header" ) ) { return; }
+
+  fitHeader( );
+  $( window ).on( "resize", debounce( fitHeader, 100 ) );
+}
+
+if ( document.readyState === "loading" ) {
+  document.addEventListener( "DOMContentLoaded", start );
+} else {
+  start( );
+}

--- a/app/webpack/shared/header/webpack-entry.ts
+++ b/app/webpack/shared/header/webpack-entry.ts
@@ -1,30 +1,25 @@
-// Exposes the header behavior to the layouts, which call the count setters from
-// an inline script, and to the legacy Sprockets bundle, which calls them from
-// the notification dropdown handlers.
+// Exposes the notification-count setters to the legacy Sprockets bundle, whose
+// dropdown handlers still reset them imperatively. Initial counts arrive as data
+// attributes on #header (see initHeaderCounts), not an inline layout script.
 import debounce from "lodash/debounce";
 import {
   fitHeader,
-  getHeaderCounts,
-  getMessagesCount,
-  getUpdatesCount,
+  initHeaderCounts,
   setMessagesCount,
   setUpdatesCount
 } from "./header";
 
-Object.assign( window, {
-  fitHeader,
-  getHeaderCounts,
-  getMessagesCount,
-  getUpdatesCount,
-  setMessagesCount,
-  setUpdatesCount
-} );
+// TODO: drop this window bridge once application.js.erb's notification dropdown
+// handlers (which call setUpdatesCount/setMessagesCount to reset the badge on
+// open) are migrated into webpack and can import these directly.
+Object.assign( window, { setMessagesCount, setUpdatesCount } );
 
 function start( ): void {
   if ( !document.getElementById( "header" ) ) { return; }
 
   fitHeader( );
   $( window ).on( "resize", debounce( fitHeader, 100 ) );
+  initHeaderCounts( );
 }
 
 if ( document.readyState === "loading" ) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -16,6 +16,10 @@ const config = {
       import: "./kml/webpack-entry",
       runtime: "runtime"
     },
+    "header": {
+      import: "./shared/header/webpack-entry",
+      runtime: "runtime"
+    },
     "computer-vision": {
       import: "./computer_vision/demo/webpack-entry",
       dependOn: ["react-main", "react-dropzone"]

--- a/spec/e2e/playwright/helpers/overflow.helper.ts
+++ b/spec/e2e/playwright/helpers/overflow.helper.ts
@@ -10,12 +10,27 @@ async function measureHorizontalOverflow(
   } ) );
 }
 
+export async function expectWithinViewport( page: Page, context?: string ): Promise<void> {
+  const { bodyWidth, viewportWidth } = await measureHorizontalOverflow( page );
+
+  expect(
+    bodyWidth,
+    `body (${bodyWidth}px) overflows the ${context || "current"} viewport (${viewportWidth}px)`
+  ).toBeLessThanOrEqual( viewportWidth + 1 );
+}
+
 export function expectNoHorizontalOverflow(
   path: string | ( () => string ) = "/",
-  options: { waitForSelector?: string; setup?: ( page: Page ) => Promise<void> } = {}
+  options: {
+    waitForSelector?: string;
+    setup?: ( page: Page ) => Promise<void>;
+    viewports?: BreakpointName[];
+  } = {}
 ): void {
   test.describe( "no horizontal overflow", () => {
-    for ( const name of Object.keys( VIEWPORTS ) as BreakpointName[] ) {
+    const viewports = options.viewports || Object.keys( VIEWPORTS ) as BreakpointName[];
+
+    viewports.forEach( name => {
       const viewport = VIEWPORTS[name];
 
       test( `the document body does not overflow the viewport at the ${name} breakpoint (${viewport.width}px)`, async ( { page } ) => {
@@ -24,15 +39,11 @@ export function expectNoHorizontalOverflow(
         await page.goto( typeof path === "function" ? path() : path );
         await page.locator( options.waitForSelector || "#header" ).first().waitFor();
 
-        const { bodyWidth, viewportWidth } = await measureHorizontalOverflow( page );
-
+        const { viewportWidth } = await measureHorizontalOverflow( page );
         expect( viewportWidth ).toBeGreaterThanOrEqual( BREAKPOINTS[name].minWidth );
 
-        expect(
-          bodyWidth,
-          `body (${bodyWidth}px) overflows the ${name} viewport (${viewportWidth}px)`
-        ).toBeLessThanOrEqual( viewportWidth + 1 );
+        await expectWithinViewport( page, `${name} breakpoint` );
       } );
-    }
+    } );
   } );
 }

--- a/spec/e2e/playwright/helpers/overflow.helper.ts
+++ b/spec/e2e/playwright/helpers/overflow.helper.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { BREAKPOINTS, BreakpointName, VIEWPORTS } from "../../shared/breakpoints";
+import { BREAKPOINT_WIDTHS, BreakpointName, VIEWPORTS } from "../../shared/breakpoints";
 
 async function measureHorizontalOverflow(
   page: Page
@@ -40,7 +40,7 @@ export function expectNoHorizontalOverflow(
         await page.locator( options.waitForSelector || "#header" ).first().waitFor();
 
         const { viewportWidth } = await measureHorizontalOverflow( page );
-        expect( viewportWidth ).toBeGreaterThanOrEqual( BREAKPOINTS[name].minWidth );
+        expect( viewportWidth ).toBeGreaterThanOrEqual( BREAKPOINT_WIDTHS[name] );
 
         await expectWithinViewport( page, `${name} breakpoint` );
       } );

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from "@playwright/test";
 import { login } from "../../helpers/auth.helper";
 import { app, appMake } from "../../support/on-rails";
 import { VIEWPORTS } from "../../../shared/breakpoints";
-import { expectNoHorizontalOverflow } from "../../helpers/overflow.helper";
+import { expectNoHorizontalOverflow, expectWithinViewport } from "../../helpers/overflow.helper";
 
 const TEST_PASSWORD = "TestPass123!";
 
@@ -173,10 +173,6 @@ test.describe( "Header with large notification counts (xs)", () => {
     ).evaluate( el => getComputedStyle( el ).display );
     expect( menuItemDisplay ).not.toBe( "none" );
 
-    const { bodyWidth, viewportWidth } = await page.evaluate( () => ( {
-      bodyWidth: document.body.scrollWidth,
-      viewportWidth: window.innerWidth
-    } ) );
-    expect( bodyWidth ).toBeLessThanOrEqual( viewportWidth + 1 );
+    await expectWithinViewport( page, "xs breakpoint" );
   } );
 } );

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -142,3 +142,41 @@ test.describe( "Header at the lg breakpoint (logged in)", () => {
     await expect( page.locator( "#header .add-obs .btn-inat span" ) ).toBeVisible();
   } );
 } );
+
+test.describe( "Header with large notification counts (xs)", () => {
+  const setCounts = ( page: Page, count: number ) => page.evaluate( c => {
+    ( window as any ).setUpdatesCount( c, { skipAnimation: true } );
+    ( window as any ).setMessagesCount( c, { skipAnimation: true } );
+  }, count );
+
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.xs );
+    await page.goto( "/" );
+    await page.locator( "#header .add-obs" ).waitFor();
+  } );
+
+  test( "keeps the upload button while the counts are small", async ( { page } ) => {
+    await setCounts( page, 1 );
+    await expect( page.locator( "#header .add-obs" ) ).toBeVisible();
+    await expect( page.locator( "#header" ) ).not.toHaveClass( /\bcrowded\b/ );
+  } );
+
+  test( "drops the upload button for the user menu when the counts overflow", async ( { page } ) => {
+    await setCounts( page, 8888 );
+
+    await expect( page.locator( "#header" ) ).toHaveClass( /\bcrowded\b/ );
+    await expect( page.locator( "#header .add-obs" ) ).toBeHidden();
+
+    // The user menu keeps offering the upload link, so nothing becomes unreachable.
+    const menuItemDisplay = await page.locator(
+      "#header .dropdown-menu .add-obs-menu-item"
+    ).evaluate( el => getComputedStyle( el ).display );
+    expect( menuItemDisplay ).not.toBe( "none" );
+
+    const { bodyWidth, viewportWidth } = await page.evaluate( () => ( {
+      bodyWidth: document.body.scrollWidth,
+      viewportWidth: window.innerWidth
+    } ) );
+    expect( bodyWidth ).toBeLessThanOrEqual( viewportWidth + 1 );
+  } );
+} );

--- a/spec/e2e/playwright/tests/shared/header.spec.ts
+++ b/spec/e2e/playwright/tests/shared/header.spec.ts
@@ -162,7 +162,7 @@ test.describe( "Header with large notification counts (xs)", () => {
   } );
 
   test( "drops the upload button for the user menu when the counts overflow", async ( { page } ) => {
-    await setCounts( page, 8888 );
+    await setCounts( page, 99999 );
 
     await expect( page.locator( "#header" ) ).toHaveClass( /\bcrowded\b/ );
     await expect( page.locator( "#header .add-obs" ) ).toBeHidden();

--- a/spec/e2e/shared/breakpoints.ts
+++ b/spec/e2e/shared/breakpoints.ts
@@ -1,26 +1,23 @@
-export type BreakpointName = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+export type BreakpointName = "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 
-export interface Breakpoint {
-  infix: string | null;
-  minWidth: number;
-}
-
-export const BREAKPOINTS: Record<BreakpointName, Breakpoint> = {
-  xs: { infix: null, minWidth: 0 },
-  sm: { infix: "sm", minWidth: 576 },
-  md: { infix: "md", minWidth: 768 },
-  lg: { infix: "lg", minWidth: 992 },
-  xl: { infix: "xl", minWidth: 1200 },
-  xxl: { infix: "xxl", minWidth: 1400 }
+export const BREAKPOINT_WIDTHS: Record<BreakpointName, number> = {
+  xxs: 360,
+  xs: 430,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+  xxl: 1400
 };
 
 const VIEWPORT_HEIGHT = 900;
 
 export const VIEWPORTS: Record<BreakpointName, { width: number; height: number }> = {
-  xs: { width: 375, height: VIEWPORT_HEIGHT },
-  sm: { width: BREAKPOINTS.sm.minWidth, height: VIEWPORT_HEIGHT },
-  md: { width: BREAKPOINTS.md.minWidth, height: VIEWPORT_HEIGHT },
-  lg: { width: BREAKPOINTS.lg.minWidth, height: VIEWPORT_HEIGHT },
-  xl: { width: BREAKPOINTS.xl.minWidth, height: VIEWPORT_HEIGHT },
-  xxl: { width: BREAKPOINTS.xxl.minWidth, height: VIEWPORT_HEIGHT }
+  xxs: { width: BREAKPOINT_WIDTHS.xxs, height: VIEWPORT_HEIGHT },
+  xs: { width: BREAKPOINT_WIDTHS.xs, height: VIEWPORT_HEIGHT },
+  sm: { width: BREAKPOINT_WIDTHS.sm, height: VIEWPORT_HEIGHT },
+  md: { width: BREAKPOINT_WIDTHS.md, height: VIEWPORT_HEIGHT },
+  lg: { width: BREAKPOINT_WIDTHS.lg, height: VIEWPORT_HEIGHT },
+  xl: { width: BREAKPOINT_WIDTHS.xl, height: VIEWPORT_HEIGHT },
+  xxl: { width: BREAKPOINT_WIDTHS.xxl, height: VIEWPORT_HEIGHT }
 };


### PR DESCRIPTION
Adds more to keep the header from overflowing on narrow screens (adds a crowded class at runtime, responsive nav/leaderboard breakpoints).

Also migrates the header JS from application.js.erb into the typed shared/header webpack module, which is more convenient for linting, testing, editor highlighting, webpack processes like tree-shaking, avoiding globals as much as possible, etc...

Initial updates/messages counts now flow through data-* attributes on #header (read by initHeaderCounts) instead of a per-layout inline <script>, collapsing the duplicated init in both layouts into the shared header partial. The window global is trimmed to just setUpdatesCount/setMessagesCount (still called by the legacy dropdown handlers, so we can remove if we migrate those eventually). getUpdatesCount/getMessagesCount removed.

In the future, it would be nice to continue to refactor application.js.erb into TS.

Additionally simplified some data structure around breakpoints for testing and broke out the overflow assertion from the `expectNoHorizontalOverflow` test so that it can be used separately.