### PR TITLE
fix: Prevent autocomplete overflows, WEB-1265

### DIFF
--- a/app/assets/stylesheets/_breakpoints.scss
+++ b/app/assets/stylesheets/_breakpoints.scss
@@ -1,12 +1,14 @@
 $mobile-max:  767px;
 $desktop-min: 768px;
 
+$xs: 420px;
 $sm:  576px;
 $md:  768px;
 $lg:  992px;
 $xl:  1200px;
 $xxl: 1400px;
 
+$xs-max:  419.98px;
 $sm-max:  575.98px;
 $md-max:  767.98px;
 $lg-max:  991.98px;

--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -114,7 +114,7 @@ body.responsive {
 
   @media ( max-width: $sm-max ) {
     .ui-autocomplete {
-      max-width: calc( 100vw - 40px );
+      max-width: calc( 100vw - 50px );
     }
   }
 }

--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -268,6 +268,14 @@ $label-start: 7px;
 .ac-chooser {
   position: relative;
 }
+// iOS Safari zooms the viewport when a field with a font smaller than 16px
+// takes focus, which shifts the JS-positioned autocomplete menu off screen
+@media ( hover: none ) and ( pointer: coarse ) {
+  .ac-chooser input.form-control {
+    font-size: 16px;
+    height: auto;
+  }
+}
 .ac-chooser .searchclear.glyphicon {
   position: absolute;
   right: 10px;

--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -64,35 +64,58 @@ $label-start: 7px;
 }
 .ui-autocomplete.taxon-autocomplete {
   max-width: 500px;
-
-  @media ( max-width: $md-max ) {
-    max-width: calc( 100vw - 70px );
-
-    .ac {
-      min-width: 0;
+}
+// Only the layouts that adapt to the viewport, marked by the body class the
+// responsive test groups set, want the rules below
+body.responsive {
+  // iOS Safari zooms the viewport when a field with a font smaller than 16px
+  // takes focus, which shifts the JS-positioned autocomplete menu off screen
+  @media ( hover: none ) and ( pointer: coarse ) {
+    // the height Bootstrap pins is sized for a smaller font
+    .ac-chooser input.form-control {
+      font-size: 16px;
+      height: auto;
     }
+  }
 
-    .ac-label {
-      min-width: 0;
-      overflow: hidden;
+  // A menu is only as wide as the input it hangs off, while its rows carry wide
+  // minimum widths, so the rows have to shrink and clip on a narrow screen or
+  // they overflow the menu and run off the side of the viewport
+  @media ( max-width: $md-max ) {
+    .ui-autocomplete {
+      max-width: calc( 100vw - 70px );
 
-      > div {
+      .ac,
+      &.projects .ac,
+      &.user-autocomplete .ac {
         min-width: 0;
-        overflow: hidden;
         width: 100%;
       }
-    }
 
-    .ac-label .title,
-    .ac-label .subtitle {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      .ac-label {
+        min-width: 0;
+        overflow: hidden;
+
+        > div {
+          min-width: 0;
+          overflow: hidden;
+          width: 100%;
+        }
+      }
+
+      .ac-label .title,
+      .ac-label .subtitle {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 
   @media ( max-width: $sm-max ) {
-    max-width: calc( 100vw - 90px );
+    .ui-autocomplete {
+      max-width: calc( 100vw - 40px );
+    }
   }
 }
 .ac-message[data-type='message'] {
@@ -267,14 +290,6 @@ $label-start: 7px;
 }
 .ac-chooser {
   position: relative;
-}
-// iOS Safari zooms the viewport when a field with a font smaller than 16px
-// takes focus, which shifts the JS-positioned autocomplete menu off screen
-@media ( hover: none ) and ( pointer: coarse ) {
-  .ac-chooser input.form-control {
-    font-size: 16px;
-    height: auto;
-  }
 }
 .ac-chooser .searchclear.glyphicon {
   position: absolute;

--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -71,16 +71,12 @@ body.responsive {
   // iOS Safari zooms the viewport when a field with a font smaller than 16px
   // takes focus, which shifts the JS-positioned autocomplete menu off screen
   @media ( hover: none ) and ( pointer: coarse ) {
-    // the height Bootstrap pins is sized for a smaller font
     .ac-chooser input.form-control {
       font-size: 16px;
       height: auto;
     }
   }
 
-  // A menu is only as wide as the input it hangs off, while its rows carry wide
-  // minimum widths, so the rows have to shrink and clip on a narrow screen or
-  // they overflow the menu and run off the side of the viewport
   @media ( max-width: $md-max ) {
     .ui-autocomplete {
       max-width: calc( 100vw - 70px );

--- a/app/assets/stylesheets/observations/show.scss
+++ b/app/assets/stylesheets/observations/show.scss
@@ -581,6 +581,17 @@ a.UserImage,
       li:first-child {
         margin-left: 15px;
       }
+      .tab-label-short {
+        display: none;
+      }
+      @media ( max-width: $xs-max ) {
+        .tab-label-full {
+          display: none;
+        }
+        .tab-label-short {
+          display: inline;
+        }
+      }
       a {
         color: #666;
         outline: none;

--- a/app/assets/stylesheets/observations/show_legacy.scss
+++ b/app/assets/stylesheets/observations/show_legacy.scss
@@ -519,6 +519,9 @@ a.UserImage,
       li:first-child {
         margin-left: 15px;
       }
+      .tab-label-short {
+        display: none;
+      }
       a {
         color: #666;
         outline: none;

--- a/app/webpack/observations/show/components/activity_create_panel.jsx
+++ b/app/webpack/observations/show/components/activity_create_panel.jsx
@@ -254,7 +254,16 @@ class ActivityCreatePanel extends React.Component {
         <Tab eventKey="comment" title={I18n.t( "comment_" )} className="comment_tab">
           { this.commentContent( ) }
         </Tab>
-        <Tab eventKey="add_id" title={I18n.t( "suggest_an_identification" )} className="id_tab">
+        <Tab
+          eventKey="add_id"
+          title={(
+            <>
+              <span className="tab-label-full">{I18n.t( "suggest_an_identification" )}</span>
+              <span className="tab-label-short">{I18n.t( "identify" )}</span>
+            </>
+          )}
+          className="id_tab"
+        >
           { this.idContent( ) }
         </Tab>
       </Tabs>


### PR DESCRIPTION
- Prevent autozoom on iPhone, which was causing the autocomplete to render offscreen.
<img width="300" height="355" alt="IMG_1788" src="https://github.com/user-attachments/assets/8e60cad9-89d2-4d19-bbfc-1e9c34be3aa8" />

- Suggest an Identification -> Identify to fit small screens
<img width="270" height="260" alt="Screenshot 2026-09-09 at 11 40 05 AM" src="https://github.com/user-attachments/assets/570a8e35-8cad-46cb-aeba-fa1f05c478d1" />

- Fix observation fields autocomplete overflowing screen when really long fields are present
<img width="331" height="184" alt="Screenshot 2026-09-09 at 11 40 34 AM" src="https://github.com/user-attachments/assets/43ee29d5-6095-4ee5-ab9f-09dbefed7a8b" />
