### PR TITLE
fix: Prevent dashboard taxon link from overlapping agree button, WEB-1257

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -663,6 +663,7 @@ h3.dashboard_id{
 h3.dashboard_id > .taxon > .comname,
 h3.dashboard_id > .taxon > a > .sciname {
   display: block;
+  width: fit-content;
 }
 
 .glyphicon-cog {

--- a/app/assets/stylesheets/dashboard_responsive.scss
+++ b/app/assets/stylesheets/dashboard_responsive.scss
@@ -745,6 +745,7 @@ h3.dashboard_id{
 h3.dashboard_id > .taxon > .comname,
 h3.dashboard_id > .taxon > a > .sciname {
   display: block;
+  width: fit-content;
 }
 
 .glyphicon-cog {


### PR DESCRIPTION
Before:
<img width="697" height="130" alt="Screenshot 2026-09-10 at 12 04 57 PM" src="https://github.com/user-attachments/assets/5b5bfc58-5e51-408b-9521-1813e057ee2d" />

After:
<img width="689" height="125" alt="Screenshot 2026-09-10 at 12 05 07 PM" src="https://github.com/user-attachments/assets/43c801fb-0606-4a70-bce8-53264a20e748" />
