### PR TITLE
feat: Add pagination and scroll to top on dashboard, WEB-1258 + WEB-1254

### DIFF
--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -19,7 +19,8 @@ jobs:
           --no-error-on-unmatched-pattern \
           app/webpack/computer_vision/language \
           "app/webpack/**/*.tsx" \
-          "app/webpack/**/*.ts"
+          "app/webpack/**/*.ts" \
+          app/assets/javascripts/users/dashboard.js
     - name: Run TypeScript type check
       run: npm run typecheck
 

--- a/app/assets/javascripts/users/dashboard.js
+++ b/app/assets/javascripts/users/dashboard.js
@@ -1,11 +1,12 @@
-/* eslint-disable */
+/* global DASHBOARD_FROM, DASHBOARD_TAB, I18n, updateSession */
 
 var DASHBOARD = {
-  fromIDs: { }
+  fromIDs: { },
+  fromPage: { }
 };
 
 // hide the flash message after 5 seconds
-setTimeout( function( ) {
+setTimeout( function ( ) {
   $( "#flash" ).fadeOut( 1000 );
 }, 5000 );
 
@@ -14,33 +15,34 @@ if ( DASHBOARD_FROM ) {
   DASHBOARD.fromIDs[DASHBOARD_TAB] = DASHBOARD_FROM;
 }
 
-window.onpopstate = function( event ) {
+window.onpopstate = function ( event ) {
   // set the tab's current `from` param based on the popped state
   DASHBOARD.fromIDs[event.state.type] = event.state.fromID;
   // show the tab and fetch the content
   DASHBOARD.loadTab( event.state.type, { noState: true } );
 };
 
-DASHBOARD.loadTab = function( tabName, options ) {
-  var tab = $("a[data-tab='" + tabName + "']")
-  $( "body" ).scrollTop( 0 );
+DASHBOARD.loadTab = function ( tabName, options ) {
+  var tab = $( "a[data-tab='" + tabName + "']" );
   // hide all other tabs
   $( ".tab-content > div" ).hide( );
-  $( ".dashboard_tab_row a").removeClass( "active" );
+  $( ".dashboard_tab_row a" ).removeClass( "active" );
   // show this one
   tab.addClass( "active" );
   $( tab.data( "targetEl" ) ).show( );
   var type = tab.data( "tab" );
   var tabSettings = DASHBOARD.tabSettings( type );
-  $( tabSettings.target ).html( "<div class='loading status'>" + I18n.t( "loading" ) + "</div>" )
+  DASHBOARD.startPanelLoading( tabSettings.target );
   // set the browser state and URL
   DASHBOARD.setState( type, tabSettings.params, options );
   // make an API call to fetch the tab's content
   DASHBOARD.fetchContent( tabSettings.fetchURL, type, tabSettings.target );
 };
 
-DASHBOARD.tabSettings = function( type ) {
-  var fetchURL, target, params = { };
+DASHBOARD.tabSettings = function ( type ) {
+  var fetchURL;
+  var target;
+  var params = { };
   // prepare the API path and params
   if ( type === "comments" ) {
     fetchURL = "/comments";
@@ -62,133 +64,141 @@ DASHBOARD.tabSettings = function( type ) {
   if ( DASHBOARD.fromIDs[type] ) {
     params.from = DASHBOARD.fromIDs[type];
   }
+  if ( DASHBOARD.fromPage[type] ) {
+    params.page = DASHBOARD.fromPage[type];
+  }
   if ( Object.keys( params ).length > 0 ) {
     fetchURL += "?" + $.param( params );
   }
   return { fetchURL: fetchURL, params: params, target: target };
 };
 
-DASHBOARD.fetchContent = function( fetchURL, type, target ) {
+DASHBOARD.fetchContent = function ( fetchURL, type, target ) {
   $.ajax( {
     type: "GET",
     url: fetchURL,
-    error: function( data ) {
+    error: function ( ) {
       console.log( "There was a problem" );
     },
-    success: function( data ) {
-      if ( type === "comments" ) {
-        // the coments partial renders <li>s, so wrap in a ul.timeline
-        data = $("<ul/>").addClass( "timeline" ).append( data );
+    success: function ( data ) {
+      var content = type === "comments"
+        ? $( "<ul/>" ).addClass( "timeline" ).append( data )
+        : data;
+      DASHBOARD.finishPanelLoading( target );
+      $( target ).html( content );
+      // enable jQuery click events on loaded pagination buttons
+      if ( $( "body" ).hasClass( "responsive" ) ) {
+        DASHBOARD.enablePageButtonClickEvents( target );
+      } else {
+        DASHBOARD.enableMoreButtonClickEvents( target );
       }
-      // show the content
-      $( target ).html( data );
-      // enable jQuery click events on loaded `more` buttons
-      DASHBOARD.enableMoreButtonClickEvents( target );
       if ( type !== "comments" ) {
         $( ".subscriptionsettings" ).subscriptionSettings( );
       }
     }
-  });
+  } );
 };
 
-DASHBOARD.enableMoreButtonClickEvents = function( target ) {
+DASHBOARD.enableMoreButtonClickEvents = function ( target ) {
   $( target ).find( "#more_pagination" ).unbind( "click" );
-  $( target ).find( "#more_pagination" ).bind( "click", function( e ) {
+  $( target ).find( "#more_pagination" ).bind( "click", function ( e ) {
     e.preventDefault( );
-    var tab = $( e.target ).parents( ".tab-pane:first" ).data( "tab" )
+    var tab = $( e.target ).parents( ".tab-pane:first" ).data( "tab" );
     DASHBOARD.fromIDs[tab] = $( this ).data( "from" );
     DASHBOARD.loadTab( tab );
-  });
-}
+  } );
+};
 
-DASHBOARD.setState = function( type, params, options ) {
-  var options = options || { };
+DASHBOARD.enablePageButtonClickEvents = function ( target ) {
+  $( target ).find( ".page_button" ).unbind( "click" );
+  $( target ).find( ".page_button" ).bind( "click", function ( e ) {
+    e.preventDefault( );
+    if ( $( this ).hasClass( "disabled" ) ) { return; }
+    var tab = $( e.target ).parents( ".tab-pane:first" ).data( "tab" );
+    DASHBOARD.fromPage[tab] = $( this ).data( "page" );
+    DASHBOARD.loadTab( tab );
+  } );
+};
+
+DASHBOARD.setState = function ( type, params, options ) {
+  var opts = options || { };
   var state = { type: type, fromID: DASHBOARD.fromIDs[type] };
   // on page load, just replace the empty state with the default params
-  if ( options.replaceState ) {
-    history.replaceState( state, "" );
-  }
-  // with onpopstate, noState will be set since we're popping not pushing
-  else if ( !options.noState ) {
+  if ( opts.replaceState ) {
+    window.history.replaceState( state, "" );
+  } else if ( !opts.noState ) {
     var dashboardParams = { tab: type };
     // store this tab's current `from` param in state
-    if ( DASHBOARD.fromIDs[type]) { dashboardParams.from = DASHBOARD.fromIDs[type]; }
+    if ( DASHBOARD.fromIDs[type] ) { dashboardParams.from = DASHBOARD.fromIDs[type]; }
     // stores the state and changes the browser URL
-    history.pushState( state, "", "/home?" + $.param( dashboardParams ) );
+    window.history.pushState( state, "", "/home?" + $.param( dashboardParams ) );
   }
 };
 
-DASHBOARD.loadingPanel = function( selector ) {
-  $( "body" ).scrollTop( 0 );
-  $( selector ).html( "<div class='loading status'>" + I18n.t( "loading" ) + "</div>" );
+DASHBOARD.startPanelLoading = function ( selector ) {
+  var target = $( selector );
+  window.scrollTo( 0, 0 );
+  target.attr( "aria-busy", true );
+  target.html( "<div class='loading status'>" + I18n.t( "loading" ) + "</div>" );
 };
 
-DASHBOARD.closePanel = function( element, panelType ) {
-  $( "#" + panelType + "_panel" ).fadeOut( );
-  var pref = { };
-  pref[ "prefers_hide_" + panelType + "_onboarding" ] = true;
-  updateSession( pref );
+DASHBOARD.finishPanelLoading = function ( selector ) {
+  $( selector ).attr( "aria-busy", false );
 };
 
-$( function( ) {
+$( function ( ) {
   // load the default tab from a variable set in the view
   // make sure to replaceState and not setState as this is the initial load
   DASHBOARD.loadTab( DASHBOARD_TAB, { replaceState: true } );
 
   // prepare the click events for the tab labels
-  $( ".dashboard_tab_row a" ).on( "click", function( e ) {
+  $( ".dashboard_tab_row a" ).on( "click", function ( e ) {
     e.preventDefault( );
     DASHBOARD.loadTab( $( e.target ).data( "tab" ) );
-  });
+  } );
 
   $( "abbr.timeago" ).timeago( );
-  var dayInSeconds = 24 * 60 * 60,
-      now = new Date( ),
-      monthNames = [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ];
+  var now = new Date( );
+  var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
   var elt = $( "abbr.compact.date:first" );
   if ( elt.length > 0 ) {
-    var dateString = $( elt ).attr( "title" ).split( "T" )[0],
-        timeString = $( elt ).attr( "title" ).split( "T" )[1],
-        d = new Date( Date.parse( $( elt ).attr( "title" )));
-
-    $( "abbr.compact.date" ).each( function( ) {
-      var dateString = $( this ).attr( "title" ).split( "T" )[0],
-          timeString = $( this ).attr( "title" ).split( "T" )[1],
-          d = new Date( Date.parse( $( elt ).attr( "title" )));
-      if ( !timeString.indexOf( ":" ) || typeof( d ) != "object" ) { return; }
-      if ( now.getFullYear( ) == d.getFullYear( ) &&
-           now.getMonth( ) == d.getMonth( ) &&
-           now.getDate( ) == d.getDate( ) ) {
+    $( "abbr.compact.date" ).each( function ( ) {
+      var timeString = $( this ).attr( "title" ).split( "T" )[1];
+      var d = new Date( Date.parse( $( elt ).attr( "title" ) ) );
+      if ( !timeString.indexOf( ":" ) || typeof ( d ) !== "object" ) { return; }
+      if ( now.getFullYear( ) === d.getFullYear( )
+           && now.getMonth( ) === d.getMonth( )
+           && now.getDate( ) === d.getDate( ) ) {
         return;
       }
       $( this ).html( monthNames[d.getMonth( )] + " " + d.getDate( ) );
-    })
+    } );
   }
 
-  $( "#subscribeModal" ).on( "show.bs.modal", function( e ) {
+  $( "#subscribeModal" ).on( "show.bs.modal", function ( ) {
     var that = $( this );
-    taxonLabel = that.find( "#subscribeTaxonLabel" );
-    subscribe_type = ( taxonLabel.css( "display" ) == "none" ) ? "place" : "taxon";
-    subscribe_url = "/subscriptions/new?type=" + subscribe_type +
-      "&partial=form&authenticity_token=" + $( "meta[name=csrf-token]" ).attr( "content" );
+    var taxonLabel = that.find( "#subscribeTaxonLabel" );
+    var subscribeType = ( taxonLabel.css( "display" ) === "none" ) ? "place" : "taxon";
+    var subscribeUrl = "/subscriptions/new?type=" + subscribeType
+      + "&partial=form&authenticity_token=" + $( "meta[name=csrf-token]" ).attr( "content" );
     $.ajax( {
-      url: subscribe_url,
+      url: subscribeUrl,
       cache: false,
-      success: function( html ) {
+      success: function ( html ) {
         that.find( ".modal-body" ).append( html );
       }
-    });
-  });
+    } );
+  } );
 
-  $( "#subscribeModal" ).on( "hide.bs.modal", function( e ) {
+  $( "#subscribeModal" ).on( "hide.bs.modal", function ( ) {
     $( this ).find( ".modal-body" ).children( "form" ).remove( );
-  });
+  } );
 
-  $( "a[data-subscribe-type]" ).click( function( e ) {
-    subscribeType = $( this ).data( "subscribe-type" );
-    if ( subscribeType == "taxon" ) {
+  $( "a[data-subscribe-type]" ).click( function ( ) {
+    var subscribeType = $( this ).data( "subscribe-type" );
+    if ( subscribeType === "taxon" ) {
       $( "#subscribeTaxonLabel" ).show( );
       $( "#subscribePlaceLabel" ).hide( );
       $( "#subscribeTaxonBody" ).show( );
@@ -199,101 +209,87 @@ $( function( ) {
       $( "#subscribePlaceBody" ).show( );
       $( "#subscribeTaxonBody" ).hide( );
     }
-  });
+  } );
 
-  $( "a[data-panel-type]" ).click( function( e ) {
-    // If a specific handler exists, skip the generic one
-    if ( this.id === "close_gaps_obs_pilot_panel" ||
-         this.id === "close_needs_id_pilot_panel" ||
-         this.id === "close_gaps_id_pilot_panel" ) {
-      return;
-    }
+  $( ".dashboard_tab" ).click( function ( ) {
+    $( ".dashboard_tab" ).removeClass( "active" );
+    $( this ).addClass( "active" );
+  } );
 
-    e.preventDefault( );
-    panelType = $( this ).data( "panel-type" );
-    DASHBOARD.closePanel( this, panelType );
-  });
-
-  $( ".dashboard_tab" ).click( function( ) {
-     $( ".dashboard_tab" ).removeClass( "active" );
-     $( this ).addClass( "active" );
-  });
-
-  $( "#forum-topics" ).on( "show.bs.collapse", function( e ) {
+  $( "#forum-topics" ).on( "show.bs.collapse", function ( ) {
     $( "#forum .panel-heading .pull-right i.fa" ).removeClass( "fa-caret-left" ).addClass( "fa-caret-down" );
     updateSession( { prefers_forum_topics_on_dashboard: true } );
   } );
-  $( "#forum-topics" ).on( "hide.bs.collapse", function( e ) {
+  $( "#forum-topics" ).on( "hide.bs.collapse", function ( ) {
     $( "#forum .panel-heading .pull-right i.fa" ).removeClass( "fa-caret-down" ).addClass( "fa-caret-left" );
     updateSession( { prefers_forum_topics_on_dashboard: false } );
   } );
 
-  $( "#close_needs_id_pilot_panel" ).on( "click", function( e ) {
+  $( "#close_needs_id_pilot_panel" ).on( "click", function ( e ) {
     e.preventDefault( );
     $( "#needs_id_pilot_panel" ).hide( );
     updateSession( { prefers_needs_id_pilot: false } );
   } );
 
-  $( "#participate_button" ).on( "click", function( e ) {
+  $( "#participate_button" ).on( "click", function ( e ) {
     e.preventDefault( );
     updateSession( { prefers_needs_id_pilot: true } );
     $( "#participate_section" ).hide( );
     $( "#stop_participating_section" ).show( );
     $( "#close_needs_id_pilot_panel" ).hide( );
-  });
+  } );
 
-  $( "#stop_participating_link" ).on( "click", function( e ) {
+  $( "#stop_participating_link" ).on( "click", function ( e ) {
     e.preventDefault( );
     updateSession( { prefers_needs_id_pilot: null } );
     $( "#stop_participating_section" ).hide( );
     $( "#participate_section" ).show( );
     $( "#close_needs_id_pilot_panel" ).show( );
-  });
+  } );
 
   // gaps obs
-  $( "#close_gaps_obs_pilot_panel" ).on( "click", function( e ) {
+  $( "#close_gaps_obs_pilot_panel" ).on( "click", function ( e ) {
     e.preventDefault( );
     $( "#gaps_obs_pilot_panel" ).hide( );
     updateSession( { prefers_gaps_obs_pilot: false } );
   } );
 
-  $( "#gaps_obs_participate_button" ).on( "click", function( e ) {
+  $( "#gaps_obs_participate_button" ).on( "click", function ( e ) {
     e.preventDefault( );
     updateSession( { prefers_gaps_obs_pilot: true } );
     $( "#gaps_obs_participate_section" ).hide( );
     $( "#gaps_obs_stop_participating_section" ).show( );
     $( "#close_gaps_obs_pilot_panel" ).hide( );
-  });
+  } );
 
-  $( "#gaps_obs_stop_participating_link" ).on( "click", function( e ) {
+  $( "#gaps_obs_stop_participating_link" ).on( "click", function ( e ) {
     e.preventDefault( );
     updateSession( { prefers_gaps_obs_pilot: null } );
     $( "#gaps_obs_stop_participating_section" ).hide( );
     $( "#gaps_obs_participate_section" ).show( );
     $( "#close_gaps_obs_pilot_panel" ).show( );
-  });
+  } );
 
   // gaps id
-    $( "#close_gaps_id_pilot_panel" ).on( "click", function( e ) {
+  $( "#close_gaps_id_pilot_panel" ).on( "click", function ( e ) {
     e.preventDefault( );
     $( "#gaps_id_pilot_panel" ).hide( );
     updateSession( { prefers_gaps_id_pilot: false } );
   } );
 
-  $( "#gaps_id_participate_button" ).on( "click", function( e ) {
+  $( "#gaps_id_participate_button" ).on( "click", function ( e ) {
     e.preventDefault( );
     updateSession( { prefers_gaps_id_pilot: true } );
     $( "#gaps_id_participate_section" ).hide( );
     $( "#gaps_id_stop_participating_section" ).show( );
     $( "#close_gaps_id_pilot_panel" ).hide( );
+  } );
 
-  });
-
-  $( "#gaps_id_stop_participating_link" ).on( "click", function( e ) {
+  $( "#gaps_id_stop_participating_link" ).on( "click", function ( e ) {
     e.preventDefault( );
     updateSession( { prefers_gaps_id_pilot: null } );
     $( "#gaps_id_stop_participating_section" ).hide( );
     $( "#gaps_id_participate_section" ).show( );
     $( "#close_gaps_id_pilot_panel" ).show( );
-  });
-});
+  } );
+} );

--- a/app/assets/stylesheets/dashboard_responsive.scss
+++ b/app/assets/stylesheets/dashboard_responsive.scss
@@ -44,8 +44,8 @@ body.responsive {
   padding-top: 15px;
 
   .tab-content .loading.status {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    width: fit-content;
+    margin: 20px auto;
   }
 }
 
@@ -860,5 +860,11 @@ a.icon_container,
 }
 
 #obsbutton {
+  margin-bottom: 20px;
+}
+
+nav.dashboard-pagination {
+  display: flex;
+  justify-content: space-between;
   margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/dashboard_responsive.scss
+++ b/app/assets/stylesheets/dashboard_responsive.scss
@@ -865,7 +865,7 @@ a.icon_container,
 
 nav.dashboard-pagination {
   display: flex;
-  justify-content: space-between;
+  gap: 10px;
   margin-bottom: 20px;
 }
 

--- a/app/assets/stylesheets/dashboard_responsive.scss
+++ b/app/assets/stylesheets/dashboard_responsive.scss
@@ -868,3 +868,30 @@ nav.dashboard-pagination {
   justify-content: space-between;
   margin-bottom: 20px;
 }
+
+a.scroll-to-top {
+  display: none;
+
+  @media ( max-width: $md-max ) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    right: 15px;
+    bottom: 15px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: white;
+    color: #286090;
+    z-index: 1000;
+    box-shadow: 0 1px 4px rgba( 0, 0, 0, 0.3 );
+    font-size: 18px;
+
+    .glyphicon {
+      top: 0;
+      left: 1px;
+      line-height: 1;
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -449,7 +449,7 @@ class UsersController < ApplicationController
     end
 
     @pagination_updates = current_user.recent_notifications(
-      filters: filters, per_page: 50
+      filters: filters, per_page: 50, page: params[:page]
     )
     @updates = UpdateAction.load_all_update_actions_for_updated_resources_for_user(
       @pagination_updates,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1674,7 +1674,9 @@ class User < ApplicationRecord
       filters: options[:filters],
       inverse_filters: options[:inverse_filters],
       per_page: options[:per_page],
-      sort: { created_at: :desc })
+      sort: { created_at: :desc },
+      page: options[:page] || 1
+    )
   end
 
   def blocked_by?( user )

--- a/app/views/users/_dashboard_updates.html+responsive.haml
+++ b/app/views/users/_dashboard_updates.html+responsive.haml
@@ -33,7 +33,7 @@
                 = compact_date( notifying_update.sort_by_date, obscured: notifier.class.name == "Observation" && !notifier.coordinates_viewable_by?( current_user ) )
               = update_tagline_for( notifying_update, count: updates.size )
           - if notification == "activity" || is_mention
-            .timeline-body
+            .timeline-body{ "aria-live" => "polite" }
               - if updates[0].resource_type == 'Observation'
                 - observations = [updates[0].resource]
                 = render partial: 'observations/observations_component_for_dashboard', locals: { for_idents: true, observations: observations }
@@ -61,6 +61,6 @@
               = render partial: "#{resource_type.underscore.pluralize}/update_#{notification}", object: resource, locals: { updates: updates, resource: resource }
             - rescue ActionView::MissingTemplate, Errno::ENOENT
               = "#{resource_type} #{notification}"
-  .pagination
-    - unless @pagination_updates.blank? || @pagination_updates.next_page.blank?
-      = link_to t(:more), url_for_params( from: @pagination_updates.last.created_at.to_i ), data: { from: @pagination_updates.last.created_at.to_i }, id:"more_pagination", class: "btn btn-sm btn-default"
+  %nav.dashboard-pagination{ "aria-label" => t(:pagination) }
+    = link_to t(:back), url_for_params( page: @pagination_updates.previous_page ), data: { page: @pagination_updates.previous_page }, class: "btn btn-sm btn-default page_button #{'disabled' unless @pagination_updates.previous_page }"
+    = link_to t(:next), url_for_params( page: @pagination_updates.next_page ), data: { page: @pagination_updates.next_page }, class: "btn btn-sm btn-default page_button #{'disabled' unless @pagination_updates.next_page }"

--- a/app/views/users/_dashboard_updates.html+responsive.haml
+++ b/app/views/users/_dashboard_updates.html+responsive.haml
@@ -62,5 +62,6 @@
             - rescue ActionView::MissingTemplate, Errno::ENOENT
               = "#{resource_type} #{notification}"
   %nav.dashboard-pagination{ "aria-label" => t(:pagination) }
+    = link_to t(:first, default: "First"), url_for_params( page: 1 ), data: { page: 1 }, class: "btn btn-sm btn-default page_button #{'disabled' unless @pagination_updates.previous_page }"
     = link_to t(:back), url_for_params( page: @pagination_updates.previous_page ), data: { page: @pagination_updates.previous_page }, class: "btn btn-sm btn-default page_button #{'disabled' unless @pagination_updates.previous_page }"
     = link_to t(:next), url_for_params( page: @pagination_updates.next_page ), data: { page: @pagination_updates.next_page }, class: "btn btn-sm btn-default page_button #{'disabled' unless @pagination_updates.next_page }"

--- a/app/views/users/_dashboard_updates.html.haml
+++ b/app/views/users/_dashboard_updates.html.haml
@@ -43,7 +43,7 @@
                 = compact_date( notifying_update.sort_by_date, obscured: notifier.class.name == "Observation" && !notifier.coordinates_viewable_by?( current_user ) )
               = update_tagline_for( notifying_update, count: updates.size )
           - if notification == "activity" || is_mention
-            .timeline-body
+            .timeline-body{ "aria-live" => "polite" }
               - if updates[0].resource_type == 'Observation'
                 - observations = [updates[0].resource]
                 = render partial: 'observations/observations_component_for_dashboard', locals: { for_idents: true, observations: observations }

--- a/app/views/users/dashboard.html+responsive.haml
+++ b/app/views/users/dashboard.html+responsive.haml
@@ -362,3 +362,5 @@
           %p= t :show_off_your_recent_observations
           %p
             = link_to t(:learn_more), { controller: "observations", action: "widget" }, class: "btn btn-default btn-md"
+  %a.scroll-to-top{ href: "#header", "aria-label" => t(:scroll_to_top, default: "Scroll to top") }
+    %span.glyphicon.glyphicon-chevron-up

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4181,6 +4181,7 @@ en:
   overlapping_atlases: Overlapping atlases
   overlapping_downstream_taxon_frameworks_html: "Overlapping downstream Taxon Frameworks: %{count}"
   owner: Owner
+  pagination: Pagination
   # One level up in a hierarchy, e.g. the genus Homo is the parent of the species Homo sapiens, or the state of California is the parent of Alameda County
   parent: Parent
   # Name of the entity one level up in a hierarchy, generally used for a parent taxon

--- a/spec/e2e/playwright/tests/users/dashboard.spec.ts
+++ b/spec/e2e/playwright/tests/users/dashboard.spec.ts
@@ -1,7 +1,8 @@
-import { test } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { login } from "../../helpers/auth.helper";
 import { app, appMake } from "../../support/on-rails";
 import { expectNoHorizontalOverflow } from "../../helpers/overflow.helper";
+import { VIEWPORTS } from "../../../shared/breakpoints";
 
 const TEST_PASSWORD = "TestPass123!";
 
@@ -25,3 +26,138 @@ test.beforeEach( async ( { page } ) => {
 } );
 
 expectNoHorizontalOverflow( "/home" );
+
+// Controlled HTML for the two tab-content endpoints so tab-switching, pagination,
+// and content-injection are deterministic without a live iNaturalistAPI. The
+// updates fragment carries a responsive .page_button so pagination can be driven;
+// the comments fragment is bare <li>s so fetchContent's ul.timeline wrap shows.
+const UPDATES_HTML = `<ul class="timeline"><li id="mock-update">mock update</li></ul>
+  <nav class="dashboard-pagination">
+    <a class="btn btn-sm btn-default page_button" data-page="2" href="#">Next</a>
+  </nav>`;
+const COMMENTS_HTML = "<li class=\"mock-comment\">mock comment</li>";
+
+async function mockDashboardEndpoints( page: Page ): Promise<void> {
+  await page.route( "**/users/dashboard_updates**", route => route.fulfill( {
+    status: 200, contentType: "text/html", body: UPDATES_HTML
+  } ) );
+  await page.route( "**/comments**", route => route.fulfill( {
+    status: 200, contentType: "text/html", body: COMMENTS_HTML
+  } ) );
+  // The subscribe modal's show.bs.modal handler fetches this; keep it from erroring.
+  await page.route( "**/subscriptions/new**", route => route.fulfill( {
+    status: 200, contentType: "text/html", body: "<form></form>"
+  } ) );
+}
+
+test.describe( "dashboard tab interactions", () => {
+  test.beforeEach( async ( { page } ) => {
+    await page.setViewportSize( VIEWPORTS.xl );
+    await mockDashboardEndpoints( page );
+  } );
+
+  test( "loads the default updates tab on page load", async ( { page } ) => {
+    const [request] = await Promise.all( [
+      page.waitForRequest( "**/users/dashboard_updates**" ),
+      page.goto( "/home" )
+    ] );
+    expect( request.url() ).not.toContain( "filter=" );
+
+    await expect( page.locator( "a[data-tab='updates']" ) ).toHaveClass( /\bactive\b/ );
+    await expect( page.locator( "#updates_target #mock-update" ) ).toBeVisible();
+    await expect( page.locator( "#updates_target" ) ).toHaveAttribute( "aria-busy", "false" );
+  } );
+
+  const tabCases = [
+    { tab: "yours", url: "**/users/dashboard_updates**", param: "filter=you", target: "#updates_by_you_target" },
+    { tab: "following", url: "**/users/dashboard_updates**", param: "filter=following", target: "#following_target" },
+    { tab: "comments", url: "**/comments**", param: "partial=true", target: "#comments_target" }
+  ];
+
+  tabCases.forEach( ( { tab, url, param, target } ) => {
+    test( `clicking the ${tab} tab activates it, fetches the right URL, and updates history`, async ( { page } ) => {
+      await page.goto( "/home" );
+      await expect( page.locator( "#updates_target #mock-update" ) ).toBeVisible();
+
+      const [request] = await Promise.all( [
+        page.waitForRequest( url ),
+        page.locator( `a[data-tab='${tab}']` ).click()
+      ] );
+      expect( request.url() ).toContain( param );
+
+      await expect( page.locator( `a[data-tab='${tab}']` ) ).toHaveClass( /\bactive\b/ );
+      await expect( page.locator( "a[data-tab='updates']" ) ).not.toHaveClass( /\bactive\b/ );
+      await expect( page.locator( target ) ).toBeVisible();
+      await expect( page ).toHaveURL( new RegExp( `tab=${tab}` ) );
+    } );
+  } );
+
+  test( "toggles aria-busy on the target while loading", async ( { page } ) => {
+    await page.goto( "/home" );
+    await expect( page.locator( "#updates_target #mock-update" ) ).toBeVisible();
+
+    // Hold the "yours" fetch open so the busy state is observable, then release it.
+    let release: () => void = () => {};
+    const gate = new Promise<void>( resolve => { release = resolve; } );
+    await page.route( "**/users/dashboard_updates**", async route => {
+      await gate;
+      await route.fulfill( { status: 200, contentType: "text/html", body: UPDATES_HTML } );
+    } );
+
+    await page.locator( "a[data-tab='yours']" ).click();
+    await expect( page.locator( "#updates_by_you_target" ) ).toHaveAttribute( "aria-busy", "true" );
+
+    release();
+    await expect( page.locator( "#updates_by_you_target" ) ).toHaveAttribute( "aria-busy", "false" );
+  } );
+
+  test( "wraps returned comment li's in a ul.timeline", async ( { page } ) => {
+    await page.goto( "/home" );
+    await page.locator( "a[data-tab='comments']" ).click();
+    await expect( page.locator( "#comments_target ul.timeline li.mock-comment" ) ).toBeVisible();
+  } );
+
+  test( "restores the previous tab on browser back", async ( { page } ) => {
+    await page.goto( "/home" );
+    await expect( page.locator( "#updates_target #mock-update" ) ).toBeVisible();
+
+    await page.locator( "a[data-tab='yours']" ).click();
+    await expect( page ).toHaveURL( /tab=yours/ );
+
+    const [request] = await Promise.all( [
+      page.waitForRequest( "**/users/dashboard_updates**" ),
+      page.goBack()
+    ] );
+    expect( request.url() ).not.toContain( "filter=" );
+    await expect( page.locator( "a[data-tab='updates']" ) ).toHaveClass( /\bactive\b/ );
+  } );
+
+  test( "loads the next page via the responsive pagination button", async ( { page } ) => {
+    await page.goto( "/home" );
+    await expect( page.locator( "#updates_target #mock-update" ) ).toBeVisible();
+
+    const [request] = await Promise.all( [
+      page.waitForRequest( "**/users/dashboard_updates**" ),
+      page.locator( "#updates_target .page_button:not(.disabled)" ).click()
+    ] );
+    expect( request.url() ).toContain( "page=2" );
+  } );
+
+  test( "toggles subscribe modal labels by type", async ( { page } ) => {
+    await page.goto( "/home" );
+    const modal = page.locator( "#subscribeModal" );
+
+    await page.locator( "a[data-subscribe-type='place']" ).click();
+    await expect( page.locator( "#subscribePlaceLabel" ) ).toBeVisible();
+    await expect( page.locator( "#subscribeTaxonLabel" ) ).toBeHidden();
+
+    // The trigger opens the modal, whose overlay would intercept the next click.
+    await modal.locator( ".close[data-dismiss='modal']" ).click();
+    await expect( modal ).toBeHidden();
+    await expect( page.locator( ".modal-backdrop" ) ).toHaveCount( 0 );
+
+    await page.locator( "a[data-subscribe-type='taxon']" ).click();
+    await expect( page.locator( "#subscribeTaxonLabel" ) ).toBeVisible();
+    await expect( page.locator( "#subscribePlaceLabel" ) ).toBeHidden();
+  } );
+} );


### PR DESCRIPTION
- Scrolls to top after pressing the *new* Next / Back buttons
  - This change bleeds over to the non-responsive page as well, but it seems like a good all-around change
- Adds scroll to top button under `$md` breakpoint
- Adds a more paginated way of navigating with better accessibility
- Adds `aria-live` and `aria-busy` to indicate loading for screen reader users
- Adds Playwright tests for `dashboard.js` coverage
- Removes unused stuff in `dashboard.js`
- Lints `dashboard.js` and adds it to the CI linting step

https://github.com/user-attachments/assets/88f75a65-47a8-46f1-aed2-632c07518ee2
