### PR TITLE
fix: Make project observation fields modal responsive, WEB-1263

### DIFF
--- a/app/assets/stylesheets/shared/observation_projects.scss
+++ b/app/assets/stylesheets/shared/observation_projects.scss
@@ -1,4 +1,5 @@
 @import "../colors";
+@import "../breakpoints";
 
 .Projects {
   .project,
@@ -186,3 +187,24 @@
   }
 }
 
+@media ( max-width: $md-max ) {
+  body.responsive .ProjectFieldsModal.modal .modal-dialog {
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    height: auto;
+    margin: 10px;
+    .modal-content {
+      height: auto;
+      max-height: calc( 100vh - 20px );
+      padding-bottom: 0;
+      display: flex;
+      flex-direction: column;
+    }
+    .modal-body {
+      height: auto;
+      min-height: 0;
+      overflow: auto;
+    }
+  }
+}


### PR DESCRIPTION
Before:
<img width="363" height="761" alt="Screenshot 2026-09-09 at 2 12 21 PM" src="https://github.com/user-attachments/assets/a72fd630-123f-4dc3-b3a9-8f6648c06be2" />

After:
<img width="360" height="764" alt="Screenshot 2026-09-09 at 2 12 10 PM" src="https://github.com/user-attachments/assets/be2b96fd-76e5-44f8-af2e-519686da169e" />
